### PR TITLE
GH-1: Enable force push temporary

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,9 +29,11 @@ github:
     squash: true
   features:
     issues: true
-  protected_branches:
-    main:
-      required_linear_history: true
+  # GH-1: Enable force push temporary
+  protected_branches: ~
+  # protected_branches:
+  #   main:
+  #     required_linear_history: true
 
 notifications:
   commits: commits@arrow.apache.org


### PR DESCRIPTION
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection

> To completely remove all branch protection rules, set the
> protected_branches section to null, as such:
>
> Prevent force pushes
>
>     github:
>       protected_branches: ~