### PR TITLE
GH-81: Enable delete branch on merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,6 +23,7 @@ github:
   labels:
     - apache-arrow
     - go
+  del_branch_on_merge: true
   enabled_merge_buttons:
     merge: false
     rebase: false


### PR DESCRIPTION
fix GH-81

https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Deletebranchonmerge

> Add this snippet below so branches get auto-deleted upon PR merge to
> your default branch:
>
> Delete Branch on Merge
>
>     github:
>       del_branch_on_merge: true