### PR TITLE
GH-15: Enable linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,6 @@ jobs:
       - name: Install bash via Homebrew
         run: |
           brew install bash
-      - name: Install staticcheck
-        run: |
-          . .env
-          go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK}
       - name: Build
         run: |
           $(brew --prefix)/bin/bash ci/scripts/build.sh $(pwd)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,5 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# All of the following environment variables are required to set default values
-# for the parameters in docker-compose.yml.
+linters:
+  # Disable all linters.
+  # Default: false
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - gofmt
+    - goimports
+    - staticcheck
+
+issues:
+  fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,17 @@ repos:
           # The default args is "--write --simplify" but we don't use
           # "--simplify". Because it's conflicted will ShellCheck.
           - "--write"
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.60.3
+    hooks:
+      # no built-in support for multiple go.mod
+      # https://github.com/golangci/golangci-lint/issues/828
+      - id: golangci-lint-full
+        name: golangci-lint-full-arrow
+        entry: bash -c 'cd arrow && golangci-lint run --timeout=5m'
+      - id: golangci-lint-full
+        name: golangci-lint-full-parquet
+        entry: bash -c 'cd parquet && golangci-lint run'
+      - id: golangci-lint-full
+        name: golangci-lint-full-internal
+        entry: bash -c 'cd internal && golangci-lint run'

--- a/arrow/flight/flightsql/server.go
+++ b/arrow/flight/flightsql/server.go
@@ -1177,9 +1177,9 @@ func (f *flightSqlServer) DoAction(cmd *flight.Action, stream flight.FlightServi
 		}
 
 		var (
-			//lint:ignore SA1019 for backward compatibility
+			//nolint:staticcheck,SA1019 for backward compatibility
 			request pb.ActionCancelQueryRequest
-			//lint:ignore SA1019 for backward compatibility
+			//nolint:staticcheck,SA1019 for backward compatibility
 			result pb.ActionCancelQueryResult
 			info   flight.FlightInfo
 			err    error

--- a/arrow/internal/flight_integration/scenario.go
+++ b/arrow/internal/flight_integration/scenario.go
@@ -2412,7 +2412,7 @@ func (m *flightSqlExtensionScenarioTester) ValidateStatementExecution(client *fl
 		return err
 	}
 
-	//lint:ignore SA1019 for backward compatibility
+	//nolint:staticcheck,SA1019 for backward compatibility
 	cancelResult, err := client.CancelQuery(ctx, info)
 	if err != nil {
 		return err

--- a/ci/scripts/test.sh
+++ b/ci/scripts/test.sh
@@ -47,13 +47,6 @@ MINGW*)
   ;;
 esac
 
-# Go static check (skipped in MinGW)
-if [[ -z "${MINGW_LINT:-}" ]]; then
-  pushd "${source_dir}"
-  "$(go env GOPATH)"/bin/staticcheck ./...
-  popd
-fi
-
 pushd "${source_dir}/arrow"
 
 : "${ARROW_GO_TESTCGO:=}"


### PR DESCRIPTION
Fix GH-15

Related parts:
* https://github.com/apache/arrow/blob/58415d1fac50cb829b3dcf08526033d6db8c30db/.pre-commit-config.yaml#L151-L164
* https://github.com/apache/arrow/blob/main/.golangci.yaml

staticcheck is also used via golangci. We need to use "nolint:staticcheck,XXX" instead of "lint:ignore XXX" for it.

See also: https://golangci-lint.run/usage/false-positives/#nolint