### PR TITLE
GH-100: Don't run CI jobs by Dependabot push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ name: Lint
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ name: Test
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
It seems that Dependabot always use `dependabot/*` branch. If we ignore `push` trigger for the branch, we can run only `pull_request` trigger for Dependabot.