### PR TITLE
GH-107: Add test CI for arm Runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,18 @@ jobs:
             "arch": "amd64",
             "go": "1.23",
             "runs-on": "ubuntu-latest"
+          },
+          {
+            "arch-label": "ARM64",
+            "arch": "arm64v8",
+            "go": "1.22",
+            "runs-on": ["self-hosted", "arm", "linux"]
+          },
+          {
+            "arch-label": "ARM64",
+            "arch": "arm64v8",
+            "go": "1.23",
+            "runs-on": ["self-hosted", "arm", "linux"]
           }
           JSON
           echo "]" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fix https://github.com/apache/arrow-go/issues/107

We have some jobs that run on ARM self-hosted runners, we should also add those: https://github.com/apache/arrow/blob/main/.github/workflows/go.yml#L80-L91