### PR TITLE
GH-140: Drop support for macOS 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,8 +190,8 @@ jobs:
         run: |
           docker compose push debian-cgo-python
   macos:
-    name: AMD64 macOS 12 Go ${{ matrix.go }}
-    runs-on: macos-12
+    name: AMD64 macOS 14 Go ${{ matrix.go }}
+    runs-on: macos-14
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -217,8 +217,8 @@ jobs:
         run: |
           ci/scripts/test.sh $(pwd)
   macos-cgo:
-    name: AMD64 macOS 12 Go ${{ matrix.go }} - CGO
-    runs-on: macos-12
+    name: AMD64 macOS 14 Go ${{ matrix.go }} - CGO
+    runs-on: macos-14
     timeout-minutes: 25
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fix GH-140

Use macOS 14 instead.