### PR TITLE
GH-139: Add config to publish asf-site branch to go subdir

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,3 +38,7 @@ notifications:
   issues_status: issues@arrow.apache.org
   issues_comment: github@arrow.apache.org
   pullrequests: github@arrow.apache.org
+
+publish:
+  whoami: asf-site
+  subdir: go

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,7 +38,6 @@ notifications:
   issues_status: issues@arrow.apache.org
   issues_comment: github@arrow.apache.org
   pullrequests: github@arrow.apache.org
-
 publish:
   whoami: asf-site
   subdir: go


### PR DESCRIPTION
Fix #139 

The asf-site content will be deployed to https://arrow.apache.org/go/ automatically.

I have created an empty `asf-site` branch and pushed it.

We have to add an index.html there pointing to `https://pkg.go.dev/github.com/apache/arrow-go/v${VERSION}`.