### PR TITLE
GH-26: Add Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Any committer can add themselves to any  of the path patterns
+# Any committer can add themselves to any of the path patterns
 # and will subsequently get requested as a reviewer for any PRs
 # that change matching files.
 #

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,5 +39,5 @@ compose.yaml @zeroshade @assignUser @kou @raulcd
 # PR CI and repository files
 /.github/ @zeroshade @kou @assignUser @raulcd
 .asf.yaml @zeroshade @kou @assignUser @raulcd
-.pre-commit-config.yaml
+.pre-commit-config.yaml @kou @zeroshade
 .golangci.yaml @kou @zeroshade

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Any committer can add themselves to any  of the path patterns
+# and will subsequently get requested as a reviewer for any PRs
+# that change matching files.
+#
+# This file uses .gitignore syntax with a few exceptions see the
+# documentation about the syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+## Components
+/arrow/ @zeroshade
+/internal/ @zeroshade
+/parquet/ @zeroshade
+go.mod @zeroshade
+go.sum @zeroshade
+
+# release scripts
+/ci/ @zeroshade @kou @raulcd @assignUser
+/dev/ @zeroshade @kou @raulcd @assignUser
+.env @assignUser @zeroshade @kou @raulcd
+compose.yaml @zeroshade @assignUser @kou @raulcd
+.dockerallow @zeroshade @assignUser @kou @raulcd
+
+# PR CI and repository files
+/.github/ @zeroshade @kou @assignUser @raulcd
+.asf.yaml @zeroshade @kou @assignUser @raulcd
+.pre-commit-config.yaml
+.golangci.yaml @kou @zeroshade


### PR DESCRIPTION
Adding initial CODEOWNERS file

tagging relevant people to review. If any of you don't want to be listed on the CODEOWNERS just comment here and I'll take you off.

Fixes #26