### PR TITLE
GH-41: [Array] Make String and Binary consistent

### DIFF
--- a/arrow/array/string.go
+++ b/arrow/array/string.go
@@ -69,7 +69,7 @@ func (a *String) ValueStr(i int) string {
 
 // ValueOffset returns the offset of the value at index i.
 func (a *String) ValueOffset(i int) int {
-	if i < 0 || i > a.array.data.length {
+	if i < 0 || i >= a.array.data.length {
 		panic("arrow/array: index out of range")
 	}
 	return int(a.offsets[i+a.array.data.offset])

--- a/arrow/array/string_test.go
+++ b/arrow/array/string_test.go
@@ -90,9 +90,6 @@ func TestStringArray(t *testing.T) {
 		if got, want := arr.ValueOffset(i), int(offsets[i]); got != want {
 			t.Fatalf("arr-offset-beg[%d]: got=%d, want=%d", i, got, want)
 		}
-		if got, want := arr.ValueOffset(i+1), int(offsets[i+1]); got != want {
-			t.Fatalf("arr-offset-end[%d]: got=%d, want=%d", i+1, got, want)
-		}
 	}
 
 	if !reflect.DeepEqual(offsets, arr.ValueOffsets()) {
@@ -371,9 +368,6 @@ func TestLargeStringArray(t *testing.T) {
 
 		if got, want := arr.ValueOffset(i), offsets[i]; got != want {
 			t.Fatalf("arr-offset-beg[%d]: got=%d, want=%d", i, got, want)
-		}
-		if got, want := arr.ValueOffset(i+1), offsets[i+1]; got != want {
-			t.Fatalf("arr-offset-end[%d]: got=%d, want=%d", i+1, got, want)
 		}
 	}
 

--- a/arrow/ipc/writer.go
+++ b/arrow/ipc/writer.go
@@ -627,9 +627,13 @@ func (w *recordEncoder) visit(p *Payload, arr arrow.Array) error {
 		case needTruncate(int64(data.Offset()), values, totalDataBytes):
 			// slice data buffer to include the range we need now.
 			var (
-				beg = arr.ValueOffset64(0)
-				len = minI64(paddedLength(totalDataBytes, kArrowAlignment), int64(totalDataBytes))
+				beg int64 = 0
+				len       = minI64(paddedLength(totalDataBytes, kArrowAlignment), int64(totalDataBytes))
 			)
+			if arr.Len() > 0 {
+				beg = arr.ValueOffset64(0)
+			}
+
 			values = memory.NewBufferBytes(data.Buffers()[2].Bytes()[beg : beg+len])
 		default:
 			if values != nil {

--- a/parquet/metadata/statistics_types.gen.go
+++ b/parquet/metadata/statistics_types.gen.go
@@ -1980,12 +1980,12 @@ func (s *ByteArrayStatistics) UpdateFromArrow(values arrow.Array, updateCounts b
 		min       = s.defaultMin()
 		max       = s.defaultMax()
 		arr       = values.(array.BinaryLike)
-		data      = arr.ValueBytes()
+		data      = arr.ValueBytes()		
 		curOffset = int64(0)
 	)
 
 	for i := 0; i < arr.Len(); i++ {
-		nextOffset := arr.ValueOffset64(i + 1)
+		nextOffset := curOffset + int64(arr.ValueLen(i))
 		v := data[curOffset:nextOffset]
 		curOffset = nextOffset
 


### PR DESCRIPTION
Fixes #41 

Makes the behavior of `ValueOffset` consistent between String and Binary arrays.