### PR TITLE
fix: compute fixes for extension types

### DIFF
--- a/arrow/compute/exprs/exec.go
+++ b/arrow/compute/exprs/exec.go
@@ -630,6 +630,7 @@ func executeScalarBatch(ctx context.Context, input compute.ExecBatch, exp expr.E
 
 		if ctx.Err() == context.Canceled && result != nil {
 			result.Release()
+			result = nil
 		}
 
 		return result, err

--- a/arrow/compute/exprs/exec_test.go
+++ b/arrow/compute/exprs/exec_test.go
@@ -137,12 +137,12 @@ func TestComparisons(t *testing.T) {
 		one  = scalar.MakeScalar(int32(1))
 		two  = scalar.MakeScalar(int32(2))
 
-		str           = scalar.MakeScalar("hello")
-		bin           = scalar.MakeScalar([]byte("hello"))
-		exampleUUID   = uuid.MustParse("102cb62f-e6f8-4eb0-9973-d9b012ff0967")
-		uidStorage, _ = scalar.MakeScalarParam(exampleUUID[:],
+		str            = scalar.MakeScalar("hello")
+		bin            = scalar.MakeScalar([]byte("hello"))
+		exampleUUID    = uuid.MustParse("102cb62f-e6f8-4eb0-9973-d9b012ff0967")
+		uuidStorage, _ = scalar.MakeScalarParam(exampleUUID[:],
 			&arrow.FixedSizeBinaryType{ByteWidth: 16})
-		uid = scalar.NewExtensionScalar(uidStorage, extensions.NewUUIDType())
+		uuidScalar = scalar.NewExtensionScalar(uuidStorage, extensions.NewUUIDType())
 	)
 
 	getArgType := func(dt arrow.DataType) types.Type {
@@ -191,7 +191,7 @@ func TestComparisons(t *testing.T) {
 
 	expect(t, "equal", one, one, true)
 	expect(t, "equal", one, two, false)
-	expect(t, "equal", uid, uid, true)
+	expect(t, "equal", uuidScalar, uuidScalar, true)
 	expect(t, "less", one, two, true)
 	expect(t, "less", one, zero, false)
 	expect(t, "greater", one, zero, true)

--- a/arrow/compute/exprs/extension_types.go
+++ b/arrow/compute/exprs/extension_types.go
@@ -75,7 +75,7 @@ func (ef *simpleExtensionTypeFactory[P]) ExtensionEquals(other arrow.ExtensionTy
 	return ef.params == rhs.params
 }
 func (ef *simpleExtensionTypeFactory[P]) ArrayType() reflect.Type {
-	return reflect.TypeOf(array.ExtensionArrayBase{})
+	return reflect.TypeOf(simpleExtensionArrayFactory[P]{})
 }
 
 func (ef *simpleExtensionTypeFactory[P]) CreateType(params P) arrow.DataType {
@@ -91,10 +91,14 @@ func (ef *simpleExtensionTypeFactory[P]) CreateType(params P) arrow.DataType {
 	}
 }
 
+type simpleExtensionArrayFactory[P comparable] struct {
+	array.ExtensionArrayBase
+}
+
 type uuidExtParams struct{}
 
 var uuidType = simpleExtensionTypeFactory[uuidExtParams]{
-	name: "uuid", getStorage: func(uuidExtParams) arrow.DataType {
+	name: "arrow.uuid", getStorage: func(uuidExtParams) arrow.DataType {
 		return &arrow.FixedSizeBinaryType{ByteWidth: 16}
 	}}
 

--- a/arrow/compute/scalar_compare.go
+++ b/arrow/compute/scalar_compare.go
@@ -52,6 +52,7 @@ func (fn *compareFunction) DispatchBest(vals ...arrow.DataType) (exec.Kernel, er
 	}
 
 	ensureDictionaryDecoded(vals...)
+	ensureNotExtensionType(vals...)
 	replaceNullWithOtherType(vals...)
 
 	if dt := commonNumeric(vals...); dt != nil {

--- a/arrow/compute/scalar_compare_test.go
+++ b/arrow/compute/scalar_compare_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/compute/exec"
 	"github.com/apache/arrow-go/v18/arrow/compute/internal/kernels"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/internal/testing/gen"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
@@ -1289,6 +1290,8 @@ func TestCompareKernelsDispatchBest(t *testing.T) {
 			&arrow.Decimal128Type{Precision: 3, Scale: 2}, &arrow.Decimal128Type{Precision: 21, Scale: 2}},
 		{arrow.PrimitiveTypes.Int64, &arrow.Decimal128Type{Precision: 3, Scale: 2},
 			&arrow.Decimal128Type{Precision: 21, Scale: 2}, &arrow.Decimal128Type{Precision: 3, Scale: 2}},
+
+		{extensions.NewUUIDType(), extensions.NewUUIDType(), &arrow.FixedSizeBinaryType{ByteWidth: 16}, &arrow.FixedSizeBinaryType{ByteWidth: 16}},
 	}
 
 	for _, name := range []string{"equal", "not_equal", "less", "less_equal", "greater", "greater_equal"} {

--- a/arrow/compute/utils.go
+++ b/arrow/compute/utils.go
@@ -105,6 +105,14 @@ func ensureDictionaryDecoded(vals ...arrow.DataType) {
 	}
 }
 
+func ensureNotExtensionType(vals ...arrow.DataType) {
+	for i, v := range vals {
+		if v.ID() == arrow.EXTENSION {
+			vals[i] = v.(arrow.ExtensionType).StorageType()
+		}
+	}
+}
+
 func replaceNullWithOtherType(vals ...arrow.DataType) {
 	debug.Assert(len(vals) == 2, "should be length 2")
 

--- a/arrow/extensions/uuid.go
+++ b/arrow/extensions/uuid.go
@@ -228,6 +228,10 @@ func (*UUIDType) ExtensionName() string {
 	return "arrow.uuid"
 }
 
+func (*UUIDType) Bytes() int { return 16 }
+
+func (*UUIDType) BitWidth() int { return 128 }
+
 func (e *UUIDType) String() string {
 	return fmt.Sprintf("extension<%s>", e.ExtensionName())
 }

--- a/parquet/pqarrow/encode_arrow_test.go
+++ b/parquet/pqarrow/encode_arrow_test.go
@@ -2057,6 +2057,8 @@ func (ps *ParquetIOTestSuite) TestArrowExtensionTypeRoundTrip() {
 	defer tbl.Release()
 
 	ps.roundTripTable(mem, tbl, true)
+	// ensure we get UUID back even without storing the schema
+	ps.roundTripTable(mem, tbl, false)
 }
 
 func (ps *ParquetIOTestSuite) TestArrowUnknownExtensionTypeRoundTrip() {

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -987,13 +987,15 @@ func applyOriginalStorageMetadata(origin arrow.Field, inferred *SchemaField) (mo
 			return
 		}
 
-		if !arrow.TypeEqual(extType.StorageType(), inferred.Field.Type) {
-			return modified, fmt.Errorf("%w: mismatch storage type '%s' for extension type '%s'",
-				arrow.ErrInvalid, inferred.Field.Type, extType)
-		}
+		if modified || !arrow.TypeEqual(extType, inferred.Field.Type) {
+			if !arrow.TypeEqual(extType.StorageType(), inferred.Field.Type) {
+				return modified, fmt.Errorf("%w: mismatch storage type '%s' for extension type '%s'",
+					arrow.ErrInvalid, inferred.Field.Type, extType)
+			}
 
-		inferred.Field.Type = extType
-		modified = true
+			inferred.Field.Type = extType
+			modified = true
+		}
 	case arrow.SPARSE_UNION, arrow.DENSE_UNION:
 		err = xerrors.New("unimplemented type")
 	case arrow.STRUCT:

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/flight"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/parquet"
@@ -514,8 +515,10 @@ func arrowFromFLBA(logical schema.LogicalType, length int) (arrow.DataType, erro
 	switch logtype := logical.(type) {
 	case schema.DecimalLogicalType:
 		return arrowDecimal(logtype), nil
-	case schema.NoLogicalType, schema.IntervalLogicalType, schema.UUIDLogicalType:
+	case schema.NoLogicalType, schema.IntervalLogicalType:
 		return &arrow.FixedSizeBinaryType{ByteWidth: int(length)}, nil
+	case schema.UUIDLogicalType:
+		return extensions.NewUUIDType(), nil
 	case schema.Float16LogicalType:
 		return &arrow.Float16Type{}, nil
 	default:


### PR DESCRIPTION
While working on github.com/apache/iceberg-go to enable reading data, I came across a few issues when dealing with UUID / extension types and some other small compute things. This fixes those issues and adds tests to account for them.