### PR TITLE
fix(parquet): Reading UUID columns

### DIFF
--- a/arrow/extensions/extensions.go
+++ b/arrow/extensions/extensions.go
@@ -21,8 +21,8 @@ import (
 )
 
 var canonicalExtensionTypes = []arrow.ExtensionType{
-	&Bool8Type{},
-	&UUIDType{},
+	NewBool8Type(),
+	NewUUIDType(),
 	&OpaqueType{},
 	&JSONType{},
 }

--- a/parquet/pqarrow/encode_arrow_test.go
+++ b/parquet/pqarrow/encode_arrow_test.go
@@ -2057,6 +2057,7 @@ func (ps *ParquetIOTestSuite) TestArrowExtensionTypeRoundTrip() {
 	defer tbl.Release()
 
 	ps.roundTripTable(mem, tbl, true)
+	ps.roundTripTable(mem, tbl, false)
 }
 
 func (ps *ParquetIOTestSuite) TestArrowUnknownExtensionTypeRoundTrip() {

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -990,7 +990,7 @@ func applyOriginalStorageMetadata(origin arrow.Field, inferred *SchemaField) (mo
 			return
 		}
 
-		if modified || !arrow.TypeEqual(extType, inferred.Field.Type) {
+		if modified && !arrow.TypeEqual(extType, inferred.Field.Type) {
 			if !arrow.TypeEqual(extType.StorageType(), inferred.Field.Type) {
 				return modified, fmt.Errorf("%w: mismatch storage type '%s' for extension type '%s'",
 					arrow.ErrInvalid, inferred.Field.Type, extType)

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -997,7 +997,6 @@ func applyOriginalStorageMetadata(origin arrow.Field, inferred *SchemaField) (mo
 			}
 
 			inferred.Field.Type = extType
-			modified = true
 		}
 	case arrow.SPARSE_UNION, arrow.DENSE_UNION:
 		err = xerrors.New("unimplemented type")


### PR DESCRIPTION
Split from #171 to be a more focused PR.

Currently we will properly write arrow data with the canonical UUID extension type as a parquet UUID column via `pqarrow`. This PR enables us to read back that data using the `extensions.UUID` data type correctly even when we don't have a stored schema.

Added a test to the `ArrowExtensionTypeRoundTrip` to ensure proper round trip without a stored schema.

 