### PR TITLE
fix(arrow/compute): compare kernels with UUID

### DIFF
--- a/arrow/compute/exprs/exec.go
+++ b/arrow/compute/exprs/exec.go
@@ -571,6 +571,25 @@ func executeScalarBatch(ctx context.Context, input compute.ExecBatch, exp expr.E
 			return nil, err
 		}
 
+		var newArgs []compute.Datum
+		// cast arguments if necessary
+		for i, arg := range args {
+			if !arrow.TypeEqual(argTypes[i], arg.(compute.ArrayLikeDatum).Type()) {
+				if newArgs == nil {
+					newArgs = make([]compute.Datum, len(args))
+					copy(newArgs, args)
+				}
+				newArgs[i], err = compute.CastDatum(ctx, arg, compute.SafeCastOptions(argTypes[i]))
+				if err != nil {
+					return nil, err
+				}
+				defer newArgs[i].Release()
+			}
+		}
+		if newArgs != nil {
+			args = newArgs
+		}
+
 		kctx := &exec.KernelCtx{Ctx: ctx, Kernel: k}
 		init := k.GetInitFn()
 		kinitArgs := exec.KernelInitArgs{Kernel: k, Inputs: argTypes, Options: opts}
@@ -611,9 +630,10 @@ func executeScalarBatch(ctx context.Context, input compute.ExecBatch, exp expr.E
 
 		if ctx.Err() == context.Canceled && result != nil {
 			result.Release()
+			result = nil
 		}
 
-		return result, nil
+		return result, err
 	}
 
 	return nil, arrow.ErrNotImplemented

--- a/arrow/compute/exprs/extension_types.go
+++ b/arrow/compute/exprs/extension_types.go
@@ -75,7 +75,7 @@ func (ef *simpleExtensionTypeFactory[P]) ExtensionEquals(other arrow.ExtensionTy
 	return ef.params == rhs.params
 }
 func (ef *simpleExtensionTypeFactory[P]) ArrayType() reflect.Type {
-	return reflect.TypeOf(array.ExtensionArrayBase{})
+	return reflect.TypeOf(simpleExtensionArrayFactory[P]{})
 }
 
 func (ef *simpleExtensionTypeFactory[P]) CreateType(params P) arrow.DataType {
@@ -91,10 +91,14 @@ func (ef *simpleExtensionTypeFactory[P]) CreateType(params P) arrow.DataType {
 	}
 }
 
+type simpleExtensionArrayFactory[P comparable] struct {
+	array.ExtensionArrayBase
+}
+
 type uuidExtParams struct{}
 
 var uuidType = simpleExtensionTypeFactory[uuidExtParams]{
-	name: "uuid", getStorage: func(uuidExtParams) arrow.DataType {
+	name: "arrow.uuid", getStorage: func(uuidExtParams) arrow.DataType {
 		return &arrow.FixedSizeBinaryType{ByteWidth: 16}
 	}}
 

--- a/arrow/compute/scalar_compare.go
+++ b/arrow/compute/scalar_compare.go
@@ -52,6 +52,7 @@ func (fn *compareFunction) DispatchBest(vals ...arrow.DataType) (exec.Kernel, er
 	}
 
 	ensureDictionaryDecoded(vals...)
+	ensureNoExtensionType(vals...)
 	replaceNullWithOtherType(vals...)
 
 	if dt := commonNumeric(vals...); dt != nil {

--- a/arrow/compute/scalar_compare_test.go
+++ b/arrow/compute/scalar_compare_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/compute/exec"
 	"github.com/apache/arrow-go/v18/arrow/compute/internal/kernels"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/internal/testing/gen"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
@@ -1289,6 +1290,7 @@ func TestCompareKernelsDispatchBest(t *testing.T) {
 			&arrow.Decimal128Type{Precision: 3, Scale: 2}, &arrow.Decimal128Type{Precision: 21, Scale: 2}},
 		{arrow.PrimitiveTypes.Int64, &arrow.Decimal128Type{Precision: 3, Scale: 2},
 			&arrow.Decimal128Type{Precision: 21, Scale: 2}, &arrow.Decimal128Type{Precision: 3, Scale: 2}},
+		{extensions.NewUUIDType(), extensions.NewUUIDType(), &arrow.FixedSizeBinaryType{ByteWidth: 16}, &arrow.FixedSizeBinaryType{ByteWidth: 16}},
 	}
 
 	for _, name := range []string{"equal", "not_equal", "less", "less_equal", "greater", "greater_equal"} {

--- a/arrow/compute/utils.go
+++ b/arrow/compute/utils.go
@@ -105,6 +105,14 @@ func ensureDictionaryDecoded(vals ...arrow.DataType) {
 	}
 }
 
+func ensureNoExtensionType(vals ...arrow.DataType) {
+	for i, v := range vals {
+		if v.ID() == arrow.EXTENSION {
+			vals[i] = v.(arrow.ExtensionType).StorageType()
+		}
+	}
+}
+
 func replaceNullWithOtherType(vals ...arrow.DataType) {
 	debug.Assert(len(vals) == 2, "should be length 2")
 

--- a/arrow/extensions/uuid.go
+++ b/arrow/extensions/uuid.go
@@ -228,6 +228,9 @@ func (*UUIDType) ExtensionName() string {
 	return "arrow.uuid"
 }
 
+func (*UUIDType) Bytes() int    { return 16 }
+func (*UUIDType) BitWidth() int { return 128 }
+
 func (e *UUIDType) String() string {
 	return fmt.Sprintf("extension<%s>", e.ExtensionName())
 }
@@ -262,4 +265,6 @@ var (
 	_ array.CustomExtensionBuilder = (*UUIDType)(nil)
 	_ array.ExtensionArray         = (*UUIDArray)(nil)
 	_ array.Builder                = (*UUIDBuilder)(nil)
+
+	_ arrow.FixedWidthDataType = (*UUIDType)(nil)
 )


### PR DESCRIPTION
Split from #171 

Enable using the comparison kernels (equal, less, less_equal, greater, greater_equal) with UUID columns and extension types in general.

Tests are added to check the kernel dispatch and to ensure compute via substrait works for UUID type scalars.