### PR TITLE
feat(arrow/compute): make is_nan dispatchable

### DIFF
--- a/arrow/compute/scalar_compare_test.go
+++ b/arrow/compute/scalar_compare_test.go
@@ -1495,8 +1495,8 @@ func (sv *ScalarValiditySuite) TestIsNaN() {
 	}{
 		{`[]`, `[]`},
 		{`[1]`, `[false]`},
-		{`[null]`, `[null]`},
-		{`["NaN", 1, 0, null]`, `[true, false, false, null]`},
+		{`[null]`, `[false]`},
+		{`["NaN", 1, 0, null]`, `[true, false, false, false]`},
 	}
 
 	for _, typ := range floatingTypes {


### PR DESCRIPTION
Currently the `is_nan` compute kernel is a `MetaFunction` which cannot be dispatched via kernel dispatch making it only usable via calling it directly with `CallFunction`. By shifting it to be a proper function instead of a `MetaFunction` this improves its compatibility and makes it able to be dispatched and thus called through the substrait interface in the `exprs` package.