### PR TITLE
feat(parquet/pqarrow): Add ForceLarge option

### DIFF
--- a/parquet/pqarrow/encode_arrow_test.go
+++ b/parquet/pqarrow/encode_arrow_test.go
@@ -1976,8 +1976,10 @@ func TestForceLargeTypes(t *testing.T) {
 	require.NoError(t, err)
 	defer rdr.Close()
 
-	pqrdr, err := pqarrow.NewFileReader(rdr, pqarrow.ArrowReadProperties{
-		ForceLarge: true}, mem)
+	props := pqarrow.ArrowReadProperties{}
+	props.SetForceLarge(0, true)
+	props.SetForceLarge(1, true)
+	pqrdr, err := pqarrow.NewFileReader(rdr, props, mem)
 	require.NoError(t, err)
 
 	recrdr, err := pqrdr.GetRecordReader(context.Background(), nil, nil)

--- a/parquet/pqarrow/file_reader.go
+++ b/parquet/pqarrow/file_reader.go
@@ -471,9 +471,13 @@ func (fr *FileReader) GetRecordReader(ctx context.Context, colIndices, rowGroups
 		nrows += fr.rdr.MetaData().RowGroup(rg).NumRows()
 	}
 
+	batchSize := fr.Props.BatchSize
+	if fr.Props.BatchSize <= 0 {
+		batchSize = nrows
+	}
 	return &recordReader{
 		numRows:      nrows,
-		batchSize:    fr.Props.BatchSize,
+		batchSize:    batchSize,
 		parallel:     fr.Props.Parallel,
 		sc:           sc,
 		fieldReaders: readers,

--- a/parquet/pqarrow/properties.go
+++ b/parquet/pqarrow/properties.go
@@ -165,6 +165,11 @@ type ArrowReadProperties struct {
 	Parallel bool
 	// BatchSize is the size used for calls to NextBatch when reading whole columns
 	BatchSize int64
+	// Setting ForceLarge to true will force the reader to use LargeString/LargeBinary
+	// for string and binary columns respectively, instead of the default variants. This
+	// can be necessary if you know that there are columns which contain more than 2GB of
+	// data, which would prevent use of int32 offsets.
+	ForceLarge bool
 
 	readDictIndices map[int]struct{}
 }


### PR DESCRIPTION
### Rationale for this change
closes #195

For parquet files that contain more than 2GB of data in a column, we should allow a user to force using the LargeString/LargeBinary variants without requiring a stored schema.

### What changes are included in this PR?
Adds `ForceLarge` option to `pqarrow.ArrowReadProperties` and enables it to force usage of `LargeString` and `LargeBinary` data types.

### Are these changes tested?
Yes, a unit test is added.

### Are there any user-facing changes?
No breaking changes, only the addition of a new option.
