### PR TITLE
fix(internal/json): add arrow_json_stdlib build tag

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !tinygo
-// +build !tinygo
+//go:build !tinygo && !arrow_json_stdlib
+// +build !tinygo,!arrow_json_stdlib
 
 package json
 

--- a/internal/json/json_stdlib.go
+++ b/internal/json/json_stdlib.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build tinygo
-// +build tinygo
+//go:build tinygo || arrow_json_stdlib
+// +build tinygo arrow_json_stdlib
 
 package json
 


### PR DESCRIPTION
### Rationale for this change

Grafana and Grafana plugins both use arrow-go, but do not use arrow's `internal/json`. A decent amount of used heap is initialized by https://github.com/goccy/go-json, so it would be useful to be able to prevent the initialization.

The example below shows that 60% of this heap profile in a Grafana plugin is used by `go-json`'s encoder & decoder packages.

![image](https://github.com/user-attachments/assets/abd377c6-4510-4652-8801-88785f6c121d)

I have submitted a [PR to go-json](https://github.com/goccy/go-json/pull/490) to switch to lazy initialization (additional details in the PR), but I am having a hard time getting a response from the maintainer, so am attempting a different approach to the problem with this PR.

### What changes are included in this PR?

Adds `arrow_json_stdlib` build tag so that it's possible to switch to `encoding/json` and avoid the overhead of https://github.com/goccy/go-json.

### Are these changes tested?

I tested this locally, but I can add coverage if this seems like an acceptable approach.

### Are there any user-facing changes?

