### PR TITLE
ci: use correct GitHub Actions permission "contents" instead of "content"

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -25,7 +25,7 @@ jobs:
   issue_assign:
     name: "Assign issue"
     permissions:
-      content: read
+      contents: read
       issues: write
     if: github.event.comment.body == 'take'
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Rationale for this change

The syntax for permissions should use `contents` instead of `content`, see: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions

### What changes are included in this PR?

Update to correct GitHub actions syntax.

### Are these changes tested?

No, but can be seen the usage on the Arrow repo: https://github.com/apache/arrow/blob/bbda6b1e1322c5a9b8c107a03343d18b759694c1/.github/workflows/comment_bot.yml#L28

### Are there any user-facing changes?

No