### PR TITLE
fix(parquet/metadata): fix default unsigned int statistics

### DIFF
--- a/parquet/metadata/statistics_test.go
+++ b/parquet/metadata/statistics_test.go
@@ -265,14 +265,28 @@ func TestBooleanStatisticsEncoding(t *testing.T) {
 func TestUnsignedDefaultStats(t *testing.T) {
 	// testing issue github.com/apache/arrow-go/issues/209
 	// stats for unsigned columns should not have invalid min values
-	n, err := schema.NewPrimitiveNodeLogical("uint16", parquet.Repetitions.Optional,
-		schema.NewIntLogicalType(16, false), parquet.Types.Int32, 4, -1)
-	require.NoError(t, err)
-	descr := schema.NewColumn(n, 1, 0)
-	s := metadata.NewStatistics(descr, nil).(*metadata.Int32Statistics)
-	s.UpdateSpaced([]int32{0}, []byte{1}, 0, 0)
+	{
+		n, err := schema.NewPrimitiveNodeLogical("uint16", parquet.Repetitions.Optional,
+			schema.NewIntLogicalType(16, false), parquet.Types.Int32, 4, -1)
+		require.NoError(t, err)
+		descr := schema.NewColumn(n, 1, 0)
+		s := metadata.NewStatistics(descr, nil).(*metadata.Int32Statistics)
+		s.UpdateSpaced([]int32{0}, []byte{1}, 0, 0)
 
-	minv, maxv := s.Min(), s.Max()
-	assert.Zero(t, minv)
-	assert.Zero(t, maxv)
+		minv, maxv := s.Min(), s.Max()
+		assert.Zero(t, minv)
+		assert.Zero(t, maxv)
+	}
+	{
+		n, err := schema.NewPrimitiveNodeLogical("uint64", parquet.Repetitions.Optional,
+			schema.NewIntLogicalType(64, false), parquet.Types.Int64, 4, -1)
+		require.NoError(t, err)
+		descr := schema.NewColumn(n, 1, 0)
+		s := metadata.NewStatistics(descr, nil).(*metadata.Int64Statistics)
+		s.UpdateSpaced([]int64{0}, []byte{1}, 0, 0)
+
+		minv, maxv := s.Min(), s.Max()
+		assert.Zero(t, minv)
+		assert.Zero(t, maxv)
+	}
 }

--- a/parquet/metadata/statistics_types.gen.go
+++ b/parquet/metadata/statistics_types.gen.go
@@ -1999,7 +1999,7 @@ func (s *ByteArrayStatistics) UpdateFromArrow(values arrow.Array, updateCounts b
 	)
 
 	for i := 0; i < arr.Len(); i++ {
-		nextOffset := arr.ValueOffset64(i + 1)
+		nextOffset := curOffset + int64(arr.ValueLen(i))		
 		v := data[curOffset:nextOffset]
 		curOffset = nextOffset
 

--- a/parquet/metadata/statistics_types.gen.go
+++ b/parquet/metadata/statistics_types.gen.go
@@ -164,13 +164,26 @@ func (s *Int32Statistics) getMinMax(values []int32) (min, max int32) {
 func (s *Int32Statistics) getMinMaxSpaced(values []int32, validBits []byte, validBitsOffset int64) (min, max int32) {
 	min = s.defaultMin()
 	max = s.defaultMax()
-	var fn func([]int32) (int32, int32)
+	var fn func([]int32)
 	if s.order == schema.SortSIGNED {
-		fn = shared_utils.GetMinMaxInt32
+		fn = func(v []int32) {
+			localMin, localMax := shared_utils.GetMinMaxInt32(v)
+			if min > localMin {
+				min = localMin
+			}
+			if max < localMax {
+				max = localMax
+			}
+		}
 	} else {
-		fn = func(v []int32) (int32, int32) {
-			umin, umax := shared_utils.GetMinMaxUint32(arrow.Uint32Traits.CastFromBytes(arrow.Int32Traits.CastToBytes(values)))
-			return int32(umin), int32(umax)
+		fn = func(v []int32) {
+			umin, umax := shared_utils.GetMinMaxUint32(arrow.Uint32Traits.CastFromBytes(arrow.Int32Traits.CastToBytes(v)))
+			if uint32(min) > umin {
+				min = int32(umin)
+			}
+			if uint32(max) < umax {
+				max = int32(umax)
+			}
 		}
 	}
 
@@ -185,13 +198,7 @@ func (s *Int32Statistics) getMinMaxSpaced(values []int32, validBits []byte, vali
 		if run.Length == 0 {
 			break
 		}
-		localMin, localMax := fn(values[int(run.Pos):int(run.Pos+run.Length)])
-		if min > localMin {
-			min = localMin
-		}
-		if max < localMax {
-			max = localMax
-		}
+		fn(values[int(run.Pos):int(run.Pos+run.Length)])
 	}
 	return
 }
@@ -457,13 +464,26 @@ func (s *Int64Statistics) getMinMax(values []int64) (min, max int64) {
 func (s *Int64Statistics) getMinMaxSpaced(values []int64, validBits []byte, validBitsOffset int64) (min, max int64) {
 	min = s.defaultMin()
 	max = s.defaultMax()
-	var fn func([]int64) (int64, int64)
+	var fn func([]int64)
 	if s.order == schema.SortSIGNED {
-		fn = shared_utils.GetMinMaxInt64
+		fn = func(v []int64) {
+			localMin, localMax := shared_utils.GetMinMaxInt64(v)
+			if min > localMin {
+				min = localMin
+			}
+			if max < localMax {
+				max = localMax
+			}
+		}
 	} else {
-		fn = func(v []int64) (int64, int64) {
-			umin, umax := shared_utils.GetMinMaxUint64(arrow.Uint64Traits.CastFromBytes(arrow.Int64Traits.CastToBytes(values)))
-			return int64(umin), int64(umax)
+		fn = func(v []int64) {
+			umin, umax := shared_utils.GetMinMaxUint64(arrow.Uint64Traits.CastFromBytes(arrow.Int64Traits.CastToBytes(v)))
+			if uint64(min) > umin {
+				min = int64(umin)
+			}
+			if uint64(max) < umax {
+				max = int64(umax)
+			}
 		}
 	}
 
@@ -478,13 +498,7 @@ func (s *Int64Statistics) getMinMaxSpaced(values []int64, validBits []byte, vali
 		if run.Length == 0 {
 			break
 		}
-		localMin, localMax := fn(values[int(run.Pos):int(run.Pos+run.Length)])
-		if min > localMin {
-			min = localMin
-		}
-		if max < localMax {
-			max = localMax
-		}
+		fn(values[int(run.Pos):int(run.Pos+run.Length)])
 	}
 	return
 }
@@ -1980,12 +1994,12 @@ func (s *ByteArrayStatistics) UpdateFromArrow(values arrow.Array, updateCounts b
 		min       = s.defaultMin()
 		max       = s.defaultMax()
 		arr       = values.(array.BinaryLike)
-		data      = arr.ValueBytes()		
+		data      = arr.ValueBytes()
 		curOffset = int64(0)
 	)
 
 	for i := 0; i < arr.Len(); i++ {
-		nextOffset := curOffset + int64(arr.ValueLen(i))
+		nextOffset := arr.ValueOffset64(i + 1)
 		v := data[curOffset:nextOffset]
 		curOffset = nextOffset
 

--- a/parquet/metadata/statistics_types.gen.go.tmpl
+++ b/parquet/metadata/statistics_types.gen.go.tmpl
@@ -248,13 +248,26 @@ func (s *{{.Name}}Statistics) getMinMaxSpaced(values []{{.name}}, validBits []by
   max = s.defaultMax()
 
 {{- if or (eq .name "int32") (eq .name "int64")}}
-  var fn func([]{{.name}}) ({{.name}}, {{.name}})
+  var fn func([]{{.name}})
   if s.order == schema.SortSIGNED {
-    fn = shared_utils.GetMinMax{{.Name}}
+    fn = func(v []{{.name}}) {
+      localMin, localMax := shared_utils.GetMinMax{{.Name}}(v)
+      if min > localMin { 
+        min = localMin
+      }
+      if max < localMax {
+        max = localMax
+      }
+    }
   } else {
-    fn = func(v []{{.name}}) ({{.name}}, {{.name}}) {
-      umin, umax := shared_utils.GetMinMaxU{{.name}}(arrow.U{{.name}}Traits.CastFromBytes(arrow.{{.Name}}Traits.CastToBytes(values)))
-      return {{.name}}(umin), {{.name}}(umax)
+    fn = func(v []{{.name}}) {
+      umin, umax := shared_utils.GetMinMaxU{{.name}}(arrow.U{{.name}}Traits.CastFromBytes(arrow.{{.Name}}Traits.CastToBytes(v)))
+      if u{{.name}}(min) > umin {
+        min = {{.name}}(umin)
+      }
+      if u{{.name}}(max) < umax {
+        max = {{.name}}(umax)
+      }      
     }
   }
 {{- end}}
@@ -271,13 +284,7 @@ func (s *{{.Name}}Statistics) getMinMaxSpaced(values []{{.name}}, validBits []by
       break
     }
 {{- if or (eq .name "int32") (eq .name "int64")}}
-    localMin, localMax := fn(values[int(run.Pos):int(run.Pos+run.Length)])
-    if min > localMin {
-      min = localMin
-    }
-    if max < localMax {
-      max = localMax
-    }
+    fn(values[int(run.Pos):int(run.Pos+run.Length)])    
 {{- else}}
     for _, v := range values[int(run.Pos):int(run.Pos+run.Length)] {
 {{- if or (eq .name "float32") (eq .name "float64") (eq .Name "Float16") }}

--- a/parquet/metadata/statistics_types.gen.go.tmpl
+++ b/parquet/metadata/statistics_types.gen.go.tmpl
@@ -392,7 +392,7 @@ func (s *{{.Name}}Statistics) UpdateFromArrow(values arrow.Array, updateCounts b
   )
 
   for i := 0; i < arr.Len(); i++ {
-    nextOffset := arr.ValueOffset64(i + 1)
+    nextOffset := curOffset + int64(arr.ValueLen(i))
     v := data[curOffset:nextOffset]
     curOffset = nextOffset
 


### PR DESCRIPTION
### Rationale for this change
fixes #209 

### What changes are included in this PR?
Fixing `UpdateSpaced` statistics methods to properly check unsigned values to ensure proper handling of default min/max values.

### Are these changes tested?
Yes, unit test was added to confirm.

### Are there any user-facing changes?
None, other than fixing the reported bug.
