### PR TITLE
feat(arrow/ipc): implement lazy loading/zero-copy for IPC files

### DIFF
--- a/arrow/ipc/file_writer.go
+++ b/arrow/ipc/file_writer.go
@@ -41,8 +41,8 @@ type fileWriter struct {
 	streamWriter
 
 	schema *arrow.Schema
-	dicts  []fileBlock
-	recs   []fileBlock
+	dicts  []dataBlock
+	recs   []dataBlock
 }
 
 func (w *fileWriter) Start() error {
@@ -63,13 +63,13 @@ func (w *fileWriter) Start() error {
 }
 
 func (w *fileWriter) WritePayload(p Payload) error {
-	blk := fileBlock{Offset: w.pos, Meta: 0, Body: p.size}
+	blk := fileBlock{offset: w.pos, meta: 0, body: p.size}
 	n, err := writeIPCPayload(w, p)
 	if err != nil {
 		return err
 	}
 
-	blk.Meta = int32(n)
+	blk.meta = int32(n)
 
 	switch flatbuf.MessageHeader(p.msg) {
 	case flatbuf.MessageHeaderDictionaryBatch:

--- a/arrow/ipc/metadata_test.go
+++ b/arrow/ipc/metadata_test.go
@@ -89,8 +89,8 @@ func TestRWSchema(t *testing.T) {
 func TestRWFooter(t *testing.T) {
 	for _, tc := range []struct {
 		schema *arrow.Schema
-		dicts  []fileBlock
-		recs   []fileBlock
+		dicts  []dataBlock
+		recs   []dataBlock
 	}{
 		{
 			schema: arrow.NewSchema([]arrow.Field{
@@ -98,15 +98,15 @@ func TestRWFooter(t *testing.T) {
 				{Name: "f2", Type: arrow.PrimitiveTypes.Uint16},
 				{Name: "f3", Type: arrow.PrimitiveTypes.Float64},
 			}, nil),
-			dicts: []fileBlock{
-				{Offset: 1, Meta: 2, Body: 3},
-				{Offset: 4, Meta: 5, Body: 6},
-				{Offset: 7, Meta: 8, Body: 9},
+			dicts: []dataBlock{
+				fileBlock{offset: 1, meta: 2, body: 3},
+				fileBlock{offset: 4, meta: 5, body: 6},
+				fileBlock{offset: 7, meta: 8, body: 9},
 			},
-			recs: []fileBlock{
-				{Offset: 0, Meta: 10, Body: 30},
-				{Offset: 10, Meta: 30, Body: 60},
-				{Offset: 20, Meta: 30, Body: 40},
+			recs: []dataBlock{
+				fileBlock{offset: 0, meta: 10, body: 30},
+				fileBlock{offset: 10, meta: 30, body: 60},
+				fileBlock{offset: 20, meta: 30, body: 40},
 			},
 		},
 	} {
@@ -142,7 +142,7 @@ func TestRWFooter(t *testing.T) {
 				if !footer.Dictionaries(&blk, i) {
 					t.Fatalf("could not get dictionary %d", i)
 				}
-				got := fileBlock{Offset: blk.Offset(), Meta: blk.MetaDataLength(), Body: blk.BodyLength()}
+				got := fileBlock{offset: blk.Offset(), meta: blk.MetaDataLength(), body: blk.BodyLength()}
 				want := dict
 				if got != want {
 					t.Errorf("dict[%d] differ:\ngot= %v\nwant=%v", i, got, want)
@@ -158,7 +158,7 @@ func TestRWFooter(t *testing.T) {
 				if !footer.RecordBatches(&blk, i) {
 					t.Fatalf("could not get record %d", i)
 				}
-				got := fileBlock{Offset: blk.Offset(), Meta: blk.MetaDataLength(), Body: blk.BodyLength()}
+				got := fileBlock{offset: blk.Offset(), meta: blk.MetaDataLength(), body: blk.BodyLength()}
 				want := rec
 				if got != want {
 					t.Errorf("record[%d] differ:\ngot= %v\nwant=%v", i, got, want)

--- a/arrow/ipc/reader.go
+++ b/arrow/ipc/reader.go
@@ -17,7 +17,6 @@
 package ipc
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -201,7 +200,7 @@ func (r *Reader) getInitialDicts() bool {
 		if msg.Type() != MessageDictionaryBatch {
 			r.err = fmt.Errorf("arrow/ipc: IPC stream did not have the expected (%d) dictionaries at the start of the stream", numDicts)
 		}
-		if _, err := readDictionary(&r.memo, msg.meta, bytes.NewReader(msg.body.Bytes()), r.swapEndianness, r.mem); err != nil {
+		if _, err := readDictionary(&r.memo, msg.meta, msg.body, r.swapEndianness, r.mem); err != nil {
 			r.done = true
 			r.err = err
 			return false
@@ -233,7 +232,7 @@ func (r *Reader) next() bool {
 	msg, r.err = r.r.Message()
 
 	for msg != nil && msg.Type() == MessageDictionaryBatch {
-		if _, r.err = readDictionary(&r.memo, msg.meta, bytes.NewReader(msg.body.Bytes()), r.swapEndianness, r.mem); r.err != nil {
+		if _, r.err = readDictionary(&r.memo, msg.meta, msg.body, r.swapEndianness, r.mem); r.err != nil {
 			r.done = true
 			return false
 		}
@@ -252,7 +251,7 @@ func (r *Reader) next() bool {
 		return false
 	}
 
-	r.rec = newRecord(r.schema, &r.memo, msg.meta, bytes.NewReader(msg.body.Bytes()), r.swapEndianness, r.mem)
+	r.rec = newRecord(r.schema, &r.memo, msg.meta, msg.body, r.swapEndianness, r.mem)
 	return true
 }
 


### PR DESCRIPTION
### Rationale for this change
closes #207 

### What changes are included in this PR?
Adding new method `NewMappedFileReader` to ipc package which accepts a byte slice instead of a `ReaderAtSeeker`. Updates `ipcSource` to reference the raw byte slices from the input directly instead of wrapping with `bytes.NewReader` which forces copies via `Read`, `ReadFull`, etc.

### Are these changes tested?
Unit tests added to confirm that the pointers match and that we aren't allocating unnecessarily.

### Are there any user-facing changes?
Shouldn't be any user-facing changes other than a reduction in memory usage when reading non-compressed IPC data.
