### PR TITLE
feat(parquet): Move footerOffset into FileMetaData

### DIFF
--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -180,10 +180,11 @@ func (f *Reader) parseMetaData() error {
 			return fmt.Errorf("parquet: could not read footer: %w", err)
 		}
 
-		f.metadata, err = metadata.NewFileMetaData(buf, footerOffset, nil)
+		f.metadata, err = metadata.NewFileMetaData(buf, nil)
 		if err != nil {
 			return fmt.Errorf("parquet: could not read footer: %w", err)
 		}
+		f.metadata.SetSourceFileSize(footerOffset)
 
 		if !f.metadata.IsSetEncryptionAlgorithm() {
 			if fileDecryptProps != nil && !fileDecryptProps.PlaintextFilesAllowed() {
@@ -215,10 +216,11 @@ func (f *Reader) parseMetaData() error {
 		}
 		f.fileDecryptor = encryption.NewFileDecryptor(fileDecryptProps, fileAad, algo.Algo, string(fileCryptoMetadata.KeyMetadata()), f.props.Allocator())
 
-		f.metadata, err = metadata.NewFileMetaData(buf[fileCryptoMetadata.Len():], footerOffset, f.fileDecryptor)
+		f.metadata, err = metadata.NewFileMetaData(buf[fileCryptoMetadata.Len():], f.fileDecryptor)
 		if err != nil {
 			return fmt.Errorf("parquet: could not read footer: %w", err)
 		}
+		f.metadata.SetSourceFileSize(footerOffset)
 	default:
 		return fmt.Errorf("parquet: magic bytes not found in footer. Either the file is corrupted or this isn't a parquet file")
 	}

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -84,7 +84,7 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 	colLen := col.TotalCompressedSize()
 	// PARQUET-816 workaround for old files created by older parquet-mr
 	if r.fileMetadata.WriterVersion().LessThan(metadata.Parquet816FixedVersion) {
-		sourceSz := r.fileMetadata.SourceSz()
+		sourceSz := r.fileMetadata.GetSourceFileSize()
 		// The Parquet MR writer had a bug in 1.2.8 and below where it didn't include the
 		// dictionary page header size in total_compressed_size and total_uncompressed_size
 		// (see IMPALA-694). We add padding to compensate.

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -34,7 +34,6 @@ const (
 // RowGroupReader is the primary interface for reading a single row group
 type RowGroupReader struct {
 	r             parquet.ReaderAtSeeker
-	sourceSz      int64
 	fileMetadata  *metadata.FileMetaData
 	rgMetadata    *metadata.RowGroupMetaData
 	props         *parquet.ReaderProperties
@@ -85,16 +84,17 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 	colLen := col.TotalCompressedSize()
 	// PARQUET-816 workaround for old files created by older parquet-mr
 	if r.fileMetadata.WriterVersion().LessThan(metadata.Parquet816FixedVersion) {
+		sourceSz := r.fileMetadata.SourceSz()
 		// The Parquet MR writer had a bug in 1.2.8 and below where it didn't include the
 		// dictionary page header size in total_compressed_size and total_uncompressed_size
 		// (see IMPALA-694). We add padding to compensate.
 		if colStart < 0 || colLen < 0 {
 			return nil, fmt.Errorf("invalid column chunk metadata, offset (%d) and length (%d) should both be positive", colStart, colLen)
 		}
-		if colStart > r.sourceSz || colLen > r.sourceSz {
-			return nil, fmt.Errorf("invalid column chunk metadata, offset (%d) and length (%d) must both be less than total source size (%d)", colStart, colLen, r.sourceSz)
+		if colStart > sourceSz || colLen > sourceSz {
+			return nil, fmt.Errorf("invalid column chunk metadata, offset (%d) and length (%d) must both be less than total source size (%d)", colStart, colLen, sourceSz)
 		}
-		bytesRemain := r.sourceSz - (colStart + colLen)
+		bytesRemain := sourceSz - (colStart + colLen)
 		padding := utils.Min(maxDictHeaderSize, bytesRemain)
 		colLen += padding
 	}

--- a/parquet/metadata/file.go
+++ b/parquet/metadata/file.go
@@ -279,10 +279,10 @@ func NewFileMetaData(data []byte, fileDecryptor encryption.FileDecryptor) (*File
 // Size is the length of the raw serialized metadata bytes in the footer
 func (f *FileMetaData) Size() int { return f.metadataLen }
 
-// SetSourceFileSize get the total size of the source file from meta data.
+// GetSourceFileSize get the total size of the source file from meta data.
 func (f *FileMetaData) GetSourceFileSize() int64 { return f.sourceFileSize }
 
-// GetSourceFileSize set the total size of the source file in meta data.
+// SetSourceFileSize set the total size of the source file in meta data.
 func (f *FileMetaData) SetSourceFileSize(sourceFileSize int64) { f.sourceFileSize = sourceFileSize }
 
 // NumSchemaElements is the length of the flattened schema list in the thrift
@@ -398,7 +398,7 @@ func (f *FileMetaData) Subset(rowGroups []int) (*FileMetaData, error) {
 		f.FileDecryptor,
 		f.version,
 		0,
-		f.footerOffset,
+		f.sourceFileSize,
 	}
 
 	out.RowGroups = make([]*format.RowGroup, 0, len(rowGroups))

--- a/parquet/metadata/file.go
+++ b/parquet/metadata/file.go
@@ -243,6 +243,8 @@ type FileMetaData struct {
 	// size of the raw bytes of the metadata in the file which were
 	// decoded by thrift, Size() getter returns the value.
 	metadataLen int
+
+	FooterOffset int64
 }
 
 // NewFileMetaData takes in the raw bytes of the serialized metadata to deserialize
@@ -388,6 +390,7 @@ func (f *FileMetaData) Subset(rowGroups []int) (*FileMetaData, error) {
 		f.FileDecryptor,
 		f.version,
 		0,
+		f.FooterOffset,
 	}
 
 	out.RowGroups = make([]*format.RowGroup, 0, len(rowGroups))

--- a/parquet/metadata/file.go
+++ b/parquet/metadata/file.go
@@ -244,12 +244,14 @@ type FileMetaData struct {
 	// decoded by thrift, Size() getter returns the value.
 	metadataLen int
 
-	footerOffset int64
+	// sourceFileSize is not a part of FileMetaData, but it is mainly used to parse meta data.
+	// Users can manually set this value and they are responsible for the validity of it.
+	sourceFileSize int64
 }
 
 // NewFileMetaData takes in the raw bytes of the serialized metadata to deserialize
 // and will attempt to decrypt the footer if a decryptor is provided.
-func NewFileMetaData(data []byte, footerOffset int64, fileDecryptor encryption.FileDecryptor) (*FileMetaData, error) {
+func NewFileMetaData(data []byte, fileDecryptor encryption.FileDecryptor) (*FileMetaData, error) {
 	meta := format.NewFileMetaData()
 	if fileDecryptor != nil {
 		footerDecryptor := fileDecryptor.GetFooterDecryptor()
@@ -266,7 +268,6 @@ func NewFileMetaData(data []byte, footerOffset int64, fileDecryptor encryption.F
 		version:       NewAppVersion(meta.GetCreatedBy()),
 		metadataLen:   len(data) - int(remain),
 		FileDecryptor: fileDecryptor,
-		footerOffset:  footerOffset,
 	}
 
 	f.initSchema()
@@ -278,8 +279,11 @@ func NewFileMetaData(data []byte, footerOffset int64, fileDecryptor encryption.F
 // Size is the length of the raw serialized metadata bytes in the footer
 func (f *FileMetaData) Size() int { return f.metadataLen }
 
-// SourceSz is the total size of the source file
-func (f *FileMetaData) SourceSz() int64 { return f.footerOffset }
+// SetSourceFileSize get the total size of the source file from meta data.
+func (f *FileMetaData) GetSourceFileSize() int64 { return f.sourceFileSize }
+
+// GetSourceFileSize set the total size of the source file in meta data.
+func (f *FileMetaData) SetSourceFileSize(sourceFileSize int64) { f.sourceFileSize = sourceFileSize }
 
 // NumSchemaElements is the length of the flattened schema list in the thrift
 func (f *FileMetaData) NumSchemaElements() int {

--- a/parquet/metadata/metadata_test.go
+++ b/parquet/metadata/metadata_test.go
@@ -114,7 +114,7 @@ func TestBuildAccess(t *testing.T) {
 	require.NoError(t, err)
 	serialized, err := faccessor.SerializeString(context.Background())
 	assert.NoError(t, err)
-	faccessorCopy, err := metadata.NewFileMetaData([]byte(serialized), 0, nil)
+	faccessorCopy, err := metadata.NewFileMetaData([]byte(serialized), nil)
 	assert.NoError(t, err)
 
 	for _, accessor := range []*metadata.FileMetaData{faccessor, faccessorCopy} {

--- a/parquet/metadata/metadata_test.go
+++ b/parquet/metadata/metadata_test.go
@@ -114,7 +114,7 @@ func TestBuildAccess(t *testing.T) {
 	require.NoError(t, err)
 	serialized, err := faccessor.SerializeString(context.Background())
 	assert.NoError(t, err)
-	faccessorCopy, err := metadata.NewFileMetaData([]byte(serialized), nil)
+	faccessorCopy, err := metadata.NewFileMetaData([]byte(serialized), 0, nil)
 	assert.NoError(t, err)
 
 	for _, accessor := range []*metadata.FileMetaData{faccessor, faccessorCopy} {


### PR DESCRIPTION
### Rationale for this change

After looking into the code, I found that `footerOffset` is mainly used in parsing the meta data of parquet file.

I think we can store it in `FileMetaData`, so we don't need to get `footerOffset` again when we use `WithMetadata`. 

### What changes are included in this PR?

Move `Reader.footerOffset` into `FileMetadata`

### Are these changes tested?


### Are there any user-facing changes?

