### PR TITLE
feat(parquet): Add support for Page Indexes

### DIFF
--- a/arrow/flight/flightsql/column_metadata.go
+++ b/arrow/flight/flightsql/column_metadata.go
@@ -63,7 +63,7 @@ type ColumnMetadata struct {
 }
 
 func (c *ColumnMetadata) findStrVal(key string) (string, bool) {
-	idx := c.Data.FindKey(CatalogNameKey)
+	idx := c.Data.FindKey(key)
 	if idx == -1 {
 		return "", false
 	}
@@ -71,7 +71,7 @@ func (c *ColumnMetadata) findStrVal(key string) (string, bool) {
 }
 
 func (c *ColumnMetadata) findBoolVal(key string) (bool, bool) {
-	idx := c.Data.FindKey(CatalogNameKey)
+	idx := c.Data.FindKey(key)
 	if idx == -1 {
 		return false, false
 	}
@@ -79,7 +79,7 @@ func (c *ColumnMetadata) findBoolVal(key string) (bool, bool) {
 }
 
 func (c *ColumnMetadata) findInt32Val(key string) (int32, bool) {
-	idx := c.Data.FindKey(CatalogNameKey)
+	idx := c.Data.FindKey(key)
 	if idx == -1 {
 		return 0, false
 	}

--- a/parquet/encryption_write_config_test.go
+++ b/parquet/encryption_write_config_test.go
@@ -82,7 +82,10 @@ type EncryptionConfigTestSuite struct {
 func (en *EncryptionConfigTestSuite) encryptFile(configs *parquet.FileEncryptionProperties, filename string) {
 	filename = filepath.Join(tempdir, filename)
 
-	props := parquet.NewWriterProperties(parquet.WithCompression(compress.Codecs.Snappy), parquet.WithEncryptionProperties(configs))
+	props := parquet.NewWriterProperties(
+		parquet.WithPageIndexEnabled(true),
+		parquet.WithCompression(compress.Codecs.Snappy),
+		parquet.WithEncryptionProperties(configs))
 	outFile, err := os.Create(filename)
 	en.Require().NoError(err)
 	en.Require().NotNil(outFile)

--- a/parquet/file/column_writer_test.go
+++ b/parquet/file/column_writer_test.go
@@ -79,6 +79,9 @@ func (m *mockpagewriter) Compress(buf *bytes.Buffer, src []byte) []byte {
 func (m *mockpagewriter) Reset(sink utils.WriterTell, codec compress.Compression, compressionLevel int, metadata *metadata.ColumnChunkMetaDataBuilder, rgOrdinal, columnOrdinal int16, metaEncryptor, dataEncryptor encryption.Encryptor) error {
 	return m.Called().Error(0)
 }
+func (m *mockpagewriter) SetIndexBuilders(colidx metadata.ColumnIndexBuilder, offsetidx *metadata.OffsetIndexBuilder) {
+	m.Called(colidx, offsetidx)
+}
 
 func TestWriteDataPageV1NumValues(t *testing.T) {
 	sc := schema.NewSchema(schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Required, schema.FieldList{

--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -47,7 +47,6 @@ type Reader struct {
 	r               parquet.ReaderAtSeeker
 	props           *parquet.ReaderProperties
 	metadata        *metadata.FileMetaData
-	footerOffset    int64
 	fileDecryptor   encryption.FileDecryptor
 	pageIndexReader *metadata.PageIndexReader
 

--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -44,10 +44,12 @@ var (
 
 // Reader is the main interface for reading a parquet file
 type Reader struct {
-	r             parquet.ReaderAtSeeker
-	props         *parquet.ReaderProperties
-	metadata      *metadata.FileMetaData
-	fileDecryptor encryption.FileDecryptor
+	r               parquet.ReaderAtSeeker
+	props           *parquet.ReaderProperties
+	metadata        *metadata.FileMetaData
+	footerOffset    int64
+	fileDecryptor   encryption.FileDecryptor
+	pageIndexReader *metadata.PageIndexReader
 
 	bufferPool sync.Pool
 }
@@ -311,4 +313,16 @@ func (f *Reader) RowGroup(i int) *RowGroupReader {
 		fileDecryptor: f.fileDecryptor,
 		bufferPool:    &f.bufferPool,
 	}
+}
+
+func (f *Reader) GetPageIndexReader() *metadata.PageIndexReader {
+	if f.pageIndexReader == nil {
+		f.pageIndexReader = &metadata.PageIndexReader{
+			Input:        f.r,
+			Props:        f.props,
+			FileMetadata: f.metadata,
+			Decryptor:    f.fileDecryptor,
+		}
+	}
+	return f.pageIndexReader
 }

--- a/parquet/file/size_statistics.go
+++ b/parquet/file/size_statistics.go
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
+)
+
+type SizeStatistics format.SizeStatistics
+
+func (s *SizeStatistics) IsSet() bool {
+	return len(s.RepetitionLevelHistogram) > 0 || len(s.DefinitionLevelHistogram) > 0 ||
+		s.UnencodedByteArrayDataBytes != nil
+}
+
+

--- a/parquet/file/size_statistics.go
+++ b/parquet/file/size_statistics.go
@@ -26,5 +26,3 @@ func (s *SizeStatistics) IsSet() bool {
 	return len(s.RepetitionLevelHistogram) > 0 || len(s.DefinitionLevelHistogram) > 0 ||
 		s.UnencodedByteArrayDataBytes != nil
 }
-
-

--- a/parquet/metadata/file.go
+++ b/parquet/metadata/file.go
@@ -500,6 +500,8 @@ func (f *FileMetaData) Version() parquet.Version {
 	}
 }
 
+func (f *FileMetaData) NumRowGroups() int { return len(f.RowGroups) }
+
 // FileCryptoMetadata is a proxy for the thrift fileCryptoMetadata object
 type FileCryptoMetadata struct {
 	metadata          *format.FileCryptoMetaData

--- a/parquet/metadata/page_index.go
+++ b/parquet/metadata/page_index.go
@@ -1,0 +1,871 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/JohnCGriffin/overflow"
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/internal/debug"
+	"github.com/apache/arrow-go/v18/parquet/internal/encoding"
+	"github.com/apache/arrow-go/v18/parquet/internal/encryption"
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
+	"github.com/apache/arrow-go/v18/parquet/internal/thrift"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+)
+
+type BoundaryOrder = format.BoundaryOrder
+
+const (
+	Unordered  BoundaryOrder = format.BoundaryOrder_UNORDERED
+	Ascending  BoundaryOrder = format.BoundaryOrder_ASCENDING
+	Descending BoundaryOrder = format.BoundaryOrder_DESCENDING
+)
+
+type ColumnIndex interface {
+	GetNullPages() []bool
+	IsSetNullCounts() bool
+	GetNullCounts() []int64
+	GetBoundaryOrder() BoundaryOrder
+	GetMinValues() [][]byte
+	GetMaxValues() [][]byte
+}
+
+type TypedColumnIndex[T parquet.ColumnTypes] struct {
+	ColumnIndex
+
+	minvals            []T
+	maxvals            []T
+	nonNullPageIndices []int32
+}
+
+type typedDecoder[T parquet.ColumnTypes] interface {
+	encoding.TypedDecoder
+	Decode([]T) (int, error)
+	DecodeSpaced([]T, int, []byte, int64) (int, error)
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func mustArg[T any](val T, err error) T {
+	must(err)
+	return val
+}
+
+func NewColumnIndex(descr *schema.Column, serializedIndex []byte, props *parquet.ReaderProperties, decryptor encryption.Decryptor) ColumnIndex {
+	if decryptor != nil {
+		serializedIndex = decryptor.Decrypt(serializedIndex)
+	}
+
+	var colidx format.ColumnIndex
+	if _, err := thrift.DeserializeThrift(&colidx, serializedIndex); err != nil {
+		panic(err)
+	}
+
+	switch descr.PhysicalType() {
+	case parquet.Types.Boolean:
+		return NewTypedColumnIndex[bool](descr, &colidx)
+	case parquet.Types.Int32:
+		return NewTypedColumnIndex[int32](descr, &colidx)
+	case parquet.Types.Int64:
+		return NewTypedColumnIndex[int64](descr, &colidx)
+	case parquet.Types.Int96:
+		return NewTypedColumnIndex[parquet.Int96](descr, &colidx)
+	case parquet.Types.Float:
+		return NewTypedColumnIndex[float32](descr, &colidx)
+	case parquet.Types.Double:
+		return NewTypedColumnIndex[float64](descr, &colidx)
+	case parquet.Types.ByteArray:
+		return NewTypedColumnIndex[parquet.ByteArray](descr, &colidx)
+	case parquet.Types.FixedLenByteArray:
+		return NewTypedColumnIndex[parquet.FixedLenByteArray](descr, &colidx)
+	}
+
+	panic("unreachable: cannot make columnindex of unknown type")
+}
+
+func NewTypedColumnIndex[T parquet.ColumnTypes](descr *schema.Column, colIdx *format.ColumnIndex) *TypedColumnIndex[T] {
+	numPages := len(colIdx.NullPages)
+	if numPages >= math.MaxInt32 ||
+		len(colIdx.MinValues) != numPages ||
+		len(colIdx.MaxValues) != numPages ||
+		(colIdx.IsSetNullCounts() && len(colIdx.NullCounts) != numPages) {
+		panic("invalid column index")
+	}
+
+	numNonNullPages := 0
+	for _, page := range colIdx.NullPages {
+		if page {
+			numNonNullPages++
+		}
+	}
+	debug.Assert(numNonNullPages <= numPages, "invalid column index")
+
+	minvals, maxvals := make([]T, numPages), make([]T, numPages)
+	nonNullPageIndices := make([]int32, 0, numNonNullPages)
+	decoder := encoding.NewDecoder(descr.PhysicalType(), parquet.Encodings.Plain,
+		descr, nil).(typedDecoder[T])
+
+	for i := 0; i < numPages; i++ {
+		if !colIdx.NullPages[i] {
+			nonNullPageIndices = append(nonNullPageIndices, int32(i))
+
+			must(decoder.SetData(1, colIdx.MinValues[i]))
+			mustArg(decoder.Decode(minvals[i : i+1]))
+			must(decoder.SetData(1, colIdx.MaxValues[i]))
+			mustArg(decoder.Decode(maxvals[i : i+1]))
+		}
+	}
+	debug.Assert(len(nonNullPageIndices) == numNonNullPages, "invalid column index")
+
+	return &TypedColumnIndex[T]{
+		ColumnIndex:        colIdx,
+		minvals:            minvals,
+		maxvals:            maxvals,
+		nonNullPageIndices: nonNullPageIndices,
+	}
+}
+
+func (idx *TypedColumnIndex[T]) MinValues() []T {
+	return idx.minvals
+}
+
+func (idx *TypedColumnIndex[T]) MaxValues() []T {
+	return idx.maxvals
+}
+
+func (idx *TypedColumnIndex[T]) NonNullPageIndices() []int32 {
+	return idx.nonNullPageIndices
+}
+
+type (
+	PageLocation       = format.PageLocation
+	PageIndexSelection struct {
+		// specifies whether to read the column index
+		ColumnIndex bool
+		// specifies whether to read the offset index
+		OffsetIndex bool
+	}
+)
+
+type OffsetIndex interface {
+	GetPageLocations() []*PageLocation
+}
+
+func (p PageIndexSelection) String() string {
+	return fmt.Sprintf("PageIndexSelection{column_index = %t, offset_index = %t}",
+		p.ColumnIndex, p.OffsetIndex)
+}
+
+func NewOffsetIndex(serializedIndex []byte, _ *parquet.ReaderProperties, decryptor encryption.Decryptor) OffsetIndex {
+	if decryptor != nil {
+		serializedIndex = decryptor.Decrypt(serializedIndex)
+	}
+
+	var offsetIndex format.OffsetIndex
+	if _, err := thrift.DeserializeThrift(&offsetIndex, serializedIndex); err != nil {
+		panic(err)
+	}
+
+	return &offsetIndex
+}
+
+type readRange struct {
+	Offset, Length int64
+}
+
+func (r readRange) Contains(other readRange) bool {
+	return r.Offset <= other.Offset && other.Offset+other.Length <= r.Offset+r.Length
+}
+
+func checkReadRange(loc IndexLocation, idxRange *readRange, rgOrdinal int32) error {
+	if idxRange == nil {
+		return fmt.Errorf("%w: missing page index read range of row group %d, it may not exist or has not been requested",
+			arrow.ErrInvalid, rgOrdinal)
+	}
+
+	// coalesced read range is invalid
+	if idxRange.Offset < 0 || idxRange.Length <= 0 {
+		return fmt.Errorf("%w: invalid page index read range: offset %d, length %d",
+			arrow.ErrInvalid, idxRange.Offset, idxRange.Length)
+	}
+
+	if loc.Offset < 0 || loc.Length <= 0 {
+		return fmt.Errorf("%w: invalid page index location: offset %d, length %d",
+			arrow.ErrInvalid, loc.Offset, loc.Length)
+	}
+
+	if loc.Offset < idxRange.Offset || loc.Offset+int64(loc.Length) > idxRange.Offset+idxRange.Length {
+		return fmt.Errorf("%w: Page index location [offset:%d,length:%d] is out of range from previous WillNeed request [offset:%d,length:%d], row group: %d",
+			arrow.ErrInvalid, loc.Offset, loc.Length, idxRange.Offset, idxRange.Length, rgOrdinal)
+	}
+
+	return nil
+}
+
+type rgIndexReadRange struct {
+	ColIndex, OffsetIndex *readRange
+}
+
+type RowGroupPageIndexReader struct {
+	input            parquet.ReaderAtSeeker
+	rowGroupMetadata *RowGroupMetaData
+	props            *parquet.ReaderProperties
+	rgOrdinal        int32
+	idxReadRange     rgIndexReadRange
+	fileDecryptor    encryption.FileDecryptor
+
+	// buffers to hold raw bytes of page index
+	// will be lazily set when the corresponding page index is accessed
+	colIndexBuffer, offsetIndexBuffer []byte
+}
+
+func (r *RowGroupPageIndexReader) GetColumnIndex(i int) (ColumnIndex, error) {
+	if i < 0 || i >= r.rowGroupMetadata.NumColumns() {
+		return nil, fmt.Errorf("%w: invalid column index at column ordinal %d",
+			arrow.ErrInvalid, i)
+	}
+
+	colChunk, err := r.rowGroupMetadata.ColumnChunk(i)
+	if err != nil {
+		return nil, err
+	}
+
+	colIndexLocation := colChunk.GetColumnIndexLocation()
+	if colIndexLocation == nil {
+		return nil, nil
+	}
+
+	if err := checkReadRange(*colIndexLocation, r.idxReadRange.ColIndex, r.rgOrdinal); err != nil {
+		return nil, err
+	}
+
+	if r.colIndexBuffer == nil {
+		r.colIndexBuffer = make([]byte, r.idxReadRange.ColIndex.Length)
+		if _, err := r.input.ReadAt(r.colIndexBuffer, r.idxReadRange.ColIndex.Offset); err != nil {
+			return nil, err
+		}
+	}
+
+	bufferOffset := colIndexLocation.Offset - r.idxReadRange.ColIndex.Offset
+	descr := r.rowGroupMetadata.Schema.Column(i)
+	decryptor, err := encryption.GetColumnMetaDecryptor(colChunk.CryptoMetadata(), r.fileDecryptor)
+	if err != nil {
+		return nil, err
+	}
+
+	if decryptor != nil {
+		encryption.UpdateDecryptor(decryptor, int16(r.rgOrdinal),
+			int16(i), encryption.ColumnIndexModule)
+	}
+
+	return NewColumnIndex(descr, r.colIndexBuffer[bufferOffset:], r.props, decryptor), nil
+}
+
+func (r *RowGroupPageIndexReader) GetOffsetIndex(i int) (OffsetIndex, error) {
+	if i < 0 || i >= r.rowGroupMetadata.NumColumns() {
+		return nil, fmt.Errorf("%w: invalid column index at column ordinal %d",
+			arrow.ErrInvalid, i)
+	}
+
+	colChunk, err := r.rowGroupMetadata.ColumnChunk(i)
+	if err != nil {
+		return nil, err
+	}
+
+	offsetIndexLocation := colChunk.GetOffsetIndexLocation()
+	if offsetIndexLocation == nil {
+		return nil, nil
+	}
+
+	if err := checkReadRange(*offsetIndexLocation, r.idxReadRange.OffsetIndex, r.rgOrdinal); err != nil {
+		return nil, err
+	}
+
+	if r.offsetIndexBuffer == nil {
+		r.offsetIndexBuffer = make([]byte, r.idxReadRange.OffsetIndex.Length)
+		if _, err := r.input.ReadAt(r.offsetIndexBuffer, r.idxReadRange.OffsetIndex.Offset); err != nil {
+			return nil, err
+		}
+	}
+
+	bufferOffset := offsetIndexLocation.Offset - r.idxReadRange.OffsetIndex.Offset
+	decryptor, err := encryption.GetColumnMetaDecryptor(colChunk.CryptoMetadata(), r.fileDecryptor)
+	if err != nil {
+		return nil, err
+	}
+
+	if decryptor != nil {
+		encryption.UpdateDecryptor(decryptor, int16(r.rgOrdinal),
+			int16(i), encryption.ColumnIndexModule)
+	}
+
+	return NewOffsetIndex(r.colIndexBuffer[bufferOffset:], r.props, decryptor), nil
+}
+
+type PageIndexReader struct {
+	Input        parquet.ReaderAtSeeker
+	FileMetadata *FileMetaData
+	Props        *parquet.ReaderProperties
+	Decryptor    encryption.FileDecryptor
+
+	// coalesced read ranges of page index of row groups that have
+	// been suggested by WillNeed(). key is the row group ordinal
+	idxReadRanges map[int32]rgIndexReadRange
+}
+
+func determinePageIndexRangesInRowGroup(rgMeta *RowGroupMetaData, cols []int32) (rng rgIndexReadRange, err error) {
+	ciStart, oiStart := int64(math.MaxInt64), int64(math.MaxInt64)
+	ciEnd, oiEnd := int64(-1), int64(-1)
+
+	mergeRange := func(idxLocation *IndexLocation, start, end *int64) error {
+		if idxLocation == nil {
+			return nil
+		}
+
+		indexEnd, ok := overflow.Add64(idxLocation.Offset, int64(idxLocation.Length))
+		if idxLocation.Offset < 0 || idxLocation.Length <= 0 || ok {
+			return fmt.Errorf("%w: invalid page index location: offset %d length %d",
+				arrow.ErrIndex, idxLocation.Offset, idxLocation.Length)
+		}
+		*start = min(*start, idxLocation.Offset)
+		*end = max(*end, indexEnd)
+		return nil
+	}
+
+	var colChunk *ColumnChunkMetaData
+	if len(cols) == 0 {
+		for i := 0; i < rgMeta.NumColumns(); i++ {
+			if colChunk, err = rgMeta.ColumnChunk(i); err != nil {
+				return
+			}
+
+			if err = mergeRange(colChunk.GetColumnIndexLocation(), &ciStart, &ciEnd); err != nil {
+				return
+			}
+
+			if err = mergeRange(colChunk.GetOffsetIndexLocation(), &oiStart, &oiEnd); err != nil {
+				return
+			}
+		}
+	} else {
+		for _, i := range cols {
+			if i < 0 || i >= int32(rgMeta.NumColumns()) {
+				return rng, fmt.Errorf("%w: invalid column ordinal %d", arrow.ErrIndex, i)
+			}
+
+			if colChunk, err = rgMeta.ColumnChunk(int(i)); err != nil {
+				return
+			}
+
+			if err = mergeRange(colChunk.GetColumnIndexLocation(), &ciStart, &ciEnd); err != nil {
+				return
+			}
+
+			if err = mergeRange(colChunk.GetOffsetIndexLocation(), &oiStart, &oiEnd); err != nil {
+				return
+			}
+		}
+	}
+
+	if ciEnd != -1 {
+		rng.ColIndex = &readRange{Offset: ciStart, Length: ciEnd - ciStart}
+	}
+
+	if oiEnd != -1 {
+		rng.OffsetIndex = &readRange{Offset: oiStart, Length: oiEnd - oiStart}
+	}
+	return
+}
+
+func (r *PageIndexReader) RowGroup(i int) (*RowGroupPageIndexReader, error) {
+	if i < 0 || i >= r.FileMetadata.NumRowGroups() {
+		return nil, fmt.Errorf("%w: invalid row group ordinal %d", arrow.ErrInvalid, i)
+	}
+
+	var err error
+	rgmeta := r.FileMetadata.RowGroup(i)
+	idxReadRange, ok := r.idxReadRanges[int32(i)]
+	if !ok {
+		// row group has not been requested by WillNeed(), by default both
+		// column index and offset index of all column chunks for the row group
+		// can be read.
+		if idxReadRange, err = determinePageIndexRangesInRowGroup(rgmeta, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	if idxReadRange.ColIndex != nil || idxReadRange.OffsetIndex != nil {
+		return &RowGroupPageIndexReader{
+			input:            r.Input,
+			rowGroupMetadata: rgmeta,
+			props:            r.Props,
+			rgOrdinal:        int32(i),
+			idxReadRange:     idxReadRange,
+			fileDecryptor:    r.Decryptor,
+		}, nil
+	}
+
+	// the row group does not have a page index or has not been requested by willneed
+	// simply return a nil pointer
+	return nil, nil
+}
+
+func (r *PageIndexReader) WillNeed(rgIndices, colIndices []int32, selection PageIndexSelection) error {
+	if r.idxReadRanges == nil {
+		r.idxReadRanges = make(map[int32]rgIndexReadRange)
+	}
+
+	for _, ordinal := range rgIndices {
+		readRange, err := determinePageIndexRangesInRowGroup(r.FileMetadata.RowGroup(int(ordinal)), colIndices)
+		if err != nil {
+			return err
+		}
+
+		if !selection.ColumnIndex || readRange.ColIndex == nil {
+			// mark column index as not requested
+			readRange.ColIndex = nil
+		}
+
+		if !selection.OffsetIndex || readRange.OffsetIndex == nil {
+			// mark offset index as not requested
+			readRange.OffsetIndex = nil
+		}
+		r.idxReadRanges[int32(ordinal)] = readRange
+	}
+	// TODO: possibly use read ranges to prefetch data of the input
+	return nil
+}
+
+func (r *PageIndexReader) WillNotNeed(rgIndices []int32) {
+	if r.idxReadRanges == nil {
+		return
+	}
+
+	for _, i := range rgIndices {
+		delete(r.idxReadRanges, i)
+	}
+}
+
+type builderState int8
+
+const (
+	stateCreated builderState = iota
+	stateStarted
+	stateFinished
+	stateDiscarded
+)
+
+type ColumnIndexBuilder interface {
+	AddPage(stats *EncodedStatistics) error
+	Finish() error
+	WriteTo(w io.Writer, encryptor encryption.Encryptor) (int, error)
+	Build() ColumnIndex
+}
+
+type columnIndexBuilder[T parquet.ColumnTypes] struct {
+	descr              *schema.Column
+	colIndex           format.ColumnIndex
+	nonNullPageIndices []int64
+	state              builderState
+}
+
+func NewColumnIndexBuilder(descr *schema.Column) ColumnIndexBuilder {
+	switch descr.PhysicalType() {
+	case parquet.Types.Boolean:
+		return newColumnIndexBuilder[bool](descr)
+	case parquet.Types.Int32:
+		return newColumnIndexBuilder[int32](descr)
+	case parquet.Types.Int64:
+		return newColumnIndexBuilder[int64](descr)
+	case parquet.Types.Int96:
+		return newColumnIndexBuilder[parquet.Int96](descr)
+	case parquet.Types.Float:
+		return newColumnIndexBuilder[float32](descr)
+	case parquet.Types.Double:
+		return newColumnIndexBuilder[float64](descr)
+	case parquet.Types.ByteArray:
+		return newColumnIndexBuilder[parquet.ByteArray](descr)
+	case parquet.Types.FixedLenByteArray:
+		return newColumnIndexBuilder[parquet.FixedLenByteArray](descr)
+	case parquet.Types.Undefined:
+		return nil
+	}
+	panic("unreachable: cannot make column index builder of unknown type")
+}
+
+func newColumnIndexBuilder[T parquet.ColumnTypes](descr *schema.Column) *columnIndexBuilder[T] {
+	return &columnIndexBuilder[T]{
+		descr: descr,
+		colIndex: format.ColumnIndex{
+			NullCounts:    make([]int64, 0),
+			BoundaryOrder: Unordered,
+		},
+		nonNullPageIndices: make([]int64, 0),
+		state:              stateCreated,
+	}
+}
+
+func (b *columnIndexBuilder[T]) AddPage(stats *EncodedStatistics) error {
+	if b.state == stateFinished {
+		return fmt.Errorf("%w: cannot add page to finished ColumnIndexBuilder", arrow.ErrInvalid)
+	} else if b.state == stateDiscarded {
+		return nil
+	}
+
+	b.state = stateStarted
+
+	switch {
+	case stats.AllNullValue:
+		b.colIndex.NullPages = append(b.colIndex.NullPages, true)
+		b.colIndex.MinValues = append(b.colIndex.MinValues, nil)
+		b.colIndex.MaxValues = append(b.colIndex.MaxValues, nil)
+	case stats.HasMin && stats.HasMax:
+		pageOrdinal := len(b.colIndex.NullPages)
+		b.nonNullPageIndices = append(b.nonNullPageIndices, int64(pageOrdinal))
+		b.colIndex.MinValues = append(b.colIndex.MinValues, stats.Min)
+		b.colIndex.MaxValues = append(b.colIndex.MaxValues, stats.Max)
+		b.colIndex.NullPages = append(b.colIndex.NullPages, false)
+	default:
+		// this is a non-null page but it lacks meaningful min/max values
+		// discard the column index
+		b.state = stateDiscarded
+		return nil
+	}
+
+	if b.colIndex.IsSetNullCounts() && stats.HasNullCount {
+		b.colIndex.NullCounts = append(b.colIndex.NullCounts, stats.NullCount)
+	} else {
+		b.colIndex.NullCounts = nil
+	}
+
+	return nil
+}
+
+func (b *columnIndexBuilder[T]) Finish() error {
+	switch b.state {
+	case stateCreated:
+		// no page added, discard the column index
+		b.state = stateDiscarded
+		return nil
+	case stateFinished:
+		return fmt.Errorf("%w: ColumnIndexBuilder is already finished", arrow.ErrInvalid)
+	case stateDiscarded:
+		// column index is discarded, do nothing
+		return nil
+	case stateStarted:
+	}
+
+	b.state = stateFinished
+	// clear null counts vector because at least one page does not provide it
+	if !b.colIndex.IsSetNullCounts() {
+		b.colIndex.NullCounts = nil
+	}
+
+	// decode min/max values according to data type
+	nonNullPageCnt := len(b.nonNullPageIndices)
+	minVals, maxVals := make([]T, nonNullPageCnt), make([]T, nonNullPageCnt)
+	decoder := encoding.NewDecoder(b.descr.PhysicalType(), parquet.Encodings.Plain, b.descr, nil).(typedDecoder[T])
+	for i, pageOrdinal := range b.nonNullPageIndices {
+		must(decoder.SetData(1, b.colIndex.MinValues[pageOrdinal]))
+		mustArg(decoder.Decode(minVals[i : i+1]))
+		must(decoder.SetData(1, b.colIndex.MaxValues[pageOrdinal]))
+		mustArg(decoder.Decode(maxVals[i : i+1]))
+	}
+
+	// decode the boundary order from decoded min/max vals
+	b.colIndex.BoundaryOrder = b.determineBoundaryOrder(minVals, maxVals)
+	return nil
+}
+
+func (b *columnIndexBuilder[T]) Build() ColumnIndex {
+	if b.state != stateFinished {
+		return nil
+	}
+	return NewTypedColumnIndex[T](b.descr, &b.colIndex)
+}
+
+func (b *columnIndexBuilder[T]) WriteTo(w io.Writer, encryptor encryption.Encryptor) (int, error) {
+	if b.state == stateFinished {
+		return thrift.NewThriftSerializer().Serialize(&b.colIndex, w, encryptor)
+	}
+	return 0, nil
+}
+
+func (b *columnIndexBuilder[T]) determineBoundaryOrder(minVals, maxVals []T) BoundaryOrder {
+	debug.Assert(len(minVals) == len(maxVals), "min/max values length mismatch")
+	if len(minVals) == 0 {
+		return Unordered
+	}
+
+	comp, err := NewTypedComparator[T](b.descr)
+	if err != nil {
+		return Unordered
+	}
+
+	// check if both minVals and maxVals are in ascending order
+	isAsc := true
+	for i := 1; i < len(minVals); i++ {
+		if comp.Compare(minVals[i], minVals[i-1]) ||
+			comp.Compare(maxVals[i], maxVals[i-1]) {
+			isAsc = false
+			break
+		}
+	}
+
+	if isAsc {
+		return Ascending
+	}
+
+	// check if both minVals and maxVals are in descending order
+	isDesc := true
+	for i := 1; i < len(minVals); i++ {
+		if comp.Compare(minVals[i-1], minVals[i]) ||
+			comp.Compare(maxVals[i-1], maxVals[i]) {
+			isDesc = false
+			break
+		}
+	}
+	if isDesc {
+		return Descending
+	}
+
+	return Unordered
+}
+
+type OffsetIndexBuilder struct {
+	offsetIndex format.OffsetIndex
+	state       builderState
+}
+
+func (o *OffsetIndexBuilder) AddPageLoc(pgloc PageLocation) error {
+	return o.AddPage(pgloc.Offset, pgloc.FirstRowIndex, pgloc.CompressedPageSize)
+}
+
+func (o *OffsetIndexBuilder) AddPage(offset, firstRowIdx int64, compressedPgSize int32) error {
+	if o.state == stateFinished {
+		return fmt.Errorf("%w: cannot add page to finished OffsetIndexBuilder", arrow.ErrInvalid)
+	} else if o.state == stateDiscarded {
+		// offset index is discarded, do nothing
+		return nil
+	}
+
+	o.state = stateStarted
+	o.offsetIndex.PageLocations = append(o.offsetIndex.PageLocations, &PageLocation{
+		Offset:             offset,
+		FirstRowIndex:      firstRowIdx,
+		CompressedPageSize: compressedPgSize,
+	})
+	return nil
+}
+
+func (o *OffsetIndexBuilder) Finish(finalPos int64) error {
+	switch o.state {
+	case stateCreated:
+		o.state = stateDiscarded
+	case stateStarted:
+		// adjust page offsets according to final position
+		if finalPos > 0 {
+			for _, loc := range o.offsetIndex.PageLocations {
+				loc.Offset += finalPos
+			}
+		}
+		o.state = stateFinished
+	case stateFinished, stateDiscarded:
+		return fmt.Errorf("%w: OffsetIndexBuilder is already finished", arrow.ErrInvalid)
+	}
+	return nil
+}
+
+func (o *OffsetIndexBuilder) WriteTo(w io.Writer, encryptor encryption.Encryptor) (int, error) {
+	if o.state == stateFinished {
+		return thrift.NewThriftSerializer().Serialize(&o.offsetIndex, w, encryptor)
+	}
+	return 0, nil
+}
+
+func (o *OffsetIndexBuilder) Build() OffsetIndex {
+	if o.state != stateFinished {
+		return nil
+	}
+
+	return &o.offsetIndex
+}
+
+type PageIndexBuilder struct {
+	Schema    *schema.Schema
+	Encryptor encryption.FileEncryptor
+
+	colIndexBuilders    [][]ColumnIndexBuilder
+	offsetIndexBuilders [][]*OffsetIndexBuilder
+	finished            bool
+}
+
+func (b *PageIndexBuilder) AppendRowGroup() error {
+	if b.finished {
+		return fmt.Errorf("%w: cannot append row group to finished PageIndexBuilder", arrow.ErrInvalid)
+	}
+
+	if b.Schema == nil {
+		return fmt.Errorf("%w: schema is not set in PageIndexBuilder", arrow.ErrInvalid)
+	}
+
+	numColumns := b.Schema.NumColumns()
+	b.colIndexBuilders = append(b.colIndexBuilders, make([]ColumnIndexBuilder, numColumns))
+	b.offsetIndexBuilders = append(b.offsetIndexBuilders, make([]*OffsetIndexBuilder, numColumns))
+
+	debug.Assert(len(b.colIndexBuilders) == len(b.offsetIndexBuilders), "column and offset index builders mismatch")
+	return nil
+}
+
+func (b *PageIndexBuilder) GetColumnIndexBuilder(i int) ColumnIndexBuilder {
+	if err := b.checkState(i); err != nil {
+		panic(err)
+	}
+
+	bldr := &b.colIndexBuilders[len(b.colIndexBuilders)-1][i]
+	if *bldr == nil {
+		*bldr = NewColumnIndexBuilder(b.Schema.Column(i))
+	}
+	return *bldr
+}
+
+func (b *PageIndexBuilder) GetOffsetIndexBuilder(i int) *OffsetIndexBuilder {
+	if err := b.checkState(i); err != nil {
+		panic(err)
+	}
+
+	bldr := &b.offsetIndexBuilders[len(b.offsetIndexBuilders)-1][i]
+	if *bldr == nil {
+		*bldr = &OffsetIndexBuilder{}
+	}
+	return *bldr
+}
+
+func (b *PageIndexBuilder) Finish() { b.finished = true }
+
+func (b *PageIndexBuilder) WriteTo(w io.WriteSeeker, location *PageIndexLocation) error {
+	if !b.finished {
+		return fmt.Errorf("%w: PageIndexBuilder is not finished", arrow.ErrInvalid)
+	}
+
+	location.ColIndexLocation = make(map[uint64][]*IndexLocation)
+	location.OffsetIndexLocation = make(map[uint64][]*IndexLocation)
+
+	// serialize column index
+	if err := serializeIndex(b.Schema, b.colIndexBuilders, w, location.ColIndexLocation, b.getColumnMetaEncryptor); err != nil {
+		return err
+	}
+
+	// serialize offset index
+	if err := serializeIndex(b.Schema, b.offsetIndexBuilders, w, location.OffsetIndexLocation, b.getColumnMetaEncryptor); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *PageIndexBuilder) checkState(col int) error {
+	if b.finished {
+		return fmt.Errorf("%w: cannot add page to finished PageIndexBuilder", arrow.ErrInvalid)
+	}
+
+	if col < 0 || col >= b.Schema.NumColumns() {
+		return fmt.Errorf("%w: invalid column ordinal %d", arrow.ErrInvalid, col)
+	}
+
+	if len(b.colIndexBuilders) == 0 || len(b.offsetIndexBuilders) == 0 {
+		return fmt.Errorf("%w: No row group appended to PageIndexBuilder", arrow.ErrInvalid)
+	}
+	return nil
+}
+
+func (b *PageIndexBuilder) getColumnMetaEncryptor(rgOrdinal, colOrdinal int, moduleType int8) encryption.Encryptor {
+	if b.Encryptor == nil {
+		return nil
+	}
+
+	colPath := b.Schema.Column(colOrdinal).Path()
+	encryptor := b.Encryptor.GetColumnMetaEncryptor(colPath)
+	if encryptor != nil {
+		encryptor.UpdateAad(encryption.CreateModuleAad(
+			encryptor.FileAad(), moduleType, int16(rgOrdinal),
+			int16(colOrdinal), encryption.NonPageOrdinal))
+	}
+	return encryptor
+}
+
+func serializeIndex[T interface {
+	WriteTo(io.Writer, encryption.Encryptor) (int, error)
+}](s *schema.Schema, bldrs [][]T, w io.WriteSeeker, location map[uint64][]*IndexLocation, encFn func(int, int, int8) encryption.Encryptor) error {
+	var (
+		z          T
+		numCols    = s.NumColumns()
+		moduleType = encryption.ColumnIndexModule
+	)
+
+	if _, ok := any(z).(ColumnIndexBuilder); !ok {
+		moduleType = encryption.OffsetIndexModule
+	}
+
+	// serialize the same kind of page index, row group by row group
+	for rg, idxBldrs := range bldrs {
+		debug.Assert(len(idxBldrs) == numCols, "column index builders length mismatch")
+
+		hasValidIndex := false
+		locations := make([]*IndexLocation, numCols)
+
+		// in the same row group, serialize the same kind of page index column by column
+		for col, bldr := range idxBldrs {
+			encryptor := encFn(rg, col, moduleType)
+			posBefore, err := w.Seek(0, io.SeekCurrent)
+			if err != nil {
+				return err
+			}
+
+			n, err := bldr.WriteTo(w, encryptor)
+			if err != nil {
+				return err
+			}
+
+			if n == 0 {
+				continue
+			}
+
+			if n > math.MaxInt32 {
+				return fmt.Errorf("%w: serialized page index size overflows INT32_MAX", arrow.ErrInvalid)
+			}
+
+			locations[col] = &IndexLocation{Offset: posBefore, Length: int32(n)}
+			hasValidIndex = true
+		}
+
+		if hasValidIndex {
+			location[uint64(rg)] = locations
+		}
+	}
+
+	return nil
+}

--- a/parquet/metadata/page_index_internal_test.go
+++ b/parquet/metadata/page_index_internal_test.go
@@ -1,0 +1,197 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/parquet"
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
+	"github.com/apache/arrow-go/v18/parquet/internal/thrift"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type PageIndexRanges struct {
+	ColIndexOffset, OffsetIndexOffset int64
+	ColIndexLen, OffsetIndexLen       int32
+}
+
+func constructFakeMetadata(rowGroupRanges []PageIndexRanges) *FileMetaData {
+	var rg format.RowGroup
+	for _, r := range rowGroupRanges {
+		var colChunk format.ColumnChunk
+		colChunk.MetaData = &format.ColumnMetaData{}
+		if r.ColIndexOffset != -1 {
+			colChunk.ColumnIndexOffset = &r.ColIndexOffset
+		}
+		if r.ColIndexLen != -1 {
+			colChunk.ColumnIndexLength = &r.ColIndexLen
+		}
+		if r.OffsetIndexOffset != -1 {
+			colChunk.OffsetIndexOffset = &r.OffsetIndexOffset
+		}
+		if r.OffsetIndexLen != -1 {
+			colChunk.OffsetIndexLength = &r.OffsetIndexLen
+		}
+		rg.Columns = append(rg.Columns, &colChunk)
+	}
+
+	var fileMeta format.FileMetaData
+	fileMeta.RowGroups = append(fileMeta.RowGroups, &rg)
+
+	fields := make(schema.FieldList, 0)
+	for i := range rowGroupRanges {
+		fields = append(fields, schema.NewInt64Node(strconv.Itoa(i), parquet.Repetitions.Optional, -1))
+	}
+
+	grpNode, _ := schema.NewGroupNode("schema", parquet.Repetitions.Repeated, fields, -1)
+	fileMeta.Schema = schema.ToThrift(grpNode)
+
+	var buf bytes.Buffer
+	thrift.NewThriftSerializer().Serialize(&fileMeta, &buf, nil)
+
+	meta, _ := NewFileMetaData(buf.Bytes(), nil)
+	return meta
+}
+
+// validates that determinePagteIndexRangesInRowGroup selects the expected
+// file offsets and sizes or returns false when the row group doesn't have
+// a page index
+func validatePageIndexRange(t *testing.T, ranges []PageIndexRanges, colIndices []int32, expectedHasColIndex, expectedHasOffsetIndex bool, expCIStart, expCISize, expOIStart, expOISize int) {
+	fileMeta := constructFakeMetadata(ranges)
+	readRange, err := determinePageIndexRangesInRowGroup(fileMeta.RowGroup(0), colIndices)
+	require.NoError(t, err)
+
+	if expectedHasColIndex {
+		assert.NotNil(t, readRange.ColIndex)
+		assert.EqualValues(t, expCIStart, readRange.ColIndex.Offset)
+		assert.EqualValues(t, expCISize, readRange.ColIndex.Length)
+	} else {
+		assert.Nil(t, readRange.ColIndex)
+	}
+
+	if expectedHasOffsetIndex {
+		assert.NotNil(t, readRange.OffsetIndex)
+		assert.EqualValues(t, expOIStart, readRange.OffsetIndex.Offset)
+		assert.EqualValues(t, expOISize, readRange.OffsetIndex.Length)
+	} else {
+		assert.Nil(t, readRange.OffsetIndex)
+	}
+}
+
+// construct artificial row groups with page index offsets in them.
+// then validate if determinePageIndexRangesInRowGroup properly
+// computes the file range that contains the whole page index
+func TestDeterminePageIndexRangesInRowGroup(t *testing.T) {
+	tests := []struct {
+		name                          string
+		ranges                        []PageIndexRanges
+		cols                          []int32
+		expectHasCol, expectHasOffset bool
+		expectCIStart, expectCISize   int
+		expectOIStart, expectOISize   int
+	}{
+		{"no col chunks", nil, nil, false, false, -1, -1, -1, -1},
+		{"no page index", []PageIndexRanges{{-1, -1, -1, -1}}, nil, false, false, -1, -1, -1, -1},
+		{"page index for single col", []PageIndexRanges{{10, 15, 5, 5}}, nil, true, true, 10, 5, 15, 5},
+		{"page index for two columns", []PageIndexRanges{{10, 30, 5, 25}, {15, 50, 15, 20}},
+			nil, true, true, 10, 20, 30, 40},
+		{"page index for second column", []PageIndexRanges{{-1, -1, -1, -1}, {20, 30, 10, 25}}, nil,
+			true, true, 20, 10, 30, 25},
+		{"page index for first column", []PageIndexRanges{{10, 15, 5, 5}, {-1, -1, -1, -1}}, nil,
+			true, true, 10, 5, 15, 5},
+		{"missing offset index for first column, gap in col index",
+			[]PageIndexRanges{{10, -1, 5, -1}, {20, 30, 10, 25}}, nil, true, true, 10, 20, 30, 25},
+		{"missing offset index for second column", []PageIndexRanges{{10, 25, 5, 5}, {20, -1, 10, -1}},
+			nil, true, true, 10, 20, 25, 5},
+		{"four col chunks",
+			[]PageIndexRanges{{100, 220, 10, 30}, {110, 250, 25, 10}, {140, 260, 30, 40}, {200, 300, 10, 100}}, nil,
+			true, true, 100, 110, 220, 180},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validatePageIndexRange(t, tt.ranges, tt.cols, tt.expectHasCol, tt.expectHasOffset,
+				tt.expectCIStart, tt.expectCISize, tt.expectOIStart, tt.expectOISize)
+		})
+	}
+}
+
+// properly compute file range that contains the page index of selected columns
+func TestDeterminePageIndexRangesInRowGroupWithPartialColumnsSelected(t *testing.T) {
+	tests := []struct {
+		name                          string
+		ranges                        []PageIndexRanges
+		cols                          []int32
+		expectHasCol, expectHasOffset bool
+		expectCIStart, expectCISize   int
+		expectOIStart, expectOISize   int
+	}{
+		{"no page index", []PageIndexRanges{{-1, -1, -1, -1}}, []int32{0}, false, false, -1, -1, -1, -1},
+		{"page index for single col", []PageIndexRanges{{10, 15, 5, 5}}, []int32{0}, true, true, 10, 5, 15, 5},
+		{"page index for the 1st col", []PageIndexRanges{{10, 30, 5, 25}, {15, 50, 15, 20}}, []int32{0},
+			true, true, 10, 5, 30, 25},
+		{"page index for the 2nd col", []PageIndexRanges{{10, 30, 5, 25}, {15, 50, 15, 20}}, []int32{0},
+			true, true, 10, 5, 30, 25},
+		{"only 2nd col is selected from 4 chunks",
+			[]PageIndexRanges{{100, 220, 10, 30}, {110, 250, 25, 10}, {140, 260, 30, 40}, {200, 300, 10, 100}},
+			[]int32{1}, true, true, 110, 25, 250, 10},
+		{"2nd and 3rd cols selected", []PageIndexRanges{{100, 220, 10, 30}, {110, 250, 25, 10}, {140, 260, 30, 40}, {200, 300, 10, 100}},
+			[]int32{1, 2}, true, true, 110, 60, 250, 50},
+		{"2nd and 4th cols selected", []PageIndexRanges{{100, 220, 10, 30}, {110, 250, 25, 10}, {140, 260, 30, 40}, {200, 300, 10, 100}},
+			[]int32{1, 3}, true, true, 110, 100, 250, 150},
+		{"1st, 2nd, and 4th cols selected", []PageIndexRanges{{100, 220, 10, 30}, {110, 250, 25, 10}, {140, 260, 30, 40}, {200, 300, 10, 100}},
+			[]int32{0, 1, 3}, true, true, 100, 110, 220, 180},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validatePageIndexRange(t, tt.ranges, tt.cols, tt.expectHasCol, tt.expectHasOffset,
+				tt.expectCIStart, tt.expectCISize, tt.expectOIStart, tt.expectOISize)
+		})
+	}
+}
+
+// validate that a column index or offset index is missing
+func TestDeterminePageIndexRangesInRowGroupWithMissingPageIndex(t *testing.T) {
+	tests := []struct {
+		name                          string
+		ranges                        []PageIndexRanges
+		cols                          []int32
+		expectHasCol, expectHasOffset bool
+		expectCIStart, expectCISize   int
+		expectOIStart, expectOISize   int
+	}{
+		{"no page index", []PageIndexRanges{{-1, 15, -1, 5}}, nil, false, true, -1, -1, 15, 5},
+		{"no offset index", []PageIndexRanges{{10, -1, 5, -1}}, nil, true, false, 10, 5, -1, -1},
+		{"no column index at all among two cols", []PageIndexRanges{{-1, 30, -1, 25}, {-1, 50, -1, 20}}, nil,
+			false, true, -1, -1, 30, 40},
+		{"no offset index at all among two cols", []PageIndexRanges{{10, -1, 5, -1}, {15, -1, 15, -1}}, nil,
+			true, false, 10, 20, -1, -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validatePageIndexRange(t, tt.ranges, tt.cols, tt.expectHasCol, tt.expectHasOffset,
+				tt.expectCIStart, tt.expectCISize, tt.expectOIStart, tt.expectOISize)
+		})
+	}
+}

--- a/parquet/metadata/page_index_test.go
+++ b/parquet/metadata/page_index_test.go
@@ -1,0 +1,802 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"testing"
+	"unsafe"
+
+	"github.com/apache/arrow-go/v18/arrow/float16"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/internal/utils"
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestReadOffsetIndex(t *testing.T) {
+	dir := os.Getenv("PARQUET_TEST_DATA")
+	if dir == "" {
+		t.Skip("PARQUET_TEST_DATA not set")
+	}
+	require.DirExists(t, dir)
+
+	path := filepath.Join(dir, "alltypes_tiny_pages.parquet")
+	rdr, err := file.OpenParquetFile(path, false)
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	const (
+		rgID, colID int = 0, 0
+	)
+
+	fileMetadata := rdr.MetaData()
+	colMeta, err := fileMetadata.RowGroup(rgID).ColumnChunk(colID)
+	require.NoError(t, err)
+	indexLoc := colMeta.GetOffsetIndexLocation()
+	require.NotNil(t, indexLoc)
+
+	// read serialized offset index from file
+	src, err := os.Open(path)
+	require.NoError(t, err)
+	buf := make([]byte, indexLoc.Length)
+	n, err := src.ReadAt(buf, indexLoc.Offset)
+	require.NoError(t, err)
+	assert.EqualValues(t, indexLoc.Length, n)
+	require.NoError(t, src.Close())
+
+	// deserialize offset index
+	offsetIdx := metadata.NewOffsetIndex(buf, nil, nil)
+
+	// verify only partial data as it contains 325 pages in total
+	const numPages = 325
+	var (
+		pageIndices   = [...]uint64{0, 100, 200, 300}
+		pageLocations = []metadata.PageLocation{
+			{Offset: 4, CompressedPageSize: 109, FirstRowIndex: 0},
+			{Offset: 11480, CompressedPageSize: 133, FirstRowIndex: 2244},
+			{Offset: 22980, CompressedPageSize: 133, FirstRowIndex: 4494},
+			{Offset: 34480, CompressedPageSize: 133, FirstRowIndex: 6744},
+		}
+	)
+
+	offsetPageLocs := offsetIdx.GetPageLocations()
+	assert.Len(t, offsetPageLocs, numPages)
+
+	for i, pageID := range pageIndices {
+		readPageLocation := offsetPageLocs[pageID]
+		expectedPageLoc := pageLocations[i]
+
+		assert.Equal(t, expectedPageLoc, *readPageLocation)
+	}
+}
+
+func ulps64(actual, expected float64) int64 {
+	ulp := math.Nextafter(actual, math.Inf(1)) - actual
+	return int64(math.Abs((expected - actual) / ulp))
+}
+
+func ulps32(actual, expected float32) int64 {
+	ulp := math.Nextafter32(actual, float32(math.Inf(1))) - actual
+	return int64(math.Abs(float64((expected - actual) / ulp)))
+}
+
+func assertFloat32Approx(t assert.TestingT, expected, actual any, _ ...any) bool {
+	const maxulps int64 = 4
+	ulps := ulps32(actual.(float32), expected.(float32))
+	return assert.LessOrEqualf(t, ulps, maxulps, "%f not equal to %f (%d ulps)", actual, expected, ulps)
+}
+
+func assertFloat64Approx(t assert.TestingT, expected, actual any, _ ...any) bool {
+	const maxulps int64 = 4
+	ulps := ulps64(actual.(float64), expected.(float64))
+	return assert.LessOrEqualf(t, ulps, maxulps, "%f not equal to %f (%d ulps)", actual, expected, ulps)
+}
+
+type testcase struct {
+	fileName      string
+	colID         int
+	numPages      uint64
+	boundaryOrder metadata.BoundaryOrder
+	pageIndices   []uint64
+	nullPages     []bool
+	hasNullCounts bool
+	nullCounts    []int64
+}
+
+func testReadTypedColIndex[T parquet.ColumnTypes](t *testing.T, tc testcase, minValues, maxValues []T) {
+	dir := os.Getenv("PARQUET_TEST_DATA")
+	if dir == "" {
+		t.Skip("PARQUET_TEST_DATA not set")
+	}
+	require.DirExists(t, dir)
+
+	path := filepath.Join(dir, tc.fileName)
+	rdr, err := file.OpenParquetFile(path, false)
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	fileMetadata := rdr.MetaData()
+
+	// Get column index location to a specific column chunk
+	const rgID = 0
+	colMeta, err := fileMetadata.RowGroup(rgID).ColumnChunk(tc.colID)
+	require.NoError(t, err)
+
+	indexLoc := colMeta.GetColumnIndexLocation()
+	require.NotNil(t, indexLoc)
+
+	// read serialized column index from the file
+	src, err := os.Open(path)
+	require.NoError(t, err)
+	buf := make([]byte, indexLoc.Length)
+	n, err := src.ReadAt(buf, indexLoc.Offset)
+	require.NoError(t, err)
+	assert.EqualValues(t, indexLoc.Length, n)
+	require.NoError(t, src.Close())
+
+	descr := fileMetadata.Schema.Column(tc.colID)
+	colIndex := metadata.NewColumnIndex(descr, buf, nil, nil)
+	assert.IsType(t, (*metadata.TypedColumnIndex[T])(nil), colIndex)
+
+	typedColIndex := colIndex.(*metadata.TypedColumnIndex[T])
+	// verify only partial data as there are too many pages
+	assert.Len(t, typedColIndex.GetNullPages(), int(tc.numPages))
+	assert.Equal(t, tc.hasNullCounts, typedColIndex.IsSetNullCounts())
+	assert.Equal(t, tc.boundaryOrder, typedColIndex.GetBoundaryOrder())
+
+	var cmp assert.ComparisonAssertionFunc
+	switch any(minValues).(type) {
+	case []float64:
+		cmp = assertFloat64Approx
+	case []float32:
+		cmp = assertFloat32Approx
+	default:
+		cmp = assert.Equal
+	}
+
+	for i, pageID := range tc.pageIndices {
+		assert.Equal(t, tc.nullPages[i], typedColIndex.GetNullPages()[pageID])
+		if tc.hasNullCounts {
+			assert.Equal(t, tc.nullCounts[i], typedColIndex.GetNullCounts()[pageID])
+		}
+
+		// min/max values are only meaningful for non-null pages
+		if !tc.nullPages[i] {
+			cmp(t, minValues[i], typedColIndex.MinValues()[pageID])
+			cmp(t, maxValues[i], typedColIndex.MaxValues()[pageID])
+		}
+	}
+}
+
+func TestReadTypedColumnIndex(t *testing.T) {
+	tests := []struct {
+		tc               testcase
+		minVals, maxVals any
+	}{
+		{testcase{"alltypes_tiny_pages.parquet", 5, 528, metadata.Unordered,
+			[]uint64{0, 99, 426, 520}, []bool{false, false, false, false}, true, []int64{0, 0, 0, 0}},
+			[]int64{0, 10, 0, 0}, []int64{90, 90, 80, 70}},
+		{testcase{"alltypes_tiny_pages.parquet", 7, 528, metadata.Unordered,
+			[]uint64{0, 51, 212, 527}, []bool{false, false, false, false}, true, []int64{0, 0, 0, 0}},
+			[]float64{-0, 30.3, 10.1, 40.4}, []float64{90.9, 90.9, 90.9, 60.6}},
+		{testcase{"alltypes_tiny_pages.parquet", 9, 352, metadata.Ascending,
+			[]uint64{0, 128, 256}, []bool{false, false, false}, true, []int64{0, 0, 0}},
+			[]parquet.ByteArray{{'0'}, {'0'}, {'0'}}, []parquet.ByteArray{{'9'}, {'9'}, {'9'}}},
+		{testcase{"alltypes_tiny_pages.parquet", 1, 82, metadata.Ascending,
+			[]uint64{0, 16, 64}, []bool{false, false, false}, true, []int64{0, 0, 0}},
+			[]bool{false, false, false}, []bool{true, true, true}},
+		{testcase{"fixed_length_byte_array.parquet", 0, 10, metadata.Descending,
+			[]uint64{0, 4, 8}, []bool{false, false, false}, true, []int64{9, 13, 9}},
+			[]parquet.FixedLenByteArray{{0x00, 0x00, 0x03, 0x85}, {0x00, 0x00, 0x01, 0xF5}, {0x00, 0x00, 0x00, 0x65}},
+			[]parquet.FixedLenByteArray{{0x00, 0x00, 0x03, 0xE8}, {0x00, 0x00, 0x02, 0x58}, {0x00, 0x00, 0x00, 0xC8}}},
+		{testcase{"int32_with_null_pages.parquet", 0, 10, metadata.Unordered,
+			[]uint64{2, 4, 8}, []bool{true, false, false}, true, []int64{100, 16, 8}},
+			[]int32{0, -2048691758, -2046900272}, []int32{0, 2143189382, 2087168549}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tc.fileName+" "+strconv.Itoa(tt.tc.colID), func(t *testing.T) {
+			switch mv := tt.minVals.(type) {
+			case []bool:
+				testReadTypedColIndex(t, tt.tc, mv, tt.maxVals.([]bool))
+			case []int32:
+				testReadTypedColIndex(t, tt.tc, mv, tt.maxVals.([]int32))
+			case []int64:
+				testReadTypedColIndex(t, tt.tc, mv, tt.maxVals.([]int64))
+			case []float64:
+				testReadTypedColIndex(t, tt.tc, mv, tt.maxVals.([]float64))
+			case []parquet.ByteArray:
+				testReadTypedColIndex(t, tt.tc, mv, tt.maxVals.([]parquet.ByteArray))
+			case []parquet.FixedLenByteArray:
+				testReadTypedColIndex(t, tt.tc, mv, tt.maxVals.([]parquet.FixedLenByteArray))
+			}
+		})
+	}
+}
+
+func TestWriteOffsetIndex(t *testing.T) {
+	var bldr metadata.OffsetIndexBuilder
+
+	const (
+		numPages      = 5
+		finalPosition = 4096
+	)
+	var (
+		offsets         = []int64{100, 200, 300, 400, 500}
+		pageSizes       = []int32{1024, 2048, 3072, 4096, 8192}
+		firstRowIndices = []int64{0, 10000, 20000, 30000, 40000}
+	)
+
+	for i := 0; i < numPages; i++ {
+		bldr.AddPage(offsets[i], firstRowIndices[i], pageSizes[i])
+	}
+	bldr.Finish(finalPosition)
+
+	offsetIndexes := make([]metadata.OffsetIndex, 0)
+	// 1st element is the offset index just built
+	offsetIndexes = append(offsetIndexes, bldr.Build())
+	// 2nd element is the offset index restored by serialize-then-deserialize round trip
+	var buf bytes.Buffer
+	bldr.WriteTo(&buf, nil)
+
+	offsetIndexes = append(offsetIndexes, metadata.NewOffsetIndex(buf.Bytes(), nil, nil))
+
+	// verify the data in the offset index
+	for _, offsetIndex := range offsetIndexes {
+		pageLocations := offsetIndex.GetPageLocations()
+		assert.Len(t, pageLocations, numPages)
+
+		for i := 0; i < numPages; i++ {
+			pageLoc := pageLocations[i]
+			assert.Equal(t, offsets[i]+finalPosition, pageLoc.Offset)
+			assert.Equal(t, pageSizes[i], pageLoc.CompressedPageSize)
+			assert.Equal(t, firstRowIndices[i], pageLoc.FirstRowIndex)
+		}
+	}
+}
+
+func simpleEncode[T int32 | int64 | float32 | float64](val T) []byte {
+	return unsafe.Slice((*byte)(unsafe.Pointer(&val)), unsafe.Sizeof(val))
+}
+
+func TestWriteTypedColumnIndex(t *testing.T) {
+	tests := []struct {
+		name          string
+		n             *schema.PrimitiveNode
+		pageStats     []*metadata.EncodedStatistics
+		boundaryOrder metadata.BoundaryOrder
+		hasNullCounts bool
+	}{
+		{"write_int32", schema.NewInt32Node("c1", parquet.Repetitions.Optional, -1),
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{}).SetNullCount(1).SetMin(simpleEncode(int32(1))).SetMax(simpleEncode(int32(2))),
+				(&metadata.EncodedStatistics{}).SetNullCount(2).SetMin(simpleEncode(int32(2))).SetMax(simpleEncode(int32(3))),
+				(&metadata.EncodedStatistics{}).SetNullCount(3).SetMin(simpleEncode(int32(3))).SetMax(simpleEncode(int32(4))),
+			}, metadata.Ascending, true},
+		{"write_int64", schema.NewInt64Node("c1", parquet.Repetitions.Optional, -1),
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{}).SetNullCount(4).SetMin(simpleEncode(int64(-1))).SetMax(simpleEncode(int64(-2))),
+				(&metadata.EncodedStatistics{}).SetNullCount(0).SetMin(simpleEncode(int64(-2))).SetMax(simpleEncode(int64(-3))),
+				(&metadata.EncodedStatistics{}).SetNullCount(4).SetMin(simpleEncode(int64(-3))).SetMax(simpleEncode(int64(-4))),
+			}, metadata.Descending, true},
+		{"write_float32", schema.NewFloat32Node("c1", parquet.Repetitions.Optional, -1),
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{}).SetNullCount(0).SetMin(simpleEncode(float32(2.2))).SetMax(simpleEncode(float32(4.4))),
+				(&metadata.EncodedStatistics{}).SetNullCount(0).SetMin(simpleEncode(float32(1.1))).SetMax(simpleEncode(float32(5.5))),
+				(&metadata.EncodedStatistics{}).SetNullCount(0).SetMin(simpleEncode(float32(3.3))).SetMax(simpleEncode(float32(6.6))),
+			}, metadata.Unordered, true},
+		{"write_float64", schema.NewFloat64Node("c1", parquet.Repetitions.Optional, -1),
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{}).SetMin(simpleEncode(float64(1.2))).SetMax(simpleEncode(float64(4.4))),
+				(&metadata.EncodedStatistics{}).SetMin(simpleEncode(float64(2.2))).SetMax(simpleEncode(float64(5.5))),
+				(&metadata.EncodedStatistics{}).SetMin(simpleEncode(float64(3.3))).SetMax(simpleEncode(float64(-6.6))),
+			}, metadata.Unordered, false},
+		{"write_byte_array", schema.NewByteArrayNode("c1", parquet.Repetitions.Optional, -1),
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{}).SetMin([]byte("bar")).SetMax([]byte("foo")),
+				(&metadata.EncodedStatistics{}).SetMin([]byte("bar")).SetMax([]byte("foo")),
+				(&metadata.EncodedStatistics{}).SetMin([]byte("bar")).SetMax([]byte("foo")),
+			}, metadata.Ascending, false},
+		{"write_fixed_len_byte_array", schema.NewFixedLenByteArrayNode("c1", parquet.Repetitions.Optional, 3, -1),
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{}).SetMin([]byte("abc")).SetMax([]byte("ABC")),
+				(&metadata.EncodedStatistics{AllNullValue: true, Min: []byte{}, Max: []byte{}}),
+				(&metadata.EncodedStatistics{}).SetMin([]byte("foo")).SetMax([]byte("FOO")),
+				(&metadata.EncodedStatistics{AllNullValue: true, Min: []byte{}, Max: []byte{}}),
+				(&metadata.EncodedStatistics{}).SetMin([]byte("xyz")).SetMax([]byte("XYZ")),
+			}, metadata.Ascending, false},
+		{"write_float16", schema.MustPrimitive(
+			schema.NewPrimitiveNodeLogical("c1", parquet.Repetitions.Optional,
+				schema.Float16LogicalType{}, parquet.Types.FixedLenByteArray, 2, -1)),
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{}).SetMin(float16.New(-1.3).ToLEBytes()).SetMax(float16.New(3.6).ToLEBytes()),
+				(&metadata.EncodedStatistics{}).SetMin(float16.New(-0.2).ToLEBytes()).SetMax(float16.New(4.5).ToLEBytes()),
+				(&metadata.EncodedStatistics{}).SetMin(float16.New(1.1).ToLEBytes()).SetMax(float16.New(5.4).ToLEBytes()),
+				(&metadata.EncodedStatistics{}).SetMin(float16.New(2.0).ToLEBytes()).SetMax(float16.New(6.3).ToLEBytes()),
+			}, metadata.Ascending, false},
+		{"write_all_nulls", schema.NewInt32Node("c1", parquet.Repetitions.Optional, -1),
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{AllNullValue: true, Min: []byte{}, Max: []byte{}}).SetNullCount(100),
+				(&metadata.EncodedStatistics{AllNullValue: true, Min: []byte{}, Max: []byte{}}).SetNullCount(100),
+				(&metadata.EncodedStatistics{AllNullValue: true, Min: []byte{}, Max: []byte{}}).SetNullCount(100),
+			}, metadata.Unordered, true},
+		{"invalid_null_counts", schema.NewInt32Node("c1", parquet.Repetitions.Optional, -1),
+			// one page doesn't provide null count
+			[]*metadata.EncodedStatistics{
+				(&metadata.EncodedStatistics{}).SetMin(simpleEncode(int32(1))).SetMax(simpleEncode(int32(2))).SetNullCount(0),
+				(&metadata.EncodedStatistics{}).SetMin(simpleEncode(int32(1))).SetMax(simpleEncode(int32(3))),
+				(&metadata.EncodedStatistics{}).SetMin(simpleEncode(int32(2))).SetMax(simpleEncode(int32(3))).SetNullCount(0),
+			}, metadata.Ascending, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			descr := schema.NewColumn(tt.n, 1, 0)
+
+			bldr := metadata.NewColumnIndexBuilder(descr)
+			for _, stats := range tt.pageStats {
+				bldr.AddPage(stats)
+			}
+			require.NoError(t, bldr.Finish())
+
+			colIndexes := make([]metadata.ColumnIndex, 0)
+			// 1st element is the column index just built
+			colIndexes = append(colIndexes, bldr.Build())
+			// 2nd element is the column index restored by serialize-then-deserialize round trip
+			var buf bytes.Buffer
+			bldr.WriteTo(&buf, nil)
+			colIndexes = append(colIndexes, metadata.NewColumnIndex(descr, buf.Bytes(), nil, nil))
+
+			for _, colIndex := range colIndexes {
+				assert.Equal(t, tt.hasNullCounts, colIndex.IsSetNullCounts())
+				assert.Equal(t, tt.boundaryOrder, colIndex.GetBoundaryOrder())
+				numPages := len(colIndex.GetNullPages())
+				for i := 0; i < numPages; i++ {
+					assert.Equal(t, tt.pageStats[i].AllNullValue, colIndex.GetNullPages()[i])
+					assert.Equalf(t, tt.pageStats[i].Min, colIndex.GetMinValues()[i], "colIndex: %d, page: %d", colIndex, i)
+					assert.Equalf(t, tt.pageStats[i].Max, colIndex.GetMaxValues()[i], "colIndex: %d, page: %d", colIndex, i)
+					if tt.hasNullCounts {
+						assert.Equal(t, tt.pageStats[i].NullCount, colIndex.GetNullCounts()[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestWriteColumnIndexCorruptedStats(t *testing.T) {
+	pageStats := []*metadata.EncodedStatistics{
+		(&metadata.EncodedStatistics{}).SetMin(simpleEncode(int32(1))).SetMax(simpleEncode(int32(2))),
+		(&metadata.EncodedStatistics{}),
+		(&metadata.EncodedStatistics{}).SetMin(simpleEncode(int32(3))).SetMax(simpleEncode(int32(4))),
+	}
+
+	descr := schema.NewColumn(schema.NewInt32Node("c1", parquet.Repetitions.Optional, -1), 1, 0)
+	bldr := metadata.NewColumnIndexBuilder(descr)
+	for _, stats := range pageStats {
+		bldr.AddPage(stats)
+	}
+	require.NoError(t, bldr.Finish())
+	assert.Nil(t, bldr.Build())
+
+	var buf bytes.Buffer
+	bldr.WriteTo(&buf, nil)
+	assert.Zero(t, buf.Len())
+}
+
+func TestPageIndexBuilderWithZeroRowGroup(t *testing.T) {
+	fields := schema.FieldList{
+		schema.NewInt32Node("c1", parquet.Repetitions.Optional, -1),
+		schema.NewByteArrayNode("c2", parquet.Repetitions.Optional, -1),
+	}
+
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, fields, -1))
+	sc := schema.NewSchema(root)
+
+	bldr := metadata.PageIndexBuilder{Schema: sc}
+
+	// AppendRowGroup not called
+	cb, err := bldr.GetColumnIndexBuilder(0)
+	assert.Error(t, err)
+	assert.Nil(t, cb)
+	ob, err := bldr.GetOffsetIndexBuilder(0)
+	assert.Error(t, err)
+	assert.Nil(t, ob)
+	bldr.Finish()
+
+	var (
+		buf bytes.Buffer
+		loc metadata.PageIndexLocation
+	)
+
+	assert.NoError(t, bldr.WriteTo(&utils.TellWrapper{Writer: &buf}, &loc))
+	assert.Zero(t, buf.Len())
+	assert.Len(t, loc.ColIndexLocation, 0)
+	assert.Len(t, loc.OffsetIndexLocation, 0)
+}
+
+type PageIndexBuilderSuite struct {
+	suite.Suite
+
+	sc           *schema.Schema
+	pageIndexLoc metadata.PageIndexLocation
+	buf          bytes.Buffer
+}
+
+func (s *PageIndexBuilderSuite) SetupTest() {
+	s.buf.Reset()
+}
+
+func (s *PageIndexBuilderSuite) writePageIndexes(numRGs, numCols int, pageStats [][]*metadata.EncodedStatistics, pageLocs [][]metadata.PageLocation, finalPos int) {
+	bldr := metadata.PageIndexBuilder{Schema: s.sc}
+	for rg := range numRGs {
+		s.Require().NoError(bldr.AppendRowGroup())
+
+		for col := range numCols {
+			if col < len(pageStats[rg]) {
+				colIdxBldr, err := bldr.GetColumnIndexBuilder(col)
+				s.Require().NoError(err)
+				s.Require().NoError(colIdxBldr.AddPage(pageStats[rg][col]))
+				s.Require().NoError(colIdxBldr.Finish())
+			}
+
+			if col < len(pageLocs[rg]) {
+				offsetIdxBldr, err := bldr.GetOffsetIndexBuilder(col)
+				s.Require().NoError(err)
+				s.Require().NoError(offsetIdxBldr.AddPageLoc(pageLocs[rg][col]))
+				s.Require().NoError(offsetIdxBldr.Finish(int64(finalPos)))
+			}
+		}
+	}
+	bldr.Finish()
+
+	s.Require().NoError(bldr.WriteTo(&utils.TellWrapper{Writer: &s.buf}, &s.pageIndexLoc))
+	s.Len(s.pageIndexLoc.ColIndexLocation, numRGs)
+	s.Len(s.pageIndexLoc.OffsetIndexLocation, numRGs)
+	for rg := range numRGs {
+		s.Len(s.pageIndexLoc.ColIndexLocation[uint64(rg)], numCols)
+		s.Len(s.pageIndexLoc.OffsetIndexLocation[uint64(rg)], numCols)
+	}
+}
+
+func (s *PageIndexBuilderSuite) checkColumnIndex(rg, col int, stats *metadata.EncodedStatistics) {
+	colIndex := s.readColumnIndex(rg, col)
+	s.Require().NotNil(colIndex)
+	s.Len(colIndex.GetNullPages(), 1)
+	s.Equal(stats.AllNullValue, colIndex.GetNullPages()[0])
+	s.Equal(stats.Min, colIndex.GetMinValues()[0])
+	s.Equal(stats.Max, colIndex.GetMaxValues()[0])
+	s.Equal(stats.HasNullCount, colIndex.IsSetNullCounts())
+	if stats.HasNullCount {
+		s.Equal(stats.NullCount, colIndex.GetNullCounts()[0])
+	}
+}
+
+func (s *PageIndexBuilderSuite) checkOffsetIndex(rg, col int, loc metadata.PageLocation, finalLoc int64) {
+	offsetIndex := s.readOffsetIndex(rg, col)
+	s.Require().NotNil(offsetIndex)
+	s.Len(offsetIndex.GetPageLocations(), 1)
+	location := offsetIndex.GetPageLocations()[0]
+	s.Equal(loc.Offset+finalLoc, location.Offset)
+	s.Equal(loc.CompressedPageSize, location.CompressedPageSize)
+	s.Equal(loc.FirstRowIndex, location.FirstRowIndex)
+}
+
+func (s *PageIndexBuilderSuite) readColumnIndex(rg, col int) metadata.ColumnIndex {
+	location := s.pageIndexLoc.ColIndexLocation[uint64(rg)][col]
+	if location == nil {
+		return nil
+	}
+
+	start, end := location.Offset, location.Offset+int64(location.Length)
+	return metadata.NewColumnIndex(s.sc.Column(col), s.buf.Bytes()[start:end], nil, nil)
+}
+
+func (s *PageIndexBuilderSuite) readOffsetIndex(rg, col int) metadata.OffsetIndex {
+	location := s.pageIndexLoc.OffsetIndexLocation[uint64(rg)][col]
+	if location == nil {
+		return nil
+	}
+
+	start, end := location.Offset, location.Offset+int64(location.Length)
+	return metadata.NewOffsetIndex(s.buf.Bytes()[start:end], nil, nil)
+}
+
+func (s *PageIndexBuilderSuite) TestSingleRowGroup() {
+	s.sc = schema.NewSchema(schema.MustGroup(
+		schema.NewGroupNode("schema", parquet.Repetitions.Repeated,
+			schema.FieldList{
+				schema.NewByteArrayNode("c1", parquet.Repetitions.Optional, -1),
+				schema.NewByteArrayNode("c2", parquet.Repetitions.Optional, -1),
+				schema.NewByteArrayNode("c3", parquet.Repetitions.Optional, -1),
+			}, -1)))
+
+	// prepare page stats and page locations
+	// note the 3rd column doesnt have any stats
+	const (
+		numRowGroups = 1
+		numCols      = 3
+		finalPos     = 200
+	)
+
+	var (
+		pageStats = [][]*metadata.EncodedStatistics{
+			// row group id = 0
+			{
+				(&metadata.EncodedStatistics{}).SetNullCount(0).SetMin([]byte("a")).SetMax([]byte("b")),
+				(&metadata.EncodedStatistics{}).SetNullCount(0).SetMin([]byte("A")).SetMax([]byte("B")),
+			},
+		}
+
+		pageLocations = [][]metadata.PageLocation{
+			// row group id = 0
+			{
+				{Offset: 128, CompressedPageSize: 512, FirstRowIndex: 0},
+				{Offset: 1024, CompressedPageSize: 512, FirstRowIndex: 0},
+			},
+		}
+	)
+
+	s.writePageIndexes(numRowGroups, numCols, pageStats, pageLocations, finalPos)
+
+	// verify the column index and offset index
+	for col := 0; col < 2; col++ {
+		s.checkColumnIndex(0, col, pageStats[0][col])
+		s.checkOffsetIndex(0, col, pageLocations[0][col], finalPos)
+	}
+
+	// 3rd column should not have any column index
+	s.Nil(s.readColumnIndex(0, 2))
+	s.Nil(s.readOffsetIndex(0, 2))
+}
+
+func (s *PageIndexBuilderSuite) TestTwoRowGroups() {
+	s.sc = schema.NewSchema(schema.MustGroup(
+		schema.NewGroupNode("schema", parquet.Repetitions.Repeated,
+			schema.FieldList{
+				schema.NewByteArrayNode("c1", parquet.Repetitions.Optional, -1),
+				schema.NewByteArrayNode("c2", parquet.Repetitions.Optional, -1),
+			}, -1)))
+
+	// prepare page stats and page locations
+	// note the 3rd column doesnt have any stats
+	const (
+		numRowGroups = 2
+		numCols      = 2
+		finalPos     = 200
+	)
+
+	var (
+		pageStats = [][]*metadata.EncodedStatistics{
+			{ // row group id = 0
+				(&metadata.EncodedStatistics{}).SetMin([]byte("a")).SetMax([]byte("b")),
+				(&metadata.EncodedStatistics{}).SetNullCount(0).SetMin([]byte("A")).SetMax([]byte("B")),
+			},
+			{ // row group id = 1
+				(&metadata.EncodedStatistics{}), // corrupted stats
+				(&metadata.EncodedStatistics{}).SetNullCount(0).SetMin([]byte("bar")).SetMax([]byte("foo")),
+			},
+		}
+
+		pageLocations = [][]metadata.PageLocation{
+			{ // row group id = 0
+				{Offset: 128, CompressedPageSize: 512, FirstRowIndex: 0},
+				{Offset: 1024, CompressedPageSize: 512, FirstRowIndex: 0},
+			},
+			{ // row group id = 1
+				{Offset: 128, CompressedPageSize: 512, FirstRowIndex: 0},
+				{Offset: 1024, CompressedPageSize: 512, FirstRowIndex: 0},
+			},
+		}
+	)
+
+	s.writePageIndexes(numRowGroups, numCols, pageStats, pageLocations, finalPos)
+
+	// verify that all columns have good column indexes except the 2nd column
+	// in the 2nd row group
+	s.checkColumnIndex(0, 0, pageStats[0][0])
+	s.checkColumnIndex(0, 1, pageStats[0][1])
+	s.checkColumnIndex(1, 1, pageStats[1][1])
+	s.Nil(s.readColumnIndex(1, 0))
+
+	// verify that two columns have good offset indexes
+	s.checkOffsetIndex(0, 0, pageLocations[0][0], finalPos)
+	s.checkOffsetIndex(0, 1, pageLocations[0][1], finalPos)
+	s.checkOffsetIndex(1, 0, pageLocations[1][0], finalPos)
+	s.checkOffsetIndex(1, 1, pageLocations[1][1], finalPos)
+}
+
+func TestPageIndexBuilder(t *testing.T) {
+	suite.Run(t, new(PageIndexBuilderSuite))
+}
+
+func TestPageIndexReader(t *testing.T) {
+	dir := os.Getenv("PARQUET_TEST_DATA")
+	if dir == "" {
+		t.Skip("PARQUET_TEST_DATA not set")
+	}
+	require.DirExists(t, dir)
+
+	path := filepath.Join(dir, "alltypes_tiny_pages.parquet")
+	rdr, err := file.OpenParquetFile(path, false)
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	fileMeta := rdr.MetaData()
+	assert.EqualValues(t, 1, fileMeta.NumRowGroups())
+	assert.EqualValues(t, 13, fileMeta.Schema.NumColumns())
+
+	pageIdxReader := rdr.GetPageIndexReader()
+	require.NotNil(t, pageIdxReader)
+
+	idxSelectionTests := []metadata.PageIndexSelection{
+		{ColumnIndex: true, OffsetIndex: true},
+		{ColumnIndex: true, OffsetIndex: false},
+		{ColumnIndex: false, OffsetIndex: true},
+		{ColumnIndex: false, OffsetIndex: false},
+	}
+
+	tests := []struct {
+		rowGroupIndices []int32
+		colIndices      []int32
+	}{
+		{[]int32{}, []int32{}},
+		{[]int32{0}, []int32{}},
+		{[]int32{0}, []int32{0}},
+		{[]int32{0}, []int32{5}},
+		{[]int32{0}, []int32{0, 5}},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("rowGroupIndices=%v,colIndices=%v", tt.rowGroupIndices, tt.colIndices), func(t *testing.T) {
+			for _, idxSelection := range idxSelectionTests {
+				t.Run(fmt.Sprintf("indexSelection=%v", idxSelection), func(t *testing.T) {
+					callWillNeed := len(tt.rowGroupIndices) > 0
+					if callWillNeed {
+						pageIdxReader.WillNeed(tt.rowGroupIndices, tt.colIndices, idxSelection)
+					}
+
+					rgIdxReader, err := pageIdxReader.RowGroup(0)
+					assert.NoError(t, err)
+					if !callWillNeed || idxSelection.OffsetIndex || idxSelection.ColumnIndex {
+						assert.NotNil(t, rgIdxReader)
+					} else {
+						assert.Nil(t, rgIdxReader)
+						return
+					}
+
+					colIdxRequested := func(colID int32) bool {
+						return !callWillNeed || (idxSelection.ColumnIndex &&
+							(len(tt.colIndices) == 0 || slices.Contains(tt.colIndices, colID)))
+					}
+
+					offsetIdxRequested := func(colID int32) bool {
+						return !callWillNeed || (idxSelection.OffsetIndex &&
+							(len(tt.colIndices) == 0 || slices.Contains(tt.colIndices, colID)))
+					}
+
+					if offsetIdxRequested(0) {
+						// verify offset index of column 0 and only partial data as it contains 325 pages
+						const numPages = 325
+						var (
+							pageIndices   = []uint64{0, 100, 200, 300}
+							pageLocations = []metadata.PageLocation{
+								{Offset: 4, CompressedPageSize: 109, FirstRowIndex: 0},
+								{Offset: 11480, CompressedPageSize: 133, FirstRowIndex: 2244},
+								{Offset: 22980, CompressedPageSize: 133, FirstRowIndex: 4494},
+								{Offset: 34480, CompressedPageSize: 133, FirstRowIndex: 6744},
+							}
+						)
+
+						offsetIdx, err := rgIdxReader.GetOffsetIndex(0)
+						require.NoError(t, err)
+						assert.NotNil(t, offsetIdx)
+
+						assert.Len(t, offsetIdx.GetPageLocations(), numPages)
+						for i, pageID := range pageIndices {
+							readPageLoc, expectedPageLoc := offsetIdx.GetPageLocations()[pageID], pageLocations[i]
+							assert.EqualValues(t, expectedPageLoc.Offset, readPageLoc.Offset)
+							assert.EqualValues(t, expectedPageLoc.CompressedPageSize, readPageLoc.CompressedPageSize)
+							assert.EqualValues(t, expectedPageLoc.FirstRowIndex, readPageLoc.FirstRowIndex)
+						}
+					} else {
+						_, err := rgIdxReader.GetOffsetIndex(0)
+						assert.Error(t, err)
+					}
+
+					if colIdxRequested(5) {
+						// verify column index of column 5 and only partial data as it contains 528 pages
+						const (
+							numPages      = 528
+							boundaryOrder = metadata.Unordered
+							hasNullCounts = true
+						)
+
+						var (
+							pageIndices = []uint64{0, 99, 426, 520}
+							nullPages   = []bool{false, false, false, false}
+							nullCounts  = []int64{0, 0, 0, 0}
+							minValues   = []int64{0, 10, 0, 0}
+							maxValues   = []int64{90, 90, 80, 70}
+						)
+
+						colIdx, err := rgIdxReader.GetColumnIndex(5)
+						require.NoError(t, err)
+						assert.NotNil(t, colIdx)
+
+						assert.IsType(t, (*metadata.TypedColumnIndex[int64])(nil), colIdx)
+						typedColIdx := colIdx.(*metadata.TypedColumnIndex[int64])
+
+						assert.Len(t, colIdx.GetNullPages(), numPages)
+						assert.Equal(t, hasNullCounts, colIdx.IsSetNullCounts())
+						assert.Equal(t, boundaryOrder, colIdx.GetBoundaryOrder())
+						for i, pageID := range pageIndices {
+							assert.Equal(t, nullPages[i], colIdx.GetNullPages()[pageID])
+							if hasNullCounts {
+								assert.Equal(t, nullCounts[i], colIdx.GetNullCounts()[pageID])
+							}
+							if !nullPages[i] {
+								assert.Equal(t, minValues[i], typedColIdx.MinValues()[pageID])
+								assert.Equal(t, maxValues[i], typedColIdx.MaxValues()[pageID])
+							}
+						}
+					} else {
+						_, err := rgIdxReader.GetColumnIndex(5)
+						assert.Error(t, err)
+					}
+
+					// verify null is returned if column index does not exist
+					colIdx, err := rgIdxReader.GetColumnIndex(10)
+					assert.NoError(t, err)
+					assert.Nil(t, colIdx)
+				})
+			}
+		})
+	}
+}
+
+func TestReadFileWithoutPageIndex(t *testing.T) {
+	dir := os.Getenv("PARQUET_TEST_DATA")
+	if dir == "" {
+		t.Skip("PARQUET_TEST_DATA not set")
+	}
+	require.DirExists(t, dir)
+
+	path := filepath.Join(dir, "int32_decimal.parquet")
+	rdr, err := file.OpenParquetFile(path, false)
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	fileMeta := rdr.MetaData()
+	assert.EqualValues(t, 1, fileMeta.NumRowGroups())
+	pageIdxReader := rdr.GetPageIndexReader()
+	assert.NotNil(t, pageIdxReader)
+	rgIdxReader, err := pageIdxReader.RowGroup(0)
+	assert.NoError(t, err)
+	assert.Nil(t, rgIdxReader)
+}

--- a/parquet/metadata/statistics.go
+++ b/parquet/metadata/statistics.go
@@ -19,13 +19,16 @@ package metadata
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"math"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/float16"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/internal/bitutils"
 	"github.com/apache/arrow-go/v18/internal/utils"
+	shared_utils "github.com/apache/arrow-go/v18/internal/utils"
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/internal/debug"
 	"github.com/apache/arrow-go/v18/parquet/internal/encoding"
@@ -58,6 +61,8 @@ type EncodedStatistics struct {
 	NullCount        int64
 	HasDistinctCount bool
 	DistinctCount    int64
+
+	AllNullValue bool
 }
 
 // ApplyStatSizeLimits sets the maximum size of the min/max values.
@@ -614,4 +619,448 @@ func GetStatValue(typ parquet.Type, val []byte) interface{} {
 		return val
 	}
 	return nil
+}
+
+type Comparator[T parquet.ColumnTypes] interface {
+	// return true if a is strictly less than b
+	Compare(a, b T) bool
+	GetMinMax(vals []T) (min, max T)
+	GetMinMaxSpaced(vals []T, validBits []byte, validBitsOffset int64) (min, max T)
+}
+
+func NewComparator(descr *schema.Column) (any, error) {
+	if descr.SortOrder() == schema.SortSIGNED {
+		switch descr.PhysicalType() {
+		case parquet.Types.Boolean:
+			return &booleanComparator{}, nil
+		case parquet.Types.Int32:
+			return &intComparator[int32]{sortOrder: schema.SortSIGNED}, nil
+		case parquet.Types.Int64:
+			return &intComparator[int64]{sortOrder: schema.SortSIGNED}, nil
+		case parquet.Types.Int96:
+			return &int96Comparator{sortOrder: schema.SortSIGNED}, nil
+		case parquet.Types.Float:
+			return &floatComparator[float32]{}, nil
+		case parquet.Types.Double:
+			return &floatComparator[float64]{}, nil
+		case parquet.Types.ByteArray:
+			return &byteArrayComparator[parquet.ByteArray]{sortOrder: schema.SortSIGNED}, nil
+		case parquet.Types.FixedLenByteArray:
+			if descr.LogicalType().Equals(schema.Float16LogicalType{}) {
+				return &float16Comparator{}, nil
+			}
+			return &byteArrayComparator[parquet.FixedLenByteArray]{sortOrder: schema.SortSIGNED}, nil
+		default:
+			return nil, fmt.Errorf("%w: signed compare not implemented for %s",
+				arrow.ErrNotImplemented, descr.PhysicalType())
+		}
+	} else if descr.SortOrder() == schema.SortUNKNOWN {
+		return nil, fmt.Errorf("%w: sort order is unknown", arrow.ErrNotImplemented)
+	}
+
+	switch descr.PhysicalType() {
+	case parquet.Types.Int32:
+		return &intComparator[int32]{sortOrder: schema.SortUNSIGNED}, nil
+	case parquet.Types.Int64:
+		return &intComparator[int64]{sortOrder: schema.SortUNSIGNED}, nil
+	case parquet.Types.Int96:
+		return &int96Comparator{sortOrder: schema.SortUNSIGNED}, nil
+	case parquet.Types.ByteArray:
+		return &byteArrayComparator[parquet.ByteArray]{sortOrder: schema.SortUNSIGNED}, nil
+	case parquet.Types.FixedLenByteArray:
+		return &byteArrayComparator[parquet.FixedLenByteArray]{sortOrder: schema.SortUNSIGNED}, nil
+	default:
+		return nil, fmt.Errorf("%w: unsigned compare not implemented for %s", arrow.ErrNotImplemented, descr.PhysicalType())
+	}
+}
+
+func NewTypedComparator[T parquet.ColumnTypes](descr *schema.Column) (Comparator[T], error) {
+	comp, err := NewComparator(descr)
+	if err != nil {
+		return nil, err
+	}
+
+	c, ok := comp.(Comparator[T])
+	if !ok {
+		return nil, fmt.Errorf("unexpected comparator type %T", comp)
+	}
+	return c, nil
+}
+
+type intComparator[T int32 | int64] struct {
+	sortOrder    schema.SortOrder
+	bitSetReader bitutils.SetBitRunReader
+}
+
+func (c *intComparator[T]) defaultMin() T {
+	var z T
+	switch any(z).(type) {
+	case int32:
+		if c.sortOrder == schema.SortUNSIGNED {
+			val := uint32(math.MaxUint32)
+			return T(val)
+		}
+		return math.MaxInt32
+	case int64:
+		if c.sortOrder == schema.SortUNSIGNED {
+			val := uint64(math.MaxUint64)
+			return T(val)
+		}
+		var v int64 = math.MaxInt64
+		return T(v)
+	}
+	panic("unreachable")
+}
+
+func (c *intComparator[T]) defaultMax() T {
+	if c.sortOrder == schema.SortUNSIGNED {
+		return T(0)
+	}
+
+	var z T
+	switch any(z).(type) {
+	case int32:
+		return math.MinInt32
+	case int64:
+		var v int64 = math.MinInt64
+		return T(v)
+	}
+	panic("unreachable")
+}
+
+func (c *intComparator[T]) Compare(a, b T) bool {
+	if c.sortOrder == schema.SortUNSIGNED {
+		return uint64(a) < uint64(b)
+	}
+	return a < b
+}
+
+func (c *intComparator[T]) GetMinMax(vals []T) (min, max T) {
+	if c.sortOrder == schema.SortSIGNED {
+		switch v := any(vals).(type) {
+		case []int32:
+			minv, maxv := shared_utils.GetMinMaxInt32(v)
+			return T(minv), T(maxv)
+		case []int64:
+			minv, maxv := shared_utils.GetMinMaxInt64(v)
+			return T(minv), T(maxv)
+		}
+		panic("unreachable")
+	}
+
+	switch v := any(vals).(type) {
+	case []int32:
+		minv, maxv := shared_utils.GetMinMaxUint32(arrow.GetData[uint32](arrow.GetBytes(v)))
+		return T(minv), T(maxv)
+	case []int64:
+		minv, maxv := shared_utils.GetMinMaxUint64(arrow.GetData[uint64](arrow.GetBytes(v)))
+		return T(minv), T(maxv)
+	}
+	panic("unreachable")
+}
+
+func (c *intComparator[T]) GetMinMaxSpaced(vals []T, validBits []byte, validBitsOffset int64) (minv, maxv T) {
+	minv, maxv = c.defaultMin(), c.defaultMax()
+	var fn func([]T) (T, T)
+	switch any(vals).(type) {
+	case []int32:
+		if c.sortOrder == schema.SortSIGNED {
+			fn = func(t []T) (T, T) {
+				minv, maxv := shared_utils.GetMinMaxInt32(any(t).([]int32))
+				return T(minv), T(maxv)
+			}
+		} else {
+			fn = func(t []T) (T, T) {
+				minv, maxv := shared_utils.GetMinMaxUint32(arrow.GetData[uint32](arrow.GetBytes(any(t).([]int32))))
+				return T(minv), T(maxv)
+			}
+		}
+	case []int64:
+		if c.sortOrder == schema.SortSIGNED {
+			fn = func(t []T) (T, T) {
+				minv, maxv := shared_utils.GetMinMaxInt64(any(t).([]int64))
+				return T(minv), T(maxv)
+			}
+		} else {
+			fn = func(t []T) (T, T) {
+				minv, maxv := shared_utils.GetMinMaxUint64(arrow.GetData[uint64](arrow.GetBytes(any(t).([]int64))))
+				return T(minv), T(maxv)
+			}
+		}
+	}
+
+	if c.bitSetReader == nil {
+		c.bitSetReader = bitutils.NewSetBitRunReader(validBits, validBitsOffset, int64(len(vals)))
+	} else {
+		c.bitSetReader.Reset(validBits, validBitsOffset, int64(len(vals)))
+	}
+
+	for {
+		run := c.bitSetReader.NextRun()
+		if run.Length == 0 {
+			break
+		}
+
+		localMin, localMax := fn(vals[int(run.Pos):int(run.Pos+run.Length)])
+		minv, maxv = min(minv, localMin), max(maxv, localMax)
+	}
+	return
+}
+
+func basicMinMax[T any](vals []T, defMin, defMax T, coalesce, min, max func(T, T) T) (minv, maxv T) {
+	minv, maxv = defMin, defMax
+
+	for _, v := range vals {
+		minv = min(minv, coalesce(v, defMin))
+		maxv = max(maxv, coalesce(v, defMax))
+	}
+	return
+}
+
+func basicMinMaxSpaced[T any](vals []T, validBits []byte, validOffset int64, bitSetReader *bitutils.SetBitRunReader,
+	defMin, defMax T, coalesce, min, max func(T, T) T) (minv, maxv T) {
+
+	minv, maxv = defMin, defMax
+	if *bitSetReader == nil {
+		*bitSetReader = bitutils.NewSetBitRunReader(validBits, validOffset, int64(len(vals)))
+	} else {
+		(*bitSetReader).Reset(validBits, validOffset, int64(len(vals)))
+	}
+
+	for {
+		run := (*bitSetReader).NextRun()
+		if run.Length == 0 {
+			break
+		}
+
+		for _, v := range vals[int(run.Pos):int(run.Pos+run.Length)] {
+			minv = min(minv, coalesce(v, defMin))
+			maxv = max(maxv, coalesce(v, defMax))
+		}
+	}
+	return
+}
+
+type floatComparator[T float32 | float64] struct {
+	bitSetReader bitutils.SetBitRunReader
+}
+
+func (floatComparator[T]) coalesce(val, fallback T) T {
+	if math.IsNaN(float64(val)) {
+		return fallback
+	}
+	return val
+}
+
+func (c *floatComparator[T]) defaultMin() T {
+	var z T
+	switch any(z).(type) {
+	case float32:
+		return math.MaxFloat32
+	case float64:
+		v := math.MaxFloat64
+		return T(v)
+	}
+	panic("unreachable")
+}
+
+func (c *floatComparator[T]) defaultMax() T {
+	return -c.defaultMin()
+}
+
+func (c *floatComparator[T]) Compare(a, b T) bool {
+	return a < b
+}
+
+func (c *floatComparator[T]) GetMinMax(vals []T) (minv, maxv T) {
+	return basicMinMax(vals, c.defaultMin(), c.defaultMax(), c.coalesce,
+		func(a, b T) T { return min(a, b) }, func(a, b T) T { return max(a, b) })
+}
+
+func (c *floatComparator[T]) GetMinMaxSpaced(vals []T, validBits []byte, validBitsOffset int64) (minv, maxv T) {
+	return basicMinMaxSpaced(vals, validBits, validBitsOffset, &c.bitSetReader, c.defaultMin(), c.defaultMax(), c.coalesce,
+		func(a, b T) T { return min(a, b) }, func(a, b T) T { return max(a, b) })
+}
+
+func byteArrMinVal[T parquet.ByteArray | parquet.FixedLenByteArray](cmpFn func(T, T) bool) func(a, b T) T {
+	return func(a, b T) T {
+		switch {
+		case a == nil:
+			return b
+		case b == nil:
+			return a
+		case cmpFn(a, b):
+			return a
+		default:
+			return b
+		}
+	}
+}
+
+func byteArrMaxVal[T parquet.ByteArray | parquet.FixedLenByteArray](cmpFn func(T, T) bool) func(a, b T) T {
+	return func(a, b T) T {
+		switch {
+		case a == nil:
+			return b
+		case b == nil:
+			return a
+		case cmpFn(a, b):
+			return b
+		default:
+			return a
+		}
+	}
+}
+
+type float16Comparator struct {
+	bitSetReader bitutils.SetBitRunReader
+}
+
+func (*float16Comparator) coalesce(v, fallback parquet.FixedLenByteArray) parquet.FixedLenByteArray {
+	if float16.FromLEBytes(v).IsNaN() {
+		return fallback
+	}
+	return v
+}
+
+func (*float16Comparator) Compare(a, b parquet.FixedLenByteArray) bool {
+	return float16.FromLEBytes(a).Less(float16.FromLEBytes(b))
+}
+
+func (c *float16Comparator) GetMinMax(vals []parquet.FixedLenByteArray) (minv, maxv parquet.FixedLenByteArray) {
+	return basicMinMax(vals, defaultMinFloat16, defaultMaxFloat16, c.coalesce, byteArrMinVal(c.Compare), byteArrMaxVal(c.Compare))
+}
+
+func (c *float16Comparator) GetMinMaxSpaced(vals []parquet.FixedLenByteArray, validBits []byte, validBitsOffset int64) (minv, maxv parquet.FixedLenByteArray) {
+	return basicMinMaxSpaced(vals, validBits, validBitsOffset, &c.bitSetReader, defaultMinFloat16, defaultMaxFloat16, c.coalesce, byteArrMinVal(c.Compare), byteArrMaxVal(c.Compare))
+}
+
+type int96Comparator struct {
+	sortOrder    schema.SortOrder
+	bitSetReader bitutils.SetBitRunReader
+}
+
+func (c *int96Comparator) defaultMin() parquet.Int96 {
+	if c.sortOrder == schema.SortUNSIGNED {
+		return defaultMinUInt96
+	}
+	return defaultMinInt96
+}
+
+func (c *int96Comparator) defaultMax() parquet.Int96 {
+	if c.sortOrder == schema.SortUNSIGNED {
+		return defaultMaxUInt96
+	}
+	return defaultMaxInt96
+}
+
+func (c *int96Comparator) Compare(a, b parquet.Int96) bool {
+	i96a := arrow.Uint32Traits.CastFromBytes(a[:])
+	i96b := arrow.Uint32Traits.CastFromBytes(b[:])
+
+	a0, a1, a2 := utils.ToLEUint32(i96a[0]), utils.ToLEUint32(i96a[1]), utils.ToLEUint32(i96a[2])
+	b0, b1, b2 := utils.ToLEUint32(i96b[0]), utils.ToLEUint32(i96b[1]), utils.ToLEUint32(i96b[2])
+
+	if a2 != b2 {
+		// only the msb bit is by signed comparison
+		if c.sortOrder == schema.SortSIGNED {
+			return int32(a2) < int32(b2)
+		}
+		return a2 < b2
+	} else if a1 != b1 {
+		return a1 < b1
+	}
+	return a0 < b0
+}
+
+func (c *int96Comparator) GetMinMax(vals []parquet.Int96) (minv, maxv parquet.Int96) {
+	return basicMinMax(vals, c.defaultMin(), c.defaultMax(), func(v, _ parquet.Int96) parquet.Int96 { return v },
+		func(a, b parquet.Int96) parquet.Int96 {
+			if c.Compare(a, b) {
+				return a
+			}
+			return b
+		}, func(a, b parquet.Int96) parquet.Int96 {
+			if c.Compare(a, b) {
+				return b
+			}
+			return a
+		})
+}
+
+func (c *int96Comparator) GetMinMaxSpaced(vals []parquet.Int96, validBits []byte, validBitsOffset int64) (minv, maxv parquet.Int96) {
+	return basicMinMaxSpaced(vals, validBits, validBitsOffset, &c.bitSetReader, c.defaultMin(), c.defaultMax(),
+		func(v, _ parquet.Int96) parquet.Int96 { return v },
+		func(a, b parquet.Int96) parquet.Int96 {
+			if c.Compare(a, b) {
+				return a
+			}
+			return b
+		}, func(a, b parquet.Int96) parquet.Int96 {
+			if c.Compare(a, b) {
+				return b
+			}
+			return a
+		})
+}
+
+type byteArrayComparator[T parquet.ByteArray | parquet.FixedLenByteArray] struct {
+	sortOrder    schema.SortOrder
+	bitSetReader bitutils.SetBitRunReader
+}
+
+func (c *byteArrayComparator[T]) Compare(a, b T) bool {
+	if c.sortOrder == schema.SortUNSIGNED {
+		return bytes.Compare(a, b) == -1
+	}
+
+	return signedByteLess(a, b)
+}
+
+func (c *byteArrayComparator[T]) GetMinMax(vals []T) (minv, maxv T) {
+	return basicMinMax(vals, nil, nil, func(v, _ T) T { return v },
+		byteArrMinVal(c.Compare), byteArrMaxVal(c.Compare))
+}
+
+func (c *byteArrayComparator[T]) GetMinMaxSpaced(vals []T, validBits []byte, validBitsOffset int64) (minv, maxv T) {
+	return basicMinMaxSpaced(vals, validBits, validBitsOffset, &c.bitSetReader, nil, nil,
+		func(v, _ T) T { return v }, byteArrMinVal(c.Compare), byteArrMaxVal(c.Compare))
+}
+
+type booleanComparator struct {
+	bitSetReader bitutils.SetBitRunReader
+}
+
+func (*booleanComparator) Compare(a, b bool) bool {
+	return !a && b
+}
+
+func (c *booleanComparator) GetMinMax(vals []bool) (minv, maxv bool) {
+	return basicMinMax(vals, true, false, func(v, _ bool) bool { return v },
+		func(a, b bool) bool {
+			if c.Compare(a, b) {
+				return a
+			}
+			return b
+		}, func(a, b bool) bool {
+			if c.Compare(a, b) {
+				return b
+			}
+			return a
+		})
+}
+
+func (c *booleanComparator) GetMinMaxSpaced(vals []bool, validBits []byte, validBitsOffset int64) (minv, maxv bool) {
+	return basicMinMaxSpaced(vals, validBits, validBitsOffset, &c.bitSetReader, true, false, func(v, _ bool) bool { return v },
+		func(a, b bool) bool {
+			if c.Compare(a, b) {
+				return a
+			}
+			return b
+		}, func(a, b bool) bool {
+			if c.Compare(a, b) {
+				return b
+			}
+			return a
+		})
 }

--- a/parquet/metadata/statistics.go
+++ b/parquet/metadata/statistics.go
@@ -27,7 +27,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/float16"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/internal/bitutils"
-	"github.com/apache/arrow-go/v18/internal/utils"
 	shared_utils "github.com/apache/arrow-go/v18/internal/utils"
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/internal/debug"
@@ -471,8 +470,8 @@ func (s *Int96Statistics) less(a, b parquet.Int96) bool {
 	i96a := arrow.Uint32Traits.CastFromBytes(a[:])
 	i96b := arrow.Uint32Traits.CastFromBytes(b[:])
 
-	a0, a1, a2 := utils.ToLEUint32(i96a[0]), utils.ToLEUint32(i96a[1]), utils.ToLEUint32(i96a[2])
-	b0, b1, b2 := utils.ToLEUint32(i96b[0]), utils.ToLEUint32(i96b[1]), utils.ToLEUint32(i96b[2])
+	a0, a1, a2 := shared_utils.ToLEUint32(i96a[0]), shared_utils.ToLEUint32(i96a[1]), shared_utils.ToLEUint32(i96a[2])
+	b0, b1, b2 := shared_utils.ToLEUint32(i96b[0]), shared_utils.ToLEUint32(i96b[1]), shared_utils.ToLEUint32(i96b[2])
 
 	if a2 != b2 {
 		// only the msb bit is by signed comparison
@@ -958,8 +957,8 @@ func (c *int96Comparator) Compare(a, b parquet.Int96) bool {
 	i96a := arrow.Uint32Traits.CastFromBytes(a[:])
 	i96b := arrow.Uint32Traits.CastFromBytes(b[:])
 
-	a0, a1, a2 := utils.ToLEUint32(i96a[0]), utils.ToLEUint32(i96a[1]), utils.ToLEUint32(i96a[2])
-	b0, b1, b2 := utils.ToLEUint32(i96b[0]), utils.ToLEUint32(i96b[1]), utils.ToLEUint32(i96b[2])
+	a0, a1, a2 := shared_utils.ToLEUint32(i96a[0]), shared_utils.ToLEUint32(i96a[1]), shared_utils.ToLEUint32(i96a[2])
+	b0, b1, b2 := shared_utils.ToLEUint32(i96b[0]), shared_utils.ToLEUint32(i96b[1]), shared_utils.ToLEUint32(i96b[2])
 
 	if a2 != b2 {
 		// only the msb bit is by signed comparison

--- a/parquet/metadata/statistics_types.gen.go
+++ b/parquet/metadata/statistics_types.gen.go
@@ -326,6 +326,7 @@ func (s *Int32Statistics) Encode() (enc EncodedStatistics, err error) {
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())
@@ -626,6 +627,7 @@ func (s *Int64Statistics) Encode() (enc EncodedStatistics, err error) {
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())
@@ -904,6 +906,7 @@ func (s *Int96Statistics) Encode() (enc EncodedStatistics, err error) {
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())
@@ -1196,6 +1199,7 @@ func (s *Float32Statistics) Encode() (enc EncodedStatistics, err error) {
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())
@@ -1488,6 +1492,7 @@ func (s *Float64Statistics) Encode() (enc EncodedStatistics, err error) {
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())
@@ -1766,6 +1771,7 @@ func (s *BooleanStatistics) Encode() (enc EncodedStatistics, err error) {
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())
@@ -2073,6 +2079,7 @@ func (s *ByteArrayStatistics) Encode() (enc EncodedStatistics, err error) {
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())
@@ -2383,6 +2390,7 @@ func (s *FixedLenByteArrayStatistics) Encode() (enc EncodedStatistics, err error
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())
@@ -2684,6 +2692,7 @@ func (s *Float16Statistics) Encode() (enc EncodedStatistics, err error) {
 	}
 	if s.HasNullCount() {
 		enc.SetNullCount(s.NullCount())
+		enc.AllNullValue = s.NumValues() == 0
 	}
 	if s.HasDistinctCount() {
 		enc.SetDistinctCount(s.DistinctCount())

--- a/parquet/metadata/statistics_types.gen.go.tmpl
+++ b/parquet/metadata/statistics_types.gen.go.tmpl
@@ -480,6 +480,7 @@ func (s *{{.Name}}Statistics) Encode() (enc EncodedStatistics, err error) {
   }
   if s.HasNullCount() {
     enc.SetNullCount(s.NullCount())
+    enc.AllNullValue = s.NumValues() == 0
   }
   if s.HasDistinctCount() {
     enc.SetDistinctCount(s.DistinctCount())

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -696,7 +696,7 @@ func listToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *s
 				return err
 			}
 		} else {
-			if err := groupToStructField(listGroup, currentLevels, ctx, out, &out.Children[0]); err != nil {
+			if err := groupToStructField(listGroup, currentLevels, ctx, &out.Children[0]); err != nil {
 				return err
 			}
 		}
@@ -741,7 +741,7 @@ func listToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *s
 	return nil
 }
 
-func groupToStructField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *schemaTree, parent, out *SchemaField) error {
+func groupToStructField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *schemaTree, out *SchemaField) error {
 	arrowFields := make([]arrow.Field, 0, n.NumFields())
 	out.Children = make([]SchemaField, n.NumFields())
 
@@ -852,7 +852,7 @@ func groupToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *
 		// }
 		out.Children = make([]SchemaField, 1)
 		repeatedAncestorDef := currentLevels.IncrementRepeated()
-		if err := groupToStructField(n, currentLevels, ctx, out, &out.Children[0]); err != nil {
+		if err := groupToStructField(n, currentLevels, ctx, &out.Children[0]); err != nil {
 			return err
 		}
 
@@ -865,7 +865,7 @@ func groupToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *
 	}
 
 	currentLevels.Increment(n)
-	return groupToStructField(n, currentLevels, ctx, parent, out)
+	return groupToStructField(n, currentLevels, ctx, out)
 }
 
 func createFieldMeta(fieldID int) arrow.Metadata {

--- a/parquet/types.go
+++ b/parquet/types.go
@@ -371,3 +371,7 @@ func (t Type) ByteSize() int {
 	}
 	panic("no bytesize info for type")
 }
+
+type ColumnTypes interface {
+	bool | int32 | int64 | float32 | float64 | Int96 | ByteArray | FixedLenByteArray
+}


### PR DESCRIPTION
### Rationale for this change
Adds support for writing and retrieving Page Indexes from parquet files

### What changes are included in this PR?
Added new writer properties to enable writing PageIndexes either as default or for specific columns.
Added `RowGroupPageIndexReader`, `ColumnIndexReader`, `OffsetIndexReader` to access page index information.

### Are these changes tested?
Yes, extensive unit tests have been added including round trip tests and encryption/decryption tests.

### Are there any user-facing changes?
no. Just new functions available.

closes #33 