### PR TITLE
chore(website): add HTML for https://arrow.apache.org/go/

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above meta tags *must* come first in the head; any other head content must come *after* these tags -->
+
+    <title>Apache Arrow Go</title>
+
+    <meta property="og:title" content="Apache Arrow Go">
+    <meta property="og:locale" content="en_US">
+    <meta name="description" content="The universal columnar format and multi-language toolbox for fast data interchange and in-memory analytics">
+    <meta property="og:description" content="The universal columnar format and multi-language toolbox for fast data interchange and in-memory analytics">
+    <link rel="canonical" href="https://arrow.apache.org/go/">
+    <meta property="og:url" content="https://arrow.apache.org/go/">
+    <meta property="og:site_name" content="Apache Arrow Go">
+    <meta property="og:image" content="https://arrow.apache.org/img/arrow-logo_horizontal_black-txt_white-bg.png">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta property="twitter:image" content="https://arrow.apache.org/img/arrow-logo_horizontal_black-txt_white-bg.png">
+    <meta property="twitter:title" content="Apache Arrow Go" />
+    <meta name="twitter:site" content="@ApacheArrow" />
+    <script type="application/ld+json">
+    {"@context":"https://schema.org","@type":"WebSite","description":"The universal columnar format and multi-language toolbox for fast data interchange and in-memory analytics","headline":"Apache Arrow Go","image":"https://arrow.apache.org/img/arrow-logo_horizontal_black-txt_white-bg.png","name":"Apache Arrow","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"https://arrow.apache.org/img/logo.png"}},"url":"https://arrow.apache.org/go/"}</script>
+
+
+    <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon-16x16.png" id="light1">
+    <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon-32x32.png" id="light2">
+    <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/img/apple-touch-icon.png" id="light3">
+    <link rel="apple-touch-icon" type="image/png" sizes="120x120" href="/img/apple-touch-icon-120x120.png" id="light4">
+    <link rel="apple-touch-icon" type="image/png" sizes="76x76" href="/img/apple-touch-icon-76x76.png" id="light5">
+    <link rel="apple-touch-icon" type="image/png" sizes="60x60" href="/img/apple-touch-icon-60x60.png" id="light6">
+    <!-- dark mode favicons -->
+    <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon-16x16-dark.png" id="dark1">
+    <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon-32x32-dark.png" id="dark2">
+    <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/img/apple-touch-icon-dark.png" id="dark3">
+    <link rel="apple-touch-icon" type="image/png" sizes="120x120" href="/img/apple-touch-icon-120x120-dark.png" id="dark4">
+    <link rel="apple-touch-icon" type="image/png" sizes="76x76" href="/img/apple-touch-icon-76x76-dark.png" id="dark5">
+    <link rel="apple-touch-icon" type="image/png" sizes="60x60" href="/img/apple-touch-icon-60x60-dark.png" id="dark6">
+
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:300,300italic,400,400italic,700,700italic,900">
+
+    <link href="/css/main.css" rel="stylesheet">
+    <link href="/css/syntax.css" rel="stylesheet">
+    <script src="/javascript/main.js"></script>
+
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      /* We explicitly disable cookie tracking to avoid privacy issues */
+      _paq.push(['disableCookies']);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://analytics.apache.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '20']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
+  </head>
+
+  <body class="wrap">
+    <div class="big-arrow-bg">
+      <div class="container px-4 py-5 centered">
+        <img src="/img/arrow-inverse.png" style="max-width: 70%;"/>
+        <p class="lead">The universal columnar format and multi-language toolbox for fast data interchange and in-memory analytics</p>
+
+        <div class="social-badges">
+          <div class="social-badge">
+            <a class="github-button" href="https://github.com/apache/arrow-go" data-size="large" data-show-count="true" aria-label="Star apache/arrow-go on GitHub">Star</a>
+          </div>
+          <div class="social-badge">
+            <a href="https://twitter.com/ApacheArrow?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="true">Follow @ApacheArrow</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="container p-4 pt-5">
+      <main role="main" class="pb-5">
+        <h2>Links</h2>
+        <ul>
+          <li><a href="https://github.com/apache/arrow-go">Repository</a></li>
+          <li><a href="https://pkg.go.dev/github.com/apache/arrow-go/">Documentation</a></li>
+        </ul>
+      </main>
+
+      <hr>
+
+      <footer class="footer">
+        <div class="row">
+          <div class="col-md-9">
+            <p>Apache Arrow, Arrow, Apache, the Apache feather logo, and the Apache Arrow project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
+            <p>&copy; 2016-2025 The Apache Software Foundation</p>
+          </div>
+          <div class="col-md-3">
+            <a class="d-sm-none d-md-inline pr-2" href="https://www.apache.org/events/current-event.html">
+              <img src="https://www.apache.org/events/current-event-234x60.png"/>
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <!-- Place this tag in your head or just before your close body tag. -->
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
### Rationale for this change

Fixes #202

We need our website.

### What changes are included in this PR?

Add `index.html` to the `asf-site` branch.

### Are these changes tested?

Yes.

![arrow-go-index](https://github.com/user-attachments/assets/8d073ba2-7ca4-4ac1-8521-517dce6b5e02)

### Are there any user-facing changes?

Yes.