### PR TITLE
chore(website): redirect to https://pkg.go.dev/github.com/apache/arrow-go/

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+Redirect permanent /go/ https://pkg.go.dev/github.com/apache/arrow-go/


### PR DESCRIPTION
### Rationale for this change

Fixes GH-202

We need our canonical URL.

### What changes are included in this PR?

Redirect to https://pkg.go.dev/github.com/apache/arrow-go/ .

### Are these changes tested?

No.

### Are there any user-facing changes?

Yes.