### PR TITLE
chore(website): add .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,4 +15,29 @@
 # specific language governing permissions and limitations
 # under the License.
 
-Redirect permanent /go/ https://pkg.go.dev/github.com/apache/arrow-go/
+# https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
+
+github:
+  description: "Official Go implementation of Apache Arrow"
+  homepage: https://arrow.apache.org/go/
+  labels:
+    - apache-arrow
+    - go
+  del_branch_on_merge: true
+  enabled_merge_buttons:
+    merge: false
+    rebase: false
+    squash: true
+  features:
+    issues: true
+  protected_branches:
+    main:
+      required_linear_history: true
+notifications:
+  commits: commits@arrow.apache.org
+  issues_status: issues@arrow.apache.org
+  issues_comment: github@arrow.apache.org
+  pullrequests: github@arrow.apache.org
+publish:
+  whoami: asf-site
+  subdir: go


### PR DESCRIPTION
### Rationale for this change

Fixes GH-202

We need `.asf.yaml` to publish the `asf-site` branch to https://arrow.apache.org/go/ .

### What changes are included in this PR?

Add `.asf.yaml`.

### Are these changes tested?

No.

### Are there any user-facing changes?

Yes.