### PR TITLE
chore: Update the project URL in apache/arrow-go

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,7 +19,7 @@
 
 github:
   description: "Official Go implementation of Apache Arrow"
-  homepage: https://arrow.apache.org/
+  homepage: https://arrow.apache.org/go/
   labels:
     - apache-arrow
     - go


### PR DESCRIPTION
### Rationale for this change

https://arrow.apache.org/go/ is available now. So let's use it instead of https://arrow.apache.org/ .

Closes #233.

### What changes are included in this PR?

Changes the URL in `.asf.yml`.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.