### PR TITLE
chore: Enable Java integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -398,6 +398,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: go
+      - name: Checkout Arrow Java
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: apache/arrow-java
+          path: java
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
@@ -420,6 +425,7 @@ jobs:
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
             -e ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS=go \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
+            -e ARCHERY_INTEGRATION_WITH_JAVA=1 \
             -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
             -e ARCHERY_INTEGRATION_WITH_RUST=1 \
             conda-integration


### PR DESCRIPTION
### Rationale for this change

The Java implementation is split to apache/arrow-java from apache/arrow. So the current integration test doesn't use the Java implementation. 

Closes #238.

### What changes are included in this PR?

Checkout apache/arrow-java.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.