### PR TITLE
fix(release): fix wrong upload path

### DIFF
--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -43,23 +43,24 @@ echo "Tagging for release: ${tag}"
 git tag "${tag}" "${rc_tag}"
 git push origin "${tag}"
 
+release_id="apache-arrow-go-${version}"
 dist_url="https://dist.apache.org/repos/dist/release/arrow"
-dist_dir="dev/release/dist"
+dist_base_dir="dev/release/dist"
+dist_dir="dev/release/dist/${release_id}"
 echo "Checking out ${dist_url}"
-rm -rf "${dist_dir}"
-svn co --depth=empty "${dist_url}" "${dist_dir}"
+rm -rf "${dist_base_dir}"
+svn co --depth=empty "${dist_url}" "${dist_base_dir}"
 gh release download "${rc_tag}" \
   --repo "${repository}" \
   --dir "${dist_dir}" \
   --skip-existing
 
-release_id="apache-arrow-go-${version}"
 echo "Uploading to release/"
-pushd "${dist_dir}"
+pushd "${dist_base_dir}"
 svn add .
 svn ci -m "Apache Arrow Go ${version}"
 popd
-rm -rf "${dist_dir}"
+rm -rf "${dist_base_dir}"
 
 echo "Keep only the latest versions"
 old_releases=$(


### PR DESCRIPTION
### Rationale for this change

closes #242

We should use
`https://dist.apache.org/repos/dist/release/arrow/apache-arrow-go-${version}` but `https://dist.apache.org/repos/dist/release/arrow` was used. (The last `/apache-arrow-go-${version}` was missing.)

### What changes are included in this PR?

Add missing `apache-arrow-go-${version}` part.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
