### PR TITLE
fix(release): fix svn add command and add script to generate release notes

### DIFF
--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -69,7 +69,6 @@ fi
 export TZ=UTC
 release_date_iso8601=$(LC_TIME=C date "+%Y-%m-%d")
 
-git_tag=v${version}
 git_range=v${previous_version}..v${version}
 
 contributors_command_line="git shortlog -sn ${git_range}"

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -22,7 +22,7 @@ set -u
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ARROW_DIR="${SOURCE_DIR}/../../"
-: ${ARROW_SITE_DIR:="${ARROW_DIR}/../arrow-site"}
+: "${ARROW_SITE_DIR:="${ARROW_DIR}/../arrow-site"}"
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <previous-version> <version>"
@@ -32,7 +32,7 @@ fi
 previous_version=$1
 version=$2
 
-branch_name=release-note-arrow-go-${version}
+branch_name="release-note-arrow-go-${version}"
 release_dir="${ARROW_SITE_DIR}/_posts"
 announce_file="${release_dir}/$(date +%Y-%m-%d)-arrow-go-${version}.md"
 
@@ -52,10 +52,10 @@ popd
 
 pushd "${ARROW_DIR}"
 
-previous_major_version="$(echo ${previous_version} | cut -d. -f1)"
-previous_minor_version="$(echo ${previous_version} | cut -d. -f2)"
-major_version="$(echo ${version} | cut -d. -f1)"
-minor_version="$(echo ${version} | cut -d. -f2)"
+previous_major_version="$(echo "${previous_version}" | cut -d. -f1)"
+previous_minor_version="$(echo "${previous_version}" | cut -d. -f2)"
+major_version="$(echo "${version}" | cut -d. -f1)"
+minor_version="$(echo "${version}" | cut -d. -f2)"
 if [ "${previous_major_version}" -eq "${major_version}" ]; then
   if [ "${previous_minor_version}" -eq "${minor_version}" ]; then
     release_type="patch"
@@ -74,7 +74,7 @@ git_range=v${previous_version}..v${version}
 contributors_command_line="git shortlog -sn ${git_range}"
 contributors=$(${contributors_command_line} | grep -v dependabot)
 
-n_commits=$(git log --pretty=oneline ${git_range} | grep -c -i -v "chore: Bump")
+n_commits=$(git log --pretty=oneline "${git_range}" | grep -c -i -v "chore: Bump")
 n_contributors=$(${contributors_command_line} | grep -c -v dependabot)
 
 git_changelog="$(gh release view --json body --jq .body | grep -v '@dependabot' | sed -e 's/^#/##/g')"
@@ -82,7 +82,8 @@ popd
 
 pushd "${ARROW_SITE_DIR}"
 
-cat <<ANNOUNCE >>"${announce_file}"
+{
+  cat <<ANNOUNCE
 ---
 layout: post
 title: "Apache Arrow Go ${version} Release"
@@ -117,15 +118,16 @@ This ${release_type} release covers ${n_commits} commits from ${n_contributors} 
 $ ${contributors_command_line}
 ANNOUNCE
 
-echo "${contributors}" >>"${announce_file}"
+  echo "${contributors}"
 
-cat <<ANNOUNCE >>"${announce_file}"
+  cat <<ANNOUNCE
 \`\`\`
 
 ## Changelog
 
 ${git_changelog}
 ANNOUNCE
+} >>"${announce_file}"
 
 git add "${announce_file}"
 git commit -m "[Release] Add release notes for Arrow Go ${version}"

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -60,9 +60,8 @@ release_date_iso8601=$(LC_TIME=C date "+%Y-%m-%d")
 previous_tag_date=$(git log -n 1 --pretty=%aI v${previous_version})
 rough_previous_release_date=$(date --date "${previous_tag_date}" +%s)
 rough_release_date=$(date +%s)
-rough_n_development_months=$((
-  (${rough_release_date} - ${rough_previous_release_date}) / (60 * 60 * 24 * 30)
-))
+rough_n_development_months=$(((\
+  ${rough_release_date} - ${rough_previous_release_date}) / (60 * 60 * 24 * 30)))
 
 git_tag=v${version}
 git_range=v${previous_version}..v${version}
@@ -79,7 +78,7 @@ popd
 
 pushd "${ARROW_SITE_DIR}"
 
-cat <<ANNOUNCE >> "${announce_file}"
+cat <<ANNOUNCE >>"${announce_file}"
 ---
 layout: post
 title: "Apache Arrow Go ${version} Release"
@@ -114,9 +113,9 @@ This ${release_type} release covers ${n_commits} commits from ${n_contributors} 
 $ ${contributors_command_line}
 ANNOUNCE
 
-echo "${contributors}" >> "${announce_file}"
+echo "${contributors}" >>"${announce_file}"
 
-cat <<ANNOUNCE >> "${announce_file}"
+cat <<ANNOUNCE >>"${announce_file}"
 \`\`\`
 
 ## Changelog
@@ -128,10 +127,10 @@ git add "${announce_file}"
 git commit -m "[Release] Add release notes for Arrow Go ${version}"
 git push -u origin ${branch_name}
 
-github_url=$(git remote get-url origin | \
-               sed \
-                 -e 's,^git@github.com:,https://github.com/,' \
-                 -e 's,\.git$,,')
+github_url=$(git remote get-url origin |
+  sed \
+    -e 's,^git@github.com:,https://github.com/,' \
+    -e 's,\.git$,,')
 
 echo "Success!"
 echo "Create a pull request:"

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -39,7 +39,7 @@ announce_file="${release_dir}/$(date +%Y-%m-%d)-arrow-go-${version}.md"
 pushd "${ARROW_SITE_DIR}"
 DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)"
 git fetch --all --prune --tags --force -j$(nproc)
-git checkout ${DEFAULT_BRANCH}
+git switch ${DEFAULT_BRANCH}
 git branch -D ${branch_name} || :
 git switch -c ${branch_name}
 popd

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -105,7 +105,7 @@ limitations under the License.
 {% endcomment %}
 -->
 
-The Apache Arrow team is pleased to announce the v${version} release ofApache Arrow Go. 
+The Apache Arrow team is pleased to announce the v${version} release of Apache Arrow Go. 
 This ${release_type} release covers ${n_commits} commits from ${n_contributors} distinct contributors.
 
 ## Contributors

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -41,7 +41,7 @@ DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)"
 git fetch --all --prune --tags --force -j$(nproc)
 git checkout ${DEFAULT_BRANCH}
 git branch -D ${branch_name} || :
-git checkout -b ${branch_name}
+git switch -c ${branch_name}
 popd
 
 pushd "${ARROW_DIR}"

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -61,7 +61,7 @@ if [ ${previous_major_version} -eq ${major_version} ]; then
     release_type=patch
   else
     release_type=minor
-  fi  
+  fi
 else
   release_type=major
 fi

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -73,7 +73,7 @@ n_commits=$(git log --pretty=oneline ${git_range} | grep -i -v "chore: Bump" | w
 n_contributors=$(${contributors_command_line} | grep -v dependabot | wc -l)
 
 git_tag_hash=$(git log -n 1 --pretty=%H ${git_tag})
-git_changelog="$(gh release view --json body --jq .body | grep -v '@dependabot')"
+git_changelog="$(gh release view --json body --jq .body | grep -v '@dependabot' | sed -e 's/^#/##/g')"
 popd
 
 pushd "${ARROW_SITE_DIR}"

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARROW_DIR="${SOURCE_DIR}/../../"
+: ${ARROW_SITE_DIR:="${ARROW_DIR}/../arrow-site"}
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <previous-version> <version>"
+  exit 1
+fi
+
+previous_version=$1
+version=$2
+
+branch_name=release-note-arrow-go-${version}
+release_dir="${ARROW_SITE_DIR}/_posts"
+announce_file="${release_dir}/$(date +%Y-%m-%d)-arrow-go-${version}.md"
+
+pushd "${ARROW_SITE_DIR}"
+DEFAULT_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)"
+git fetch --all --prune --tags --force -j$(nproc)
+git checkout ${DEFAULT_BRANCH}
+git branch -D ${branch_name} || :
+git checkout -b ${branch_name}
+popd
+
+pushd "${ARROW_DIR}"
+
+previous_major_version="$(echo v${previous_version} | grep -o '^[0-9]*')"
+major_version="$(echo v${version} | grep -o '^[0-9]*')"
+if [ ${previous_major_version} -eq ${major_version} ]; then
+  release_type=patch
+else
+  release_type=major
+fi
+
+export TZ=UTC
+release_date=$(LC_TIME=C date "+%-d %B %Y")
+release_date_iso8601=$(LC_TIME=C date "+%Y-%m-%d")
+previous_tag_date=$(git log -n 1 --pretty=%aI v${previous_version})
+rough_previous_release_date=$(date --date "${previous_tag_date}" +%s)
+rough_release_date=$(date +%s)
+rough_n_development_months=$((
+  (${rough_release_date} - ${rough_previous_release_date}) / (60 * 60 * 24 * 30)
+))
+
+git_tag=v${version}
+git_range=v${previous_version}..v${version}
+
+contributors_command_line="git shortlog -sn ${git_range}"
+contributors=$(${contributors_command_line} | grep -v dependabot)
+
+n_commits=$(git log --pretty=oneline ${git_range} | grep -i -v "chore: Bump" | wc -l)
+n_contributors=$(${contributors_command_line} | grep -v dependabot | wc -l)
+
+git_tag_hash=$(git log -n 1 --pretty=%H ${git_tag})
+git_changelog="$(gh release view --json body --jq .body | grep -v '@dependabot')"
+popd
+
+pushd "${ARROW_SITE_DIR}"
+
+cat <<ANNOUNCE >> "${announce_file}"
+---
+layout: post
+title: "Apache Arrow Go ${version} Release"
+date: "${release_date_iso8601} 00:00:00"
+author: pmc
+categories: [release]
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+The Apache Arrow team is pleased to announce the v${version} release ofApache Arrow Go. 
+This ${release_type} release covers ${n_commits} commits from ${n_contributors} distinct contributors.
+
+## Contributors
+\`\`\`console
+$ ${contributors_command_line}
+ANNOUNCE
+
+echo "${contributors}" >> "${announce_file}"
+
+cat <<ANNOUNCE >> "${announce_file}"
+\`\`\`
+
+## Changelog
+
+${git_changelog}
+ANNOUNCE
+
+git add "${announce_file}"
+git commit -m "[Release] Add release notes for Arrow Go ${version}"
+git push -u origin ${branch_name}
+
+github_url=$(git remote get-url origin | \
+               sed \
+                 -e 's,^git@github.com:,https://github.com/,' \
+                 -e 's,\.git$,,')
+
+echo "Success!"
+echo "Create a pull request:"
+echo "  ${github_url}/pull/new/${branch_name}"
+popd

--- a/dev/release/post-website.sh
+++ b/dev/release/post-website.sh
@@ -46,8 +46,8 @@ popd
 
 pushd "${ARROW_DIR}"
 
-previous_major_version="$(echo v${previous_version} | grep -o '^[0-9]*')"
-major_version="$(echo v${version} | grep -o '^[0-9]*')"
+previous_major_version="$(echo ${previous_version} | grep -o '^[0-9]*')"
+major_version="$(echo ${version} | grep -o '^[0-9]*')"
 if [ ${previous_major_version} -eq ${major_version} ]; then
   release_type=patch
 else

--- a/dev/release/release.sh
+++ b/dev/release/release.sh
@@ -57,7 +57,7 @@ gh release download "${rc_tag}" \
 
 echo "Uploading to release/"
 pushd "${dist_base_dir}"
-svn add .
+svn add "${release_id}"
 svn ci -m "Apache Arrow Go ${version}"
 popd
 rm -rf "${dist_base_dir}"


### PR DESCRIPTION
### Rationale for this change
Ease of utility for release process

### What changes are included in this PR?
Fixing `svn add` command to explicitly refer to the directory so it doesn't present an error anymore.
Add script to generate the markdown page for adding release notes to the arrow-site repo.
