### PR TITLE
chore: Update self-hosted arm runner to ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,59 +30,30 @@ concurrency:
 permissions:
   contents: read
 jobs:
-  docker-targets:
-    name: Docker targets
-    runs-on: ubuntu-latest
-    outputs:
-      targets: ${{ steps.detect-targets.outputs.targets }}
-    steps:
-      - name: Detect targets
-        id: detect-targets
-        run: |
-          echo "targets<<JSON" >> "$GITHUB_OUTPUT"
-          echo "[" >> "$GITHUB_OUTPUT"
-          cat <<JSON >> "$GITHUB_OUTPUT"
-          {
-            "arch-label": "AMD64",
-            "arch": "amd64",
-            "go": "1.22",
-            "runs-on": "ubuntu-latest"
-          },
-          {
-            "arch-label": "AMD64",
-            "arch": "amd64",
-            "go": "1.23",
-            "runs-on": "ubuntu-latest"
-          }
-          JSON
-          if [ "$GITHUB_REPOSITORY_OWNER" = "apache" ]; then
-            echo "," >> "$GITHUB_OUTPUT"
-            cat <<JSON >> "$GITHUB_OUTPUT"
-          {
-            "arch-label": "ARM64",
-            "arch": "arm64v8",
-            "go": "1.22",
-            "runs-on": ["self-hosted", "arm", "linux"]
-          },
-          {
-            "arch-label": "ARM64",
-            "arch": "arm64v8",
-            "go": "1.23",
-            "runs-on": ["self-hosted", "arm", "linux"]
-          }
-          JSON
-          fi
-          echo "]" >> "$GITHUB_OUTPUT"
-          echo "JSON" >> "$GITHUB_OUTPUT"
   docker:
     name: ${{ matrix.arch-label }} Debian 12 Go ${{ matrix.go }}
-    needs: docker-targets
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.docker-targets.outputs.targets) }}
+        include:
+          - arch-label: AMD64
+            arch: amd64
+            go: 1.22
+            runs-on: ubuntu-latest
+          - arch-label: AMD64
+            arch: amd64
+            go: 1.23
+            runs-on: ubuntu-latest
+          - arch-label: ARM64
+            arch: arm64v8
+            go: 1.22
+            runs-on: ubuntu-24.04-arm
+          - arch-label: ARM64
+            arch: arm64v8
+            go: 1.23
+            runs-on: ubuntu-24.04-arm
     env:
       ARCH: ${{ matrix.arch }}
       GO: ${{ matrix.go }}


### PR DESCRIPTION
Fixes: #267 

### What changes are included in this PR?
Replaced the running platform from `self-hosted arm` runner to `ubuntu-24.04-arm` 

### Are these changes tested?
Not locally, but can be tested by triggering the runner

### Are there any user-facing changes?
No