### PR TITLE
ci: update actions/cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,7 +378,7 @@ jobs:
         run: |
           ci/scripts/util_free_space.sh
       - name: Cache Docker Volumes
-        uses: actions/cache@b7a00a3203cfa62623760990f5171f9b4a2ab1a7 # v4.0.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: .docker
           key: integration-conda-${{ hashFiles('cpp/**') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -378,7 +378,7 @@ jobs:
         run: |
           ci/scripts/util_free_space.sh
       - name: Cache Docker Volumes
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@b7a00a3203cfa62623760990f5171f9b4a2ab1a7 # v4.0.2
         with:
           path: .docker
           key: integration-conda-${{ hashFiles('cpp/**') }}


### PR DESCRIPTION
### Rationale for this change
The existing version we are using has been deprecated, we need to upgrade to maintain the stability of our CI
