### PR TITLE
fix(arrow/bitutil): fix bitmap ops on 32-bit platforms

### DIFF
--- a/arrow/bitutil/bitmaps.go
+++ b/arrow/bitutil/bitmaps.go
@@ -465,20 +465,24 @@ type bitOp struct {
 
 var (
 	bitAndOp = bitOp{
-		opWord: func(l, r uint64) uint64 { return l & r },
-		opByte: func(l, r byte) byte { return l & r },
+		opWord:    func(l, r uint64) uint64 { return l & r },
+		opByte:    func(l, r byte) byte { return l & r },
+		opAligned: alignedBitAndGo,
 	}
 	bitOrOp = bitOp{
-		opWord: func(l, r uint64) uint64 { return l | r },
-		opByte: func(l, r byte) byte { return l | r },
+		opWord:    func(l, r uint64) uint64 { return l | r },
+		opByte:    func(l, r byte) byte { return l | r },
+		opAligned: alignedBitOrGo,
 	}
 	bitAndNotOp = bitOp{
-		opWord: func(l, r uint64) uint64 { return l &^ r },
-		opByte: func(l, r byte) byte { return l &^ r },
+		opWord:    func(l, r uint64) uint64 { return l &^ r },
+		opByte:    func(l, r byte) byte { return l &^ r },
+		opAligned: alignedBitAndNotGo,
 	}
 	bitXorOp = bitOp{
-		opWord: func(l, r uint64) uint64 { return l ^ r },
-		opByte: func(l, r byte) byte { return l ^ r },
+		opWord:    func(l, r uint64) uint64 { return l ^ r },
+		opByte:    func(l, r byte) byte { return l ^ r },
+		opAligned: alignedBitXorGo,
 	}
 )
 


### PR DESCRIPTION
### Rationale for this change
Fixes the broken 32-bit arch tests identified by #32 

### What changes are included in this PR?
Defining the `opAligned` pure go fallback methods for bitmap operations.

### Are these changes tested?
Yes, it makes the tests succeed properly on `GOARCH=386`

### Are there any user-facing changes?
No.
