### PR TITLE
feat(internal/encoding): add Discard method to decoders

### DIFF
--- a/parquet/internal/encoding/byte_stream_split.go
+++ b/parquet/internal/encoding/byte_stream_split.go
@@ -92,8 +92,8 @@ func encodeByteStreamSplitWidth8(data []byte, in []byte) {
 // into the output buffer 'out' using BYTE_STREAM_SPLIT encoding.
 // 'out' must have space for at least len(data) bytes.
 func decodeByteStreamSplitBatchWidth4(data []byte, nValues, stride int, out []byte) {
-	debug.Assert(len(out) >= len(data), fmt.Sprintf("not enough space in output buffer for decoding, out: %d bytes, data: %d bytes", len(out), len(data)))
 	const width = 4
+	debug.Assert(len(out) >= nValues*width, fmt.Sprintf("not enough space in output buffer for decoding, out: %d bytes, data: %d bytes", len(out), len(data)))
 	for element := 0; element < nValues; element++ {
 		out[width*element] = data[element]
 		out[width*element+1] = data[stride+element]
@@ -106,8 +106,8 @@ func decodeByteStreamSplitBatchWidth4(data []byte, nValues, stride int, out []by
 // into the output buffer 'out' using BYTE_STREAM_SPLIT encoding.
 // 'out' must have space for at least len(data) bytes.
 func decodeByteStreamSplitBatchWidth8(data []byte, nValues, stride int, out []byte) {
-	debug.Assert(len(out) >= len(data), fmt.Sprintf("not enough space in output buffer for decoding, out: %d bytes, data: %d bytes", len(out), len(data)))
 	const width = 8
+	debug.Assert(len(out) >= nValues*width, fmt.Sprintf("not enough space in output buffer for decoding, out: %d bytes, data: %d bytes", len(out), len(data)))
 	for element := 0; element < nValues; element++ {
 		out[width*element] = data[element]
 		out[width*element+1] = data[stride+element]

--- a/parquet/internal/encoding/byte_stream_split.go
+++ b/parquet/internal/encoding/byte_stream_split.go
@@ -351,9 +351,16 @@ func (dec *ByteStreamSplitDecoder[T]) SetData(nvals int, data []byte) error {
 	return dec.decoder.SetData(nvals, data)
 }
 
+func (dec *ByteStreamSplitDecoder[T]) Discard(n int) (int, error) {
+	n = min(n, dec.nvals)
+	dec.nvals -= n
+	dec.data = dec.data[n:]
+	return n, nil
+}
+
 func (dec *ByteStreamSplitDecoder[T]) Decode(out []T) (int, error) {
 	typeLen := dec.Type().ByteSize()
-	toRead := len(out)
+	toRead := min(len(out), dec.nvals)
 	numBytesNeeded := toRead * typeLen
 	if numBytesNeeded > len(dec.data) || numBytesNeeded > math.MaxInt32 {
 		return 0, xerrors.New("parquet: eof exception")

--- a/parquet/internal/encoding/decoder.go
+++ b/parquet/internal/encoding/decoder.go
@@ -142,6 +142,12 @@ func (d *dictDecoder) SetData(nvals int, data []byte) error {
 	return nil
 }
 
+func (d *dictDecoder) discard(n int) (int, error) {
+	n = d.idxDecoder.Discard(n)
+	d.nvals -= n
+	return n, nil
+}
+
 func (d *dictDecoder) decode(out interface{}) (int, error) {
 	n, err := d.idxDecoder.GetBatchWithDict(d.dictValueDecoder, out)
 	d.nvals -= n

--- a/parquet/internal/encoding/delta_length_byte_array.go
+++ b/parquet/internal/encoding/delta_length_byte_array.go
@@ -123,6 +123,16 @@ func (d *DeltaLengthByteArrayDecoder) SetData(nvalues int, data []byte) error {
 	return d.decoder.SetData(nvalues, data[int(dec.bytesRead()):])
 }
 
+func (d *DeltaLengthByteArrayDecoder) Discard(n int) (int, error) {
+	n = min(n, d.nvals)
+	for i := 0; i < n; i++ {
+		d.data = d.data[d.lengths[i]:]
+	}
+	d.nvals -= n
+	d.lengths = d.lengths[n:]
+	return n, nil
+}
+
 // Decode populates the passed in slice with data decoded until it hits the length of out
 // or runs out of values in the column to decode, then returns the number of values actually decoded.
 func (d *DeltaLengthByteArrayDecoder) Decode(out []parquet.ByteArray) (int, error) {

--- a/parquet/internal/encoding/plain_encoder_types.gen.go
+++ b/parquet/internal/encoding/plain_encoder_types.gen.go
@@ -168,6 +168,18 @@ func (PlainInt32Decoder) Type() parquet.Type {
 	return parquet.Types.Int32
 }
 
+func (dec *PlainInt32Decoder) Discard(n int) (int, error) {
+	n = min(n, dec.nvals)
+	nbytes := int64(n) * int64(arrow.Int32SizeBytes)
+	if nbytes > int64(len(dec.data)) || nbytes > math.MaxInt32 {
+		return 0, fmt.Errorf("parquet: eof exception discard plain Int32, nvals: %d, nbytes: %d, datalen: %d", dec.nvals, nbytes, len(dec.data))
+	}
+
+	dec.data = dec.data[nbytes:]
+	dec.nvals -= n
+	return n, nil
+}
+
 // Decode populates the given slice with values from the data to be decoded,
 // decoding the min(len(out), remaining values).
 // It returns the number of values actually decoded and any error encountered.
@@ -271,6 +283,18 @@ type PlainInt64Decoder struct {
 // Type returns the physical type this decoder is able to decode for
 func (PlainInt64Decoder) Type() parquet.Type {
 	return parquet.Types.Int64
+}
+
+func (dec *PlainInt64Decoder) Discard(n int) (int, error) {
+	n = min(n, dec.nvals)
+	nbytes := int64(n) * int64(arrow.Int64SizeBytes)
+	if nbytes > int64(len(dec.data)) || nbytes > math.MaxInt32 {
+		return 0, fmt.Errorf("parquet: eof exception discard plain Int64, nvals: %d, nbytes: %d, datalen: %d", dec.nvals, nbytes, len(dec.data))
+	}
+
+	dec.data = dec.data[nbytes:]
+	dec.nvals -= n
+	return n, nil
 }
 
 // Decode populates the given slice with values from the data to be decoded,
@@ -378,6 +402,18 @@ func (PlainInt96Decoder) Type() parquet.Type {
 	return parquet.Types.Int96
 }
 
+func (dec *PlainInt96Decoder) Discard(n int) (int, error) {
+	n = min(n, dec.nvals)
+	nbytes := int64(n) * int64(parquet.Int96SizeBytes)
+	if nbytes > int64(len(dec.data)) || nbytes > math.MaxInt32 {
+		return 0, fmt.Errorf("parquet: eof exception discard plain Int96, nvals: %d, nbytes: %d, datalen: %d", dec.nvals, nbytes, len(dec.data))
+	}
+
+	dec.data = dec.data[nbytes:]
+	dec.nvals -= n
+	return n, nil
+}
+
 // Decode populates the given slice with values from the data to be decoded,
 // decoding the min(len(out), remaining values).
 // It returns the number of values actually decoded and any error encountered.
@@ -483,6 +519,18 @@ func (PlainFloat32Decoder) Type() parquet.Type {
 	return parquet.Types.Float
 }
 
+func (dec *PlainFloat32Decoder) Discard(n int) (int, error) {
+	n = min(n, dec.nvals)
+	nbytes := int64(n) * int64(arrow.Float32SizeBytes)
+	if nbytes > int64(len(dec.data)) || nbytes > math.MaxInt32 {
+		return 0, fmt.Errorf("parquet: eof exception discard plain Float32, nvals: %d, nbytes: %d, datalen: %d", dec.nvals, nbytes, len(dec.data))
+	}
+
+	dec.data = dec.data[nbytes:]
+	dec.nvals -= n
+	return n, nil
+}
+
 // Decode populates the given slice with values from the data to be decoded,
 // decoding the min(len(out), remaining values).
 // It returns the number of values actually decoded and any error encountered.
@@ -586,6 +634,18 @@ type PlainFloat64Decoder struct {
 // Type returns the physical type this decoder is able to decode for
 func (PlainFloat64Decoder) Type() parquet.Type {
 	return parquet.Types.Double
+}
+
+func (dec *PlainFloat64Decoder) Discard(n int) (int, error) {
+	n = min(n, dec.nvals)
+	nbytes := int64(n) * int64(arrow.Float64SizeBytes)
+	if nbytes > int64(len(dec.data)) || nbytes > math.MaxInt32 {
+		return 0, fmt.Errorf("parquet: eof exception discard plain Float64, nvals: %d, nbytes: %d, datalen: %d", dec.nvals, nbytes, len(dec.data))
+	}
+
+	dec.data = dec.data[nbytes:]
+	dec.nvals -= n
+	return n, nil
 }
 
 // Decode populates the given slice with values from the data to be decoded,

--- a/parquet/internal/encoding/plain_encoder_types.gen.go.tmpl
+++ b/parquet/internal/encoding/plain_encoder_types.gen.go.tmpl
@@ -129,6 +129,18 @@ func (Plain{{.Name}}Decoder) Type() parquet.Type {
   return parquet.Types.{{if .physical}}{{.physical}}{{else}}{{.Name}}{{end}}
 }
 
+func (dec *Plain{{.Name}}Decoder) Discard(n int) (int, error) {
+  n = min(n, dec.nvals)
+  nbytes := int64(n) * int64({{.prefix}}.{{.Name}}SizeBytes)
+  if nbytes > int64(len(dec.data)) || nbytes > math.MaxInt32 {
+    return 0, fmt.Errorf("parquet: eof exception discard plain {{.Name}}, nvals: %d, nbytes: %d, datalen: %d", dec.nvals, nbytes, len(dec.data))
+  }
+
+  dec.data = dec.data[nbytes:]
+  dec.nvals -= n
+  return n, nil
+}
+
 // Decode populates the given slice with values from the data to be decoded,
 // decoding the min(len(out), remaining values).
 // It returns the number of values actually decoded and any error encountered.

--- a/parquet/internal/encoding/typed_encoder.gen.go
+++ b/parquet/internal/encoding/typed_encoder.gen.go
@@ -19,6 +19,7 @@
 package encoding
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -193,6 +194,18 @@ type DictInt32Decoder struct {
 // Type returns the underlying physical type that can be decoded with this decoder
 func (DictInt32Decoder) Type() parquet.Type {
 	return parquet.Types.Int32
+}
+
+func (d *DictInt32Decoder) Discard(n int) (int, error) {
+	n = min(n, d.nvals)
+	discarded, err := d.discard(n)
+	if err != nil {
+		return discarded, err
+	}
+	if n != discarded {
+		return discarded, errors.New("parquet: dict eof exception")
+	}
+	return n, nil
 }
 
 // Decode populates the passed in slice with min(len(out), remaining values) values,
@@ -436,6 +449,18 @@ func (DictInt64Decoder) Type() parquet.Type {
 	return parquet.Types.Int64
 }
 
+func (d *DictInt64Decoder) Discard(n int) (int, error) {
+	n = min(n, d.nvals)
+	discarded, err := d.discard(n)
+	if err != nil {
+		return discarded, err
+	}
+	if n != discarded {
+		return discarded, errors.New("parquet: dict eof exception")
+	}
+	return n, nil
+}
+
 // Decode populates the passed in slice with min(len(out), remaining values) values,
 // decoding using the dictionary to get the actual values. Returns the number of values
 // actually decoded and any error encountered.
@@ -649,6 +674,18 @@ type DictInt96Decoder struct {
 // Type returns the underlying physical type that can be decoded with this decoder
 func (DictInt96Decoder) Type() parquet.Type {
 	return parquet.Types.Int96
+}
+
+func (d *DictInt96Decoder) Discard(n int) (int, error) {
+	n = min(n, d.nvals)
+	discarded, err := d.discard(n)
+	if err != nil {
+		return discarded, err
+	}
+	if n != discarded {
+		return discarded, errors.New("parquet: dict eof exception")
+	}
+	return n, nil
 }
 
 // Decode populates the passed in slice with min(len(out), remaining values) values,
@@ -880,6 +917,18 @@ func (DictFloat32Decoder) Type() parquet.Type {
 	return parquet.Types.Float
 }
 
+func (d *DictFloat32Decoder) Discard(n int) (int, error) {
+	n = min(n, d.nvals)
+	discarded, err := d.discard(n)
+	if err != nil {
+		return discarded, err
+	}
+	if n != discarded {
+		return discarded, errors.New("parquet: dict eof exception")
+	}
+	return n, nil
+}
+
 // Decode populates the passed in slice with min(len(out), remaining values) values,
 // decoding using the dictionary to get the actual values. Returns the number of values
 // actually decoded and any error encountered.
@@ -1107,6 +1156,18 @@ type DictFloat64Decoder struct {
 // Type returns the underlying physical type that can be decoded with this decoder
 func (DictFloat64Decoder) Type() parquet.Type {
 	return parquet.Types.Double
+}
+
+func (d *DictFloat64Decoder) Discard(n int) (int, error) {
+	n = min(n, d.nvals)
+	discarded, err := d.discard(n)
+	if err != nil {
+		return discarded, err
+	}
+	if n != discarded {
+		return discarded, errors.New("parquet: dict eof exception")
+	}
+	return n, nil
 }
 
 // Decode populates the passed in slice with min(len(out), remaining values) values,
@@ -1378,6 +1439,18 @@ func (DictByteArrayDecoder) Type() parquet.Type {
 	return parquet.Types.ByteArray
 }
 
+func (d *DictByteArrayDecoder) Discard(n int) (int, error) {
+	n = min(n, d.nvals)
+	discarded, err := d.discard(n)
+	if err != nil {
+		return discarded, err
+	}
+	if n != discarded {
+		return discarded, errors.New("parquet: dict eof exception")
+	}
+	return n, nil
+}
+
 // Decode populates the passed in slice with min(len(out), remaining values) values,
 // decoding using the dictionary to get the actual values. Returns the number of values
 // actually decoded and any error encountered.
@@ -1559,6 +1632,18 @@ type DictFixedLenByteArrayDecoder struct {
 // Type returns the underlying physical type that can be decoded with this decoder
 func (DictFixedLenByteArrayDecoder) Type() parquet.Type {
 	return parquet.Types.FixedLenByteArray
+}
+
+func (d *DictFixedLenByteArrayDecoder) Discard(n int) (int, error) {
+	n = min(n, d.nvals)
+	discarded, err := d.discard(n)
+	if err != nil {
+		return discarded, err
+	}
+	if n != discarded {
+		return discarded, errors.New("parquet: dict eof exception")
+	}
+	return n, nil
 }
 
 // Decode populates the passed in slice with min(len(out), remaining values) values,

--- a/parquet/internal/encoding/typed_encoder.gen.go.tmpl
+++ b/parquet/internal/encoding/typed_encoder.gen.go.tmpl
@@ -276,6 +276,18 @@ func (Dict{{.Name}}Decoder) Type() parquet.Type {
   return parquet.Types.{{if .physical}}{{.physical}}{{else}}{{.Name}}{{end}}
 }
 
+func (d *Dict{{.Name}}Decoder) Discard(n int) (int, error) {
+  n = min(n, d.nvals)
+  discarded, err := d.discard(n)
+  if err != nil {
+    return discarded, err
+  }
+  if n != discarded {
+    return discarded, errors.New("parquet: dict eof exception")
+  }
+  return n, nil
+}
+
 // Decode populates the passed in slice with min(len(out), remaining values) values,
 // decoding using the dictionary to get the actual values. Returns the number of values
 // actually decoded and any error encountered.

--- a/parquet/internal/encoding/types.go
+++ b/parquet/internal/encoding/types.go
@@ -40,6 +40,10 @@ type TypedDecoder interface {
 	ValuesLeft() int
 	// Type returns the physical type this can decode.
 	Type() parquet.Type
+	// Discard the next n values from the decoder, returning the actual number
+	// of values that were able to be discarded (should be equal to n unless an
+	// error occurs).
+	Discard(n int) (int, error)
 }
 
 // DictDecoder is a special TypedDecoder which implements dictionary decoding


### PR DESCRIPTION
### Rationale for this change
Building towards proper support for Skipping rows to address #278 we need to be able to efficiently discard values from decoders rather than actively having to allocate a buffer and read into it. This makes the skipping/seeking within a page more efficient.

### What changes are included in this PR?
Adding a new `Discard` method to the `Decoder` interface along with implementations for all the various decoders

### Are these changes tested?
Yes, tests are added for the various decoders.

### Are there any user-facing changes?
No, this is in an internal package.
