### PR TITLE
feat(parquet/file): Add SeekToRow for Column readers

### DIFF
--- a/parquet/file/column_reader.go
+++ b/parquet/file/column_reader.go
@@ -87,6 +87,9 @@ type ColumnChunkReader interface {
 	// it encountered. Otherwise this will be nil if it's just the end of the
 	// column
 	Err() error
+
+	SeekToRow(rowIdx int64) error
+
 	// Skip buffered values
 	consumeBufferedValues(int64)
 	// number of available buffered values that have not been decoded yet
@@ -113,7 +116,8 @@ type ColumnChunkReader interface {
 }
 
 type columnChunkReader struct {
-	descr             *schema.Column
+	descr *schema.Column
+
 	rdr               PageReader
 	repetitionDecoder encoding.LevelDecoder
 	definitionDecoder encoding.LevelDecoder
@@ -135,8 +139,39 @@ type columnChunkReader struct {
 	// is set when an error is encountered
 	err          error
 	defLvlBuffer []int16
+	repLvlBuffer []int16
 
 	newDictionary bool
+}
+
+func newTypedColumnChunkReader(base columnChunkReader) ColumnChunkReader {
+	switch base.descr.PhysicalType() {
+	case parquet.Types.FixedLenByteArray:
+		base.decoderTraits = &encoding.FixedLenByteArrayDecoderTraits
+		return &FixedLenByteArrayColumnChunkReader{base}
+	case parquet.Types.Float:
+		base.decoderTraits = &encoding.Float32DecoderTraits
+		return &Float32ColumnChunkReader{base}
+	case parquet.Types.Double:
+		base.decoderTraits = &encoding.Float64DecoderTraits
+		return &Float64ColumnChunkReader{base}
+	case parquet.Types.ByteArray:
+		base.decoderTraits = &encoding.ByteArrayDecoderTraits
+		return &ByteArrayColumnChunkReader{base}
+	case parquet.Types.Int32:
+		base.decoderTraits = &encoding.Int32DecoderTraits
+		return &Int32ColumnChunkReader{base}
+	case parquet.Types.Int64:
+		base.decoderTraits = &encoding.Int64DecoderTraits
+		return &Int64ColumnChunkReader{base}
+	case parquet.Types.Int96:
+		base.decoderTraits = &encoding.Int96DecoderTraits
+		return &Int96ColumnChunkReader{base}
+	case parquet.Types.Boolean:
+		base.decoderTraits = &encoding.BooleanDecoderTraits
+		return &BooleanColumnChunkReader{base}
+	}
+	return nil
 }
 
 // NewColumnReader returns a column reader for the provided column initialized with the given pagereader that will
@@ -145,6 +180,9 @@ type columnChunkReader struct {
 // In addition to the page reader and allocator, a pointer to a shared sync.Pool is expected to provide buffers for temporary
 // usage to minimize allocations. The bufferPool should provide *memory.Buffer objects that can be resized as necessary, buffers
 // should have `ResizeNoShrink(0)` called on them before being put back into the pool.
+//
+// Deprecated: This function will be removed from the public interface soon as it is currently unsafe to use
+// outside of this package.
 func NewColumnReader(descr *schema.Column, pageReader PageReader, mem memory.Allocator, bufferPool *sync.Pool) ColumnChunkReader {
 	base := columnChunkReader{descr: descr, rdr: pageReader, mem: mem, decoders: make(map[format.Encoding]encoding.TypedDecoder), bufferPool: bufferPool}
 	switch descr.PhysicalType() {
@@ -197,6 +235,15 @@ func (c *columnChunkReader) getDefLvlBuffer(sz int64) []int16 {
 	return c.defLvlBuffer[:sz]
 }
 
+func (c *columnChunkReader) getRepLvlBuffer(sz int64) []int16 {
+	if int64(cap(c.repLvlBuffer)) < sz {
+		c.repLvlBuffer = make([]int16, sz)
+		return c.repLvlBuffer
+	}
+
+	return c.repLvlBuffer[:sz]
+}
+
 // HasNext returns whether there is more data to be read in this column
 // and row group.
 func (c *columnChunkReader) HasNext() bool {
@@ -204,6 +251,23 @@ func (c *columnChunkReader) HasNext() bool {
 		return c.readNewPage() && c.numBuffered != 0
 	}
 	return true
+}
+
+func (c *columnChunkReader) readDictionary() error {
+	if c.newDictionary {
+		return nil
+	}
+
+	page, err := c.pager().GetDictionaryPage()
+	if err != nil {
+		return err
+	}
+
+	if page != nil {
+		return c.configureDict(page)
+	}
+
+	return nil
 }
 
 func (c *columnChunkReader) configureDict(page *DictionaryPage) error {
@@ -233,6 +297,30 @@ func (c *columnChunkReader) configureDict(page *DictionaryPage) error {
 	return nil
 }
 
+func (c *columnChunkReader) processPage() (bool, error) {
+	var (
+		err        error
+		lvlByteLen int64
+	)
+	switch p := c.curPage.(type) {
+	case *DictionaryPage:
+		return false, c.configureDict(p)
+	case *DataPageV1:
+		lvlByteLen, err = c.initLevelDecodersV1(p, p.repLvlEncoding, p.defLvlEncoding)
+	case *DataPageV2:
+		lvlByteLen, err = c.initLevelDecodersV2(p)
+	default:
+		// we can skip non-data pages
+		return false, nil
+	}
+
+	if err != nil {
+		return true, err
+	}
+
+	return true, c.initDataDecoder(c.curPage, lvlByteLen)
+}
+
 // read a new page from the page reader
 func (c *columnChunkReader) readNewPage() bool {
 	for c.rdr.Next() { // keep going until we get a data page
@@ -241,31 +329,15 @@ func (c *columnChunkReader) readNewPage() bool {
 			break
 		}
 
-		var lvlByteLen int64
-		switch p := c.curPage.(type) {
-		case *DictionaryPage:
-			if err := c.configureDict(p); err != nil {
-				c.err = err
-				return false
-			}
-			continue
-		case *DataPageV1:
-			lvlByteLen, c.err = c.initLevelDecodersV1(p, p.repLvlEncoding, p.defLvlEncoding)
-			if c.err != nil {
-				return false
-			}
-		case *DataPageV2:
-			lvlByteLen, c.err = c.initLevelDecodersV2(p)
-			if c.err != nil {
-				return false
-			}
-		default:
-			// we can skip non-data pages
-			continue
+		gotDataPage, err := c.processPage()
+		if err != nil {
+			c.err = err
+			return false
 		}
 
-		c.err = c.initDataDecoder(c.curPage, lvlByteLen)
-		return c.err == nil
+		if gotDataPage {
+			return true
+		}
 	}
 	c.err = c.rdr.Err()
 	return false
@@ -283,6 +355,9 @@ func (c *columnChunkReader) initLevelDecodersV2(page *DataPageV2) (int64, error)
 
 	if c.descr.MaxRepetitionLevel() > 0 {
 		c.repetitionDecoder.SetDataV2(page.repLvlByteLen, c.descr.MaxRepetitionLevel(), int(c.numBuffered), buf)
+		if c.repLvlBuffer != nil {
+			c.repLvlBuffer = c.repLvlBuffer[:0]
+		}
 	}
 	// ARROW-17453: Some writers will write repetition levels even when
 	// the max repetition level is 0, so we should respect the value
@@ -339,6 +414,11 @@ func (c *columnChunkReader) initDataDecoder(page Page, lvlByteLen int64) error {
 	encoding := page.Encoding()
 
 	if isDictIndexEncoding(encoding) {
+		// if we're seeking or otherwise skipping pages, we may not have read
+		// the dictionary page in yet, so let's ensure we got it if one exists
+		if err := c.readDictionary(); err != nil {
+			return err
+		}
 		encoding = format.Encoding_RLE_DICTIONARY
 	}
 
@@ -396,6 +476,9 @@ func (c *columnChunkReader) readRepetitionLevels(levels []int16) int {
 		return 0
 	}
 
+	if len(c.repLvlBuffer) > 0 {
+		return copy(levels, c.repLvlBuffer[c.numDecoded:])
+	}
 	nlevels, _ := c.repetitionDecoder.Decode(levels)
 	return nlevels
 }
@@ -436,49 +519,114 @@ func (c *columnChunkReader) determineNumToRead(batchLen int64, defLvls, repLvls 
 	return
 }
 
-// skipValues some number of rows using readFn as the function to read the data and throw it away.
-// If we can skipValues a whole page based on its metadata, then we do so, otherwise we read the
-// page until we have skipped the number of rows desired.
-func (c *columnChunkReader) skipValues(nvalues int64, readFn func(batch int64, buf []byte) (int64, error)) (int64, error) {
-	var err error
-	toskip := nvalues
-	for c.HasNext() && toskip > 0 {
-		// if number to skip is more than the number of undecoded values, skip the page
-		if toskip > (c.numBuffered - c.numDecoded) {
-			toskip -= c.numBuffered - c.numDecoded
-			c.numDecoded = c.numBuffered
-		} else {
-			var (
-				batchSize int64 = 1024
-				valsRead  int64 = 0
-			)
+// SeekToRow will seek to the row index provided in the column chunk. If
+// the metadata contains an OffsetIndex for skipping pages based on row indexes
+// then the pager will use that to skip to the correct page.
+//
+// If there is no OffsetIndex, then the pager will read each page until it
+// finds the page that contains the desired row index, and the Column Chunk
+// reader will discard values until it reaches the desired row index according
+// to the definition and repetition levels.
+func (c *columnChunkReader) SeekToRow(rowIdx int64) error {
+	if err := c.pager().SeekToPageWithRow(rowIdx); err != nil {
+		return err
+	}
 
-			scratch := c.bufferPool.Get().(*memory.Buffer)
-			defer func() {
-				scratch.ResizeNoShrink(0)
-				c.bufferPool.Put(scratch)
-			}()
-			bufMult := 1
-			if c.descr.PhysicalType() == parquet.Types.Boolean {
-				// for bools, BytesRequired returns 1 byte per 8 bool, but casting []byte to []bool requires 1 byte per 1 bool
-				bufMult = 8
+	c.numBuffered, c.numDecoded = 0, 0
+	c.curPage = c.rdr.Page()
+	if c.curPage == nil {
+		c.err = c.rdr.Err()
+		return c.err
+	}
+
+	gotDataPage, err := c.processPage()
+	if err != nil {
+		c.err = err
+		return err
+	}
+
+	if !gotDataPage {
+		c.readNewPage()
+	}
+
+	return c.skipRows(rowIdx - c.curPage.(DataPage).FirstRowIndex())
+}
+
+func (c *columnChunkReader) skipRows(nrows int64) error {
+	toSkip := nrows
+	for c.HasNext() && toSkip > 0 {
+		// if there are no repetition levels, then this is easy! each level
+		// is one row so we just use the definition levels to determine
+		// the number of physical values to discard!
+		if c.descr.MaxRepetitionLevel() == 0 {
+			if toSkip >= (c.numBuffered - c.numDecoded) {
+				toSkip -= c.numBuffered - c.numDecoded
+				c.numDecoded = c.numBuffered
+				continue
 			}
-			scratch.Reserve(c.decoderTraits.BytesRequired(int(batchSize) * bufMult))
 
-			for {
-				batchSize = utils.Min(batchSize, toskip)
-				valsRead, err = readFn(batchSize, scratch.Buf())
-				toskip -= valsRead
-				if valsRead <= 0 || toskip <= 0 || err != nil {
-					break
+			ndefs, nvals, err := c.determineNumToRead(toSkip, nil, nil)
+			if err != nil {
+				c.err = err
+				return err
+			}
+
+			skipped, err := c.curDecoder.Discard(int(nvals))
+			if err != nil {
+				c.err = err
+				return err
+			}
+
+			skipped = max(ndefs, skipped)
+
+			toSkip -= int64(skipped)
+			c.consumeBufferedValues(int64(skipped))
+		} else {
+			// with repetition levels, we have to check them to determine
+			// how many rows to skip. we can't just skip the number of values
+			// because there could be multiple values per row. So we read in
+			// the repetition levels for the entire page at once and then go
+			// through them to find the right row.
+			repLvls := c.getRepLvlBuffer(c.numBuffered)
+			nreps, _ := c.repetitionDecoder.Decode(repLvls)
+
+			rowsSkipped := int64(0)
+			levelsToSkip := -1
+			for i, def := range repLvls[:nreps] {
+				if def == 0 {
+					if rowsSkipped == toSkip {
+						levelsToSkip = i
+						break
+					}
+					rowsSkipped++
 				}
 			}
+
+			if levelsToSkip == -1 {
+				toSkip -= rowsSkipped
+				c.numBuffered, c.numDecoded = 0, 0
+				continue
+			}
+
+			var toSkip int64
+			if c.descr.MaxDefinitionLevel() > 0 {
+				defLvls := c.getDefLvlBuffer(int64(levelsToSkip))
+				_, toSkip = c.readDefinitionLevels(defLvls)
+			} else {
+				toSkip = int64(levelsToSkip)
+			}
+
+			skipped, err := c.curDecoder.Discard(int(toSkip))
+			if err != nil {
+				c.err = err
+				return err
+			}
+
+			toSkip -= int64(skipped)
+			c.consumeBufferedValues(int64(levelsToSkip))
 		}
 	}
-	if c.err != nil {
-		err = c.err
-	}
-	return nvalues - toskip, err
+	return nil
 }
 
 type readerFunc func(int64, int64) (int, error)
@@ -498,7 +646,7 @@ func (c *columnChunkReader) readBatch(batchSize int64, defLvls, repLvls []int16,
 		toRead int64
 	)
 
-	for c.HasNext() && totalLvls < batchSize && err == nil {
+	for totalLvls < batchSize && c.HasNext() && err == nil {
 		if defLvls != nil {
 			defs = defLvls[totalLvls:]
 		}

--- a/parquet/file/column_reader.go
+++ b/parquet/file/column_reader.go
@@ -608,15 +608,15 @@ func (c *columnChunkReader) skipRows(nrows int64) error {
 				continue
 			}
 
-			var toSkip int64
+			var valuesToSkip int64
 			if c.descr.MaxDefinitionLevel() > 0 {
 				defLvls := c.getDefLvlBuffer(int64(levelsToSkip))
-				_, toSkip = c.readDefinitionLevels(defLvls)
+				_, valuesToSkip = c.readDefinitionLevels(defLvls)
 			} else {
-				toSkip = int64(levelsToSkip)
+				valuesToSkip = int64(levelsToSkip)
 			}
 
-			skipped, err := c.curDecoder.Discard(int(toSkip))
+			skipped, err := c.curDecoder.Discard(int(valuesToSkip))
 			if err != nil {
 				c.err = err
 				return err

--- a/parquet/file/column_reader_types.gen.go
+++ b/parquet/file/column_reader_types.gen.go
@@ -19,9 +19,6 @@
 package file
 
 import (
-	"unsafe"
-
-	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/internal/encoding"
 )
@@ -35,14 +32,8 @@ type Int32ColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *Int32ColumnChunkReader) Skip(nvalues int64) (int64, error) {
-	return cr.columnChunkReader.skipValues(nvalues,
-		func(batch int64, buf []byte) (int64, error) {
-			vals, _, err := cr.ReadBatch(batch,
-				arrow.Int32Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf))
-			return vals, err
-		})
+	err := cr.columnChunkReader.skipRows(nvalues)
+	return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.
@@ -69,14 +60,8 @@ type Int64ColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *Int64ColumnChunkReader) Skip(nvalues int64) (int64, error) {
-	return cr.columnChunkReader.skipValues(nvalues,
-		func(batch int64, buf []byte) (int64, error) {
-			vals, _, err := cr.ReadBatch(batch,
-				arrow.Int64Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf))
-			return vals, err
-		})
+	err := cr.columnChunkReader.skipRows(nvalues)
+	return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.
@@ -103,14 +88,8 @@ type Int96ColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *Int96ColumnChunkReader) Skip(nvalues int64) (int64, error) {
-	return cr.columnChunkReader.skipValues(nvalues,
-		func(batch int64, buf []byte) (int64, error) {
-			vals, _, err := cr.ReadBatch(batch,
-				parquet.Int96Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf))
-			return vals, err
-		})
+	err := cr.columnChunkReader.skipRows(nvalues)
+	return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.
@@ -137,14 +116,8 @@ type Float32ColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *Float32ColumnChunkReader) Skip(nvalues int64) (int64, error) {
-	return cr.columnChunkReader.skipValues(nvalues,
-		func(batch int64, buf []byte) (int64, error) {
-			vals, _, err := cr.ReadBatch(batch,
-				arrow.Float32Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf))
-			return vals, err
-		})
+	err := cr.columnChunkReader.skipRows(nvalues)
+	return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.
@@ -171,14 +144,8 @@ type Float64ColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *Float64ColumnChunkReader) Skip(nvalues int64) (int64, error) {
-	return cr.columnChunkReader.skipValues(nvalues,
-		func(batch int64, buf []byte) (int64, error) {
-			vals, _, err := cr.ReadBatch(batch,
-				arrow.Float64Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf))
-			return vals, err
-		})
+	err := cr.columnChunkReader.skipRows(nvalues)
+	return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.
@@ -205,14 +172,8 @@ type BooleanColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *BooleanColumnChunkReader) Skip(nvalues int64) (int64, error) {
-	return cr.columnChunkReader.skipValues(nvalues,
-		func(batch int64, buf []byte) (int64, error) {
-			vals, _, err := cr.ReadBatch(batch,
-				*(*[]bool)(unsafe.Pointer(&buf)),
-				nil,
-				nil)
-			return vals, err
-		})
+	err := cr.columnChunkReader.skipRows(nvalues)
+	return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.
@@ -239,14 +200,8 @@ type ByteArrayColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *ByteArrayColumnChunkReader) Skip(nvalues int64) (int64, error) {
-	return cr.columnChunkReader.skipValues(nvalues,
-		func(batch int64, buf []byte) (int64, error) {
-			vals, _, err := cr.ReadBatch(batch,
-				parquet.ByteArrayTraits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf))
-			return vals, err
-		})
+	err := cr.columnChunkReader.skipRows(nvalues)
+	return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.
@@ -273,14 +228,8 @@ type FixedLenByteArrayColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *FixedLenByteArrayColumnChunkReader) Skip(nvalues int64) (int64, error) {
-	return cr.columnChunkReader.skipValues(nvalues,
-		func(batch int64, buf []byte) (int64, error) {
-			vals, _, err := cr.ReadBatch(batch,
-				parquet.FixedLenByteArrayTraits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf),
-				arrow.Int16Traits.CastFromBytes(buf))
-			return vals, err
-		})
+	err := cr.columnChunkReader.skipRows(nvalues)
+	return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.

--- a/parquet/file/column_reader_types.gen.go.tmpl
+++ b/parquet/file/column_reader_types.gen.go.tmpl
@@ -31,20 +31,8 @@ type {{.Name}}ColumnChunkReader struct {
 // Skip skips the next nvalues so that the next call to ReadBatch
 // will start reading *after* the skipped values.
 func (cr *{{.Name}}ColumnChunkReader) Skip(nvalues int64) (int64, error) {
-  return cr.columnChunkReader.skipValues(nvalues,
-    func(batch int64, buf []byte) (int64, error) {
-      vals, _, err := cr.ReadBatch(batch,
-        {{- if ne .Name "Boolean"}}
-        {{.prefix}}.{{.Name}}Traits.CastFromBytes(buf),
-        arrow.Int16Traits.CastFromBytes(buf),
-        arrow.Int16Traits.CastFromBytes(buf))
-        {{- else}}
-        *(*[]bool)(unsafe.Pointer(&buf)),
-        nil,
-        nil)
-        {{- end}}
-      return vals, err
-    })
+  err := cr.columnChunkReader.skipRows(nvalues)
+  return nvalues, err
 }
 
 // ReadBatch reads batchSize values from the column.

--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -120,7 +120,16 @@ func NewParquetReader(r parquet.ReaderAtSeeker, opts ...ReadOption) (*Reader, er
 	}
 
 	if f.metadata == nil {
-		return f, f.parseMetaData()
+		if err := f.parseMetaData(); err != nil {
+			return nil, err
+		}
+	}
+
+	f.pageIndexReader = &metadata.PageIndexReader{
+		Input:        f.r,
+		Props:        f.props,
+		FileMetadata: f.metadata,
+		Decryptor:    f.fileDecryptor,
 	}
 
 	return f, nil
@@ -305,24 +314,15 @@ func (f *Reader) RowGroup(i int) *RowGroupReader {
 	rg := f.metadata.RowGroups[i]
 
 	return &RowGroupReader{
-		fileMetadata:    f.metadata,
-		rgMetadata:      metadata.NewRowGroupMetaData(rg, f.metadata.Schema, f.WriterVersion(), f.fileDecryptor),
-		props:           f.props,
-		r:               f.r,
-		fileDecryptor:   f.fileDecryptor,
-		pageIndexReader: f.GetPageIndexReader(),
-		bufferPool:      &f.bufferPool,
+		fileMetadata:  f.metadata,
+		rgMetadata:    metadata.NewRowGroupMetaData(rg, f.metadata.Schema, f.WriterVersion(), f.fileDecryptor),
+		props:         f.props,
+		r:             f.r,
+		fileDecryptor: f.fileDecryptor,
+		bufferPool:    &f.bufferPool,
 	}
 }
 
 func (f *Reader) GetPageIndexReader() *metadata.PageIndexReader {
-	if f.pageIndexReader == nil {
-		f.pageIndexReader = &metadata.PageIndexReader{
-			Input:        f.r,
-			Props:        f.props,
-			FileMetadata: f.metadata,
-			Decryptor:    f.fileDecryptor,
-		}
-	}
 	return f.pageIndexReader
 }

--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -305,12 +305,13 @@ func (f *Reader) RowGroup(i int) *RowGroupReader {
 	rg := f.metadata.RowGroups[i]
 
 	return &RowGroupReader{
-		fileMetadata:  f.metadata,
-		rgMetadata:    metadata.NewRowGroupMetaData(rg, f.metadata.Schema, f.WriterVersion(), f.fileDecryptor),
-		props:         f.props,
-		r:             f.r,
-		fileDecryptor: f.fileDecryptor,
-		bufferPool:    &f.bufferPool,
+		fileMetadata:    f.metadata,
+		rgMetadata:      metadata.NewRowGroupMetaData(rg, f.metadata.Schema, f.WriterVersion(), f.fileDecryptor),
+		props:           f.props,
+		r:               f.r,
+		fileDecryptor:   f.fileDecryptor,
+		pageIndexReader: f.GetPageIndexReader(),
+		bufferPool:      &f.bufferPool,
 	}
 }
 

--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -314,12 +314,13 @@ func (f *Reader) RowGroup(i int) *RowGroupReader {
 	rg := f.metadata.RowGroups[i]
 
 	return &RowGroupReader{
-		fileMetadata:  f.metadata,
-		rgMetadata:    metadata.NewRowGroupMetaData(rg, f.metadata.Schema, f.WriterVersion(), f.fileDecryptor),
-		props:         f.props,
-		r:             f.r,
-		fileDecryptor: f.fileDecryptor,
-		bufferPool:    &f.bufferPool,
+		fileMetadata:    f.metadata,
+		rgMetadata:      metadata.NewRowGroupMetaData(rg, f.metadata.Schema, f.WriterVersion(), f.fileDecryptor),
+		props:           f.props,
+		r:               f.r,
+		fileDecryptor:   f.fileDecryptor,
+		bufferPool:      &f.bufferPool,
+		pageIndexReader: f.pageIndexReader,
 	}
 }
 

--- a/parquet/file/file_reader_mmap_windows.go
+++ b/parquet/file/file_reader_mmap_windows.go
@@ -25,6 +25,6 @@ import (
 	"github.com/apache/arrow-go/v18/parquet"
 )
 
-func mmapOpen(filename string) (parquet.ReaderAtSeeker, error) {
+func mmapOpen(_ string) (parquet.ReaderAtSeeker, error) {
 	return nil, errors.New("mmap not implemented on windows")
 }

--- a/parquet/file/record_reader.go
+++ b/parquet/file/record_reader.go
@@ -132,12 +132,16 @@ type primitiveRecordReader struct {
 
 func createPrimitiveRecordReader(descr *schema.Column, mem memory.Allocator, bufferPool *sync.Pool) primitiveRecordReader {
 	return primitiveRecordReader{
-		ColumnChunkReader: NewColumnReader(descr, nil, mem, bufferPool),
-		values:            memory.NewResizableBuffer(mem),
-		validBits:         memory.NewResizableBuffer(mem),
-		mem:               mem,
-		refCount:          1,
-		useValues:         descr.PhysicalType() != parquet.Types.ByteArray && descr.PhysicalType() != parquet.Types.FixedLenByteArray,
+		ColumnChunkReader: newTypedColumnChunkReader(columnChunkReader{
+			descr:      descr,
+			mem:        mem,
+			bufferPool: bufferPool,
+		}),
+		values:    memory.NewResizableBuffer(mem),
+		validBits: memory.NewResizableBuffer(mem),
+		mem:       mem,
+		refCount:  1,
+		useValues: descr.PhysicalType() != parquet.Types.ByteArray && descr.PhysicalType() != parquet.Types.FixedLenByteArray,
 	}
 }
 

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/apache/arrow-go/v18/internal/utils"
 	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/internal/encoding"
 	"github.com/apache/arrow-go/v18/parquet/internal/encryption"
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
 	"github.com/apache/arrow-go/v18/parquet/metadata"
 	"golang.org/x/xerrors"
 )
@@ -39,7 +41,9 @@ type RowGroupReader struct {
 	props         *parquet.ReaderProperties
 	fileDecryptor encryption.FileDecryptor
 
-	bufferPool *sync.Pool
+	pageIndexReader   *metadata.PageIndexReader
+	rgPageIndexReader *metadata.RowGroupPageIndexReader
+	bufferPool        *sync.Pool
 }
 
 // MetaData returns the metadata of the current Row Group
@@ -67,13 +71,27 @@ func (r *RowGroupReader) Column(i int) (ColumnChunkReader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parquet: unable to initialize page reader: %w", err)
 	}
-	return NewColumnReader(descr, pageRdr, r.props.Allocator(), r.bufferPool), nil
+	return newTypedColumnChunkReader(columnChunkReader{
+		descr:      descr,
+		rdr:        pageRdr,
+		mem:        r.props.Allocator(),
+		bufferPool: r.bufferPool,
+		decoders:   make(map[format.Encoding]encoding.TypedDecoder),
+	}), nil
 }
 
 func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 	col, err := r.rgMetadata.ColumnChunk(i)
 	if err != nil {
 		return nil, err
+	}
+
+	if r.rgPageIndexReader == nil {
+		rgIdx, err := r.pageIndexReader.RowGroup(int(r.rgMetadata.Ordinal()))
+		if err != nil {
+			return nil, err
+		}
+		r.rgPageIndexReader = rgIdx
 	}
 
 	colStart := col.DataPageOffset()
@@ -106,7 +124,16 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 
 	cryptoMetadata := col.CryptoMetadata()
 	if cryptoMetadata == nil {
-		return NewPageReader(stream, col.NumValues(), col.Compression(), r.props.Allocator(), nil)
+		pr := &serializedPageReader{
+			r:                 stream,
+			chunk:             col,
+			colIdx:            i,
+			pgIndexReader:     r.rgPageIndexReader,
+			maxPageHeaderSize: defaultMaxPageHeaderSize,
+			nrows:             col.NumValues(),
+			mem:               r.props.Allocator(),
+		}
+		return pr, pr.init(col.Compression(), nil)
 	}
 
 	if r.fileDecryptor == nil {
@@ -126,7 +153,16 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 			MetaDecryptor:                  r.fileDecryptor.GetFooterDecryptorForColumnMeta(""),
 			DataDecryptor:                  r.fileDecryptor.GetFooterDecryptorForColumnData(""),
 		}
-		return NewPageReader(stream, col.NumValues(), col.Compression(), r.props.Allocator(), &ctx)
+		pr := &serializedPageReader{
+			r:                 stream,
+			chunk:             col,
+			colIdx:            i,
+			pgIndexReader:     r.rgPageIndexReader,
+			maxPageHeaderSize: defaultMaxPageHeaderSize,
+			nrows:             col.NumValues(),
+			mem:               r.props.Allocator(),
+		}
+		return pr, pr.init(col.Compression(), &ctx)
 	}
 
 	// column encrypted with it's own key
@@ -140,5 +176,14 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 		MetaDecryptor:                  r.fileDecryptor.GetColumnMetaDecryptor(parquet.ColumnPath(columnPath).String(), string(columnKeyMeta), ""),
 		DataDecryptor:                  r.fileDecryptor.GetColumnDataDecryptor(parquet.ColumnPath(columnPath).String(), string(columnKeyMeta), ""),
 	}
-	return NewPageReader(stream, col.NumValues(), col.Compression(), r.props.Allocator(), &ctx)
+	pr := &serializedPageReader{
+		r:                 stream,
+		chunk:             col,
+		colIdx:            i,
+		pgIndexReader:     r.rgPageIndexReader,
+		maxPageHeaderSize: defaultMaxPageHeaderSize,
+		nrows:             col.NumValues(),
+		mem:               r.props.Allocator(),
+	}
+	return pr, pr.init(col.Compression(), &ctx)
 }

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -161,6 +161,7 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 			maxPageHeaderSize: defaultMaxPageHeaderSize,
 			nrows:             col.NumValues(),
 			mem:               r.props.Allocator(),
+			cryptoCtx:         ctx,
 		}
 		return pr, pr.init(col.Compression(), &ctx)
 	}
@@ -184,6 +185,7 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 		maxPageHeaderSize: defaultMaxPageHeaderSize,
 		nrows:             col.NumValues(),
 		mem:               r.props.Allocator(),
+		cryptoCtx:         ctx,
 	}
 	return pr, pr.init(col.Compression(), &ctx)
 }

--- a/parquet/metadata/page_index.go
+++ b/parquet/metadata/page_index.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sync"
 
 	"github.com/JohnCGriffin/overflow"
 	"github.com/apache/arrow-go/v18/arrow"
@@ -293,12 +294,29 @@ type RowGroupPageIndexReader struct {
 	// buffers to hold raw bytes of page index
 	// will be lazily set when the corresponding page index is accessed
 	colIndexBuffer, offsetIndexBuffer []byte
+
+	// cache of column indexes
+	colIndexes map[int]ColumnIndex
+	// cache of offset indices
+	offsetIndices map[int]OffsetIndex
+	mx            sync.Mutex
 }
 
 func (r *RowGroupPageIndexReader) GetColumnIndex(i int) (ColumnIndex, error) {
 	if i < 0 || i >= r.rowGroupMetadata.NumColumns() {
 		return nil, fmt.Errorf("%w: invalid column index at column ordinal %d",
 			arrow.ErrInvalid, i)
+	}
+
+	r.mx.Lock()
+	defer r.mx.Unlock()
+
+	if r.colIndexes == nil {
+		r.colIndexes = make(map[int]ColumnIndex)
+	} else {
+		if idx, ok := r.colIndexes[i]; ok {
+			return idx, nil
+		}
 	}
 
 	colChunk, err := r.rowGroupMetadata.ColumnChunk(i)
@@ -334,13 +352,26 @@ func (r *RowGroupPageIndexReader) GetColumnIndex(i int) (ColumnIndex, error) {
 			int16(i), encryption.ColumnIndexModule)
 	}
 
-	return NewColumnIndex(descr, r.colIndexBuffer[bufferOffset:], r.props, decryptor), nil
+	idx := NewColumnIndex(descr, r.colIndexBuffer[bufferOffset:], r.props, decryptor)
+	r.colIndexes[i] = idx
+	return idx, nil
 }
 
 func (r *RowGroupPageIndexReader) GetOffsetIndex(i int) (OffsetIndex, error) {
 	if i < 0 || i >= r.rowGroupMetadata.NumColumns() {
 		return nil, fmt.Errorf("%w: invalid column index at column ordinal %d",
 			arrow.ErrInvalid, i)
+	}
+
+	r.mx.Lock()
+	defer r.mx.Unlock()
+
+	if r.offsetIndices == nil {
+		r.offsetIndices = make(map[int]OffsetIndex)
+	} else {
+		if idx, ok := r.offsetIndices[i]; ok {
+			return idx, nil
+		}
 	}
 
 	colChunk, err := r.rowGroupMetadata.ColumnChunk(i)
@@ -375,7 +406,9 @@ func (r *RowGroupPageIndexReader) GetOffsetIndex(i int) (OffsetIndex, error) {
 			int16(i), encryption.OffsetIndexModule)
 	}
 
-	return NewOffsetIndex(r.offsetIndexBuffer[bufferOffset:], r.props, decryptor), nil
+	oidx := NewOffsetIndex(r.offsetIndexBuffer[bufferOffset:], r.props, decryptor)
+	r.offsetIndices[i] = oidx
+	return oidx, nil
 }
 
 // PageIndexReader is a read-only object for retrieving the Column and Offset indexes
@@ -412,36 +445,27 @@ func determinePageIndexRangesInRowGroup(rgMeta *RowGroupMetaData, cols []int32) 
 
 	var colChunk *ColumnChunkMetaData
 	if len(cols) == 0 {
+		cols = make([]int32, rgMeta.NumColumns())
 		for i := 0; i < rgMeta.NumColumns(); i++ {
-			if colChunk, err = rgMeta.ColumnChunk(i); err != nil {
-				return
-			}
-
-			if err = mergeRange(colChunk.GetColumnIndexLocation(), &ciStart, &ciEnd); err != nil {
-				return
-			}
-
-			if err = mergeRange(colChunk.GetOffsetIndexLocation(), &oiStart, &oiEnd); err != nil {
-				return
-			}
+			cols[i] = int32(i)
 		}
-	} else {
-		for _, i := range cols {
-			if i < 0 || i >= int32(rgMeta.NumColumns()) {
-				return rng, fmt.Errorf("%w: invalid column ordinal %d", arrow.ErrIndex, i)
-			}
+	}
 
-			if colChunk, err = rgMeta.ColumnChunk(int(i)); err != nil {
-				return
-			}
+	for _, i := range cols {
+		if i < 0 || i >= int32(rgMeta.NumColumns()) {
+			return rng, fmt.Errorf("%w: invalid column ordinal %d", arrow.ErrIndex, i)
+		}
 
-			if err = mergeRange(colChunk.GetColumnIndexLocation(), &ciStart, &ciEnd); err != nil {
-				return
-			}
+		if colChunk, err = rgMeta.ColumnChunk(int(i)); err != nil {
+			return
+		}
 
-			if err = mergeRange(colChunk.GetOffsetIndexLocation(), &oiStart, &oiEnd); err != nil {
-				return
-			}
+		if err = mergeRange(colChunk.GetColumnIndexLocation(), &ciStart, &ciEnd); err != nil {
+			return
+		}
+
+		if err = mergeRange(colChunk.GetOffsetIndexLocation(), &oiStart, &oiEnd); err != nil {
+			return
 		}
 	}
 

--- a/parquet/metadata/page_index.go
+++ b/parquet/metadata/page_index.go
@@ -456,8 +456,8 @@ func determinePageIndexRangesInRowGroup(rgMeta *RowGroupMetaData, cols []int32) 
 			return rng, fmt.Errorf("%w: invalid column ordinal %d", arrow.ErrIndex, i)
 		}
 
-		if colChunk, err = rgMeta.ColumnChunk(int(i)); err != nil {
-			return
+		if colChunk, _ = rgMeta.ColumnChunk(int(i)); colChunk == nil {
+			continue
 		}
 
 		if err = mergeRange(colChunk.GetColumnIndexLocation(), &ciStart, &ciEnd); err != nil {

--- a/parquet/reader_properties.go
+++ b/parquet/reader_properties.go
@@ -50,6 +50,9 @@ type ReaderProperties struct {
 type BufferedReader interface {
 	Peek(int) ([]byte, error)
 	Discard(int) (int, error)
+	Outer() utils.Reader
+	BufferSize() int
+	Reset(utils.Reader)
 	io.Reader
 }
 


### PR DESCRIPTION
### Rationale for this change
Addressing the comments in https://github.com/apache/arrow-go/issues/278#issuecomment-2657578697 to allow for optimizing reads by skipping entire pages and leveraging the offset index if it exists.

### What changes are included in this PR?
Deprecating the old `NewColumnChunkReader` and `NewPageReader` methods as they really aren't safe to use outside of the package, and have proved difficult to evolve without breaking changes. Instead users should rely on using the `RowGroupReader` to perform the creation of the column readers and page readers, which is generally what is done by consumers already.

Adding `SeekToRow` method on the ColumnChunkReader to allow skipping to a particular row in the column chunk (which also allows quickly resetting back to the beginning of a column!) along with `SeekToPageWithRow` method on the page reader. Also updates the `Skip` method to properly skip *rows* in a repeated column, not just values.

### Are these changes tested?
Yes, tests are included.

### Are there any user-facing changes?
Just the new methods. The deprecated methods are not removed currently.
