### PR TITLE
feat: Add arrayApproxEqualString to handle null characters in string.

### DIFF
--- a/arrow/array/compare.go
+++ b/arrow/array/compare.go
@@ -487,19 +487,19 @@ func arrayApproxEqual(left, right arrow.Array, opt equalOption) bool {
 		return arrayEqualBinary(l, r)
 	case *String:
 		r := right.(*String)
-		return arrayEqualString(l, r)
+		return arrayApproxEqualString(l, r)
 	case *LargeBinary:
 		r := right.(*LargeBinary)
 		return arrayEqualLargeBinary(l, r)
 	case *LargeString:
 		r := right.(*LargeString)
-		return arrayEqualLargeString(l, r)
+		return arrayApproxEqualLargeString(l, r)
 	case *BinaryView:
 		r := right.(*BinaryView)
 		return arrayEqualBinaryView(l, r)
 	case *StringView:
 		r := right.(*StringView)
-		return arrayEqualStringView(l, r)
+		return arrayApproxEqualStringView(l, r)
 	case *Int8:
 		r := right.(*Int8)
 		return arrayEqualInt8(l, r)
@@ -638,6 +638,42 @@ func validityBitmapEqual(left, right arrow.Array) bool {
 	}
 	for i := 0; i < n; i++ {
 		if left.IsNull(i) != right.IsNull(i) {
+			return false
+		}
+	}
+	return true
+}
+
+func arrayApproxEqualString(left, right *String) bool {
+	for i := 0; i < left.Len(); i++ {
+		if left.IsNull(i) {
+			continue
+		}
+		if stripNulls(left.Value(i)) != stripNulls(right.Value(i)) {
+			return false
+		}
+	}
+	return true
+}
+
+func arrayApproxEqualLargeString(left, right *LargeString) bool {
+	for i := 0; i < left.Len(); i++ {
+		if left.IsNull(i) {
+			continue
+		}
+		if stripNulls(left.Value(i)) != stripNulls(right.Value(i)) {
+			return false
+		}
+	}
+	return true
+}
+
+func arrayApproxEqualStringView(left, right *StringView) bool {
+	for i := 0; i < left.Len(); i++ {
+		if left.IsNull(i) {
+			continue
+		}
+		if stripNulls(left.Value(i)) != stripNulls(right.Value(i)) {
 			return false
 		}
 	}

--- a/arrow/array/util.go
+++ b/arrow/array/util.go
@@ -521,3 +521,7 @@ func MakeArrayOfNull(mem memory.Allocator, dt arrow.DataType, length int) arrow.
 	defer data.Release()
 	return MakeFromData(data)
 }
+
+func stripNulls(s string) string {
+	return strings.TrimRight(s, "\x00")
+}


### PR DESCRIPTION
Fixes: #56 

### Rationale for this change
Many databases, including PostgreSQL, do not accept null characters (\x00) in strings. This PR introduces `arrayApproxEqualString` & `arrayApproxEqualLargeString`, functions that enables approximate equality comparison for string arrays while ignoring trailing null characters. This helps improve consistency with database behavior and aligns with existing arrayApproxEqualFloat16.

### What changes are included in this PR?

- Added `arrayApproxEqualString`:
   - Compares two string arrays for approximate equality.
   - Ignores trailing null characters (\x00).
- Added unit tests in `compare_test.go` to verify correctness.

### Are these changes tested?
Yes, unit tests have been added to validate:

- Identical strings return true.
- Strings differing only in trailing null characters return true.
- Completely different strings return false.

### Are there any user-facing changes?
No
