### PR TITLE
feat(parquet): add byte buffer when disable buffered stream

### DIFF
--- a/internal/utils/buf_reader.go
+++ b/internal/utils/buf_reader.go
@@ -77,6 +77,10 @@ func (r *byteReader) Peek(n int) ([]byte, error) {
 }
 
 func (r *byteReader) Discard(n int) (int, error) {
+	if n < 0 {
+		return 0, fmt.Errorf("arrow/bytereader: %w", bufio.ErrNegativeCount)
+	}
+
 	var (
 		err    error
 		newPos = r.pos + n
@@ -88,7 +92,10 @@ func (r *byteReader) Discard(n int) (int, error) {
 		err = io.EOF
 	}
 
-	r.Seek(int64(n), io.SeekCurrent)
+	_, seekErr := r.Seek(int64(n), io.SeekCurrent)
+	if seekErr != nil {
+		return n, seekErr
+	}
 	return n, err
 }
 

--- a/internal/utils/buf_reader.go
+++ b/internal/utils/buf_reader.go
@@ -99,11 +99,14 @@ func (r *byteReader) Discard(n int) (int, error) {
 	return n, err
 }
 
+// Outer returns the byteReader itself, since it has already implemented Reader interface.
 func (r *byteReader) Outer() Reader {
 	return r
 }
 
 func (r *byteReader) Reset(Reader) {}
+
+func (r *byteReader) BufferSize() int { return len(r.buf) }
 
 // bufferedReader is similar to bufio.Reader except
 // it will expand the buffer if necessary when asked to Peek
@@ -179,6 +182,8 @@ func (b *bufferedReader) readErr() error {
 	b.err = nil
 	return err
 }
+
+func (b *bufferedReader) BufferSize() int { return b.bufferSz }
 
 // Buffered returns the number of bytes currently buffered
 func (b *bufferedReader) Buffered() int { return b.w - b.r }

--- a/parquet/file/column_writer_test.go
+++ b/parquet/file/column_writer_test.go
@@ -258,7 +258,7 @@ func (p *PrimitiveWriterTestSuite) TearDownTest() {
 
 func (p *PrimitiveWriterTestSuite) buildReader(nrows int64, compression compress.Compression) file.ColumnChunkReader {
 	p.readbuffer = p.sink.Finish()
-	pagereader, _ := file.NewPageReader(arrutils.NewBufferedReader(bytes.NewReader(p.readbuffer.Bytes()), p.readbuffer.Len()), nrows, compression, mem, nil)
+	pagereader, _ := file.NewPageReader(arrutils.NewByteReader(p.readbuffer.Bytes()), nrows, compression, mem, nil)
 	return file.NewColumnReader(p.descr, pagereader, mem, &p.bufferPool)
 }
 

--- a/parquet/file/file_reader_test.go
+++ b/parquet/file/file_reader_test.go
@@ -125,7 +125,7 @@ func (p *PageSerdeSuite) SetupTest() {
 func (p *PageSerdeSuite) InitSerializedPageReader(nrows int64, codec compress.Compression) {
 	p.EndStream()
 
-	p.pageReader, _ = file.NewPageReader(utils.NewBufferedReader(bytes.NewReader(p.buffer.Bytes()), p.buffer.Len()), nrows, codec, memory.DefaultAllocator, nil)
+	p.pageReader, _ = file.NewPageReader(utils.NewByteReader(p.buffer.Bytes()), nrows, codec, memory.DefaultAllocator, nil)
 }
 
 func (p *PageSerdeSuite) WriteDataPageHeader(maxSerialized int, uncompressed, compressed int32) {

--- a/parquet/file/page_reader.go
+++ b/parquet/file/page_reader.go
@@ -533,7 +533,7 @@ func (p *serializedPageReader) GetDictionaryPage() (*DictionaryPage, error) {
 		hdr := format.NewPageHeader()
 		rd := utils.NewBufferedReader(
 			io.NewSectionReader(p.r.Outer(), p.dictOffset-p.baseOffset, p.dataOffset-p.baseOffset),
-			p.r.BufferSize())
+			int(parquet.DefaultBufSize))
 		if err := p.readPageHeader(rd, hdr); err != nil {
 			return nil, err
 		}

--- a/parquet/file/page_reader.go
+++ b/parquet/file/page_reader.go
@@ -531,9 +531,10 @@ func extractStats(dataHeader dataheader) (pageStats metadata.EncodedStatistics) 
 func (p *serializedPageReader) GetDictionaryPage() (*DictionaryPage, error) {
 	if p.dictOffset > 0 {
 		hdr := format.NewPageHeader()
+		readBufSize := min(int(p.dataOffset-p.baseOffset), p.r.BufferSize())
 		rd := utils.NewBufferedReader(
 			io.NewSectionReader(p.r.Outer(), p.dictOffset-p.baseOffset, p.dataOffset-p.baseOffset),
-			int(parquet.DefaultBufSize))
+			readBufSize)
 		if err := p.readPageHeader(rd, hdr); err != nil {
 			return nil, err
 		}

--- a/parquet/reader_properties.go
+++ b/parquet/reader_properties.go
@@ -17,7 +17,6 @@
 package parquet
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
@@ -87,5 +86,5 @@ func (r *ReaderProperties) GetStream(source io.ReaderAt, start, nbytes int64) (B
 		return nil, fmt.Errorf("parquet: tried reading %d bytes starting at position %d from file but only got %d", nbytes, start, n)
 	}
 
-	return utils.NewBufferedReader(bytes.NewReader(data), int(nbytes)), nil
+	return utils.NewByteReader(data), nil
 }

--- a/parquet/reader_properties.go
+++ b/parquet/reader_properties.go
@@ -50,7 +50,6 @@ type BufferedReader interface {
 	Peek(int) ([]byte, error)
 	Discard(int) (int, error)
 	Outer() utils.Reader
-	BufferSize() int
 	Reset(utils.Reader)
 	io.Reader
 }

--- a/parquet/reader_properties.go
+++ b/parquet/reader_properties.go
@@ -50,6 +50,7 @@ type BufferedReader interface {
 	Peek(int) ([]byte, error)
 	Discard(int) (int, error)
 	Outer() utils.Reader
+	BufferSize() int
 	Reset(utils.Reader)
 	io.Reader
 }


### PR DESCRIPTION
### Rationale for this change

When we create a reader with `BufferedStreamEnabled = false`, we have to first create a `data` slice. 

https://github.com/apache/arrow-go/blob/efecae3596e6734ce8244a5ed1befdcff09884df/parquet/reader_properties.go#L76-L91

And we will create another slice with same size in the `NewBufferedReader` again, which is redundant.

https://github.com/apache/arrow-go/blob/efecae3596e6734ce8244a5ed1befdcff09884df/internal/utils/buf_reader.go#L45-L51

### What changes are included in this PR?

- Add a new struct `byteReader`, which is a wrapper of `bytes.NewReader` and implement `BufferedReader` interface.
- Remove `BufferSize()` method from `BufferedReader` interface

### Are these changes tested?

`BufferedReader` created from `bytes.NewReader` in tests are all replaced by new function `NewByteReader`.

### Are there any user-facing changes?

No.
