### PR TITLE
feat(arrow/array): convert RecordReader and iterators

### DIFF
--- a/arrow/array/record_test.go
+++ b/arrow/array/record_test.go
@@ -353,6 +353,11 @@ func TestRecordReader(t *testing.T) {
 		n := 0
 		for rdr.Next() {
 			n++
+			// facet of using the simple record reader with a slice
+			// by default it will release records when the reader is released
+			// leading to too many releases on the original record
+			// so we retain it to keep it from going away while the test runs
+			rdr.Record().Retain()
 			if got, want := rdr.Record(), recs[n-1]; !reflect.DeepEqual(got, want) {
 				t.Fatalf("itr[%d], invalid record. got=%#v, want=%#v", n-1, got, want)
 			}


### PR DESCRIPTION
### Rationale for this change
With the advent of Go iterators via the [iter](https://pkg.go.dev/iter) module, we should provide some easy compatibility and canonicity for handling streams of record batches.

### What changes are included in this PR?
Two new functions: `ReaderFromIter` and `IterFromReader` for converting between the `RecordReader` interface and an iterator of Records and errors. This should make it easy to integrate in various packages without forcing refactors or boilerplate code.

### Are these changes tested?
Yes, unit tests are added for them.

### Are there any user-facing changes?
No.
