### PR TITLE
feat(arrow/memory): experimenting with addcleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -316,7 +316,7 @@ jobs:
     name: TinyGo
     runs-on: ubuntu-latest
     env:
-      TINYGO_VERSION: 0.38.0
+      TINYGO_VERSION: 0.39.0
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -316,7 +316,7 @@ jobs:
     name: TinyGo
     runs-on: ubuntu-latest
     env:
-      TINYGO_VERSION: 0.39.0
+      TINYGO_VERSION: 0.38.0
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/arrow/array.go
+++ b/arrow/array.go
@@ -83,6 +83,8 @@ type ArrayData interface {
 	Dictionary() ArrayData
 	// SizeInBytes returns the size of the ArrayData buffers and any children and/or dictionary in bytes.
 	SizeInBytes() uint64
+
+	Equal(ArrayData) bool
 }
 
 // Array represents an immutable sequence of values using the Arrow in-memory format.

--- a/arrow/array/array_test.go
+++ b/arrow/array/array_test.go
@@ -17,6 +17,7 @@
 package array_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -202,147 +203,153 @@ func TestArraySlice(t *testing.T) {
 		vs     = []float64{1, 2, 3, 0, 4, 5}
 	)
 
-	b := array.NewFloat64Builder(pool)
-	defer b.Release()
+	{
+		b := array.NewFloat64Builder(pool)
+		defer b.Release()
 
-	for _, tc := range []struct {
-		i, j   int
-		panics bool
-		len    int
-	}{
-		{i: 0, j: len(valids), panics: false, len: len(valids)},
-		{i: len(valids), j: len(valids), panics: false, len: 0},
-		{i: 0, j: 1, panics: false, len: 1},
-		{i: 1, j: 1, panics: false, len: 0},
-		{i: 0, j: len(valids) + 1, panics: true},
-		{i: 2, j: 1, panics: true},
-		{i: len(valids) + 1, j: len(valids) + 1, panics: true},
-	} {
-		t.Run("", func(t *testing.T) {
-			b.AppendValues(vs, valids)
+		for _, tc := range []struct {
+			i, j   int
+			panics bool
+			len    int
+		}{
+			{i: 0, j: len(valids), panics: false, len: len(valids)},
+			{i: len(valids), j: len(valids), panics: false, len: 0},
+			{i: 0, j: 1, panics: false, len: 1},
+			{i: 1, j: 1, panics: false, len: 0},
+			{i: 0, j: len(valids) + 1, panics: true},
+			{i: 2, j: 1, panics: true},
+			{i: len(valids) + 1, j: len(valids) + 1, panics: true},
+		} {
+			t.Run("", func(t *testing.T) {
+				b.AppendValues(vs, valids)
 
-			arr := b.NewFloat64Array()
-			defer arr.Release()
+				arr := b.NewFloat64Array()
+				defer arr.Release()
 
-			if got, want := arr.Len(), len(valids); got != want {
-				t.Fatalf("got=%d, want=%d", got, want)
-			}
+				if got, want := arr.Len(), len(valids); got != want {
+					t.Fatalf("got=%d, want=%d", got, want)
+				}
 
-			if tc.panics {
-				defer func() {
-					e := recover()
-					if e == nil {
-						t.Fatalf("this should have panicked, but did not")
-					}
-				}()
-			}
+				if tc.panics {
+					defer func() {
+						e := recover()
+						if e == nil {
+							t.Fatalf("this should have panicked, but did not")
+						}
+					}()
+				}
 
-			slice := array.NewSlice(arr, int64(tc.i), int64(tc.j)).(*array.Float64)
-			defer slice.Release()
+				slice := array.NewSlice(arr, int64(tc.i), int64(tc.j)).(*array.Float64)
+				defer slice.Release()
 
-			if got, want := slice.Len(), tc.len; got != want {
-				t.Fatalf("invalid slice length: got=%d, want=%d", got, want)
-			}
-		})
+				if got, want := slice.Len(), tc.len; got != want {
+					t.Fatalf("invalid slice length: got=%d, want=%d", got, want)
+				}
+			})
+		}
 	}
+	runtime.GC()
 }
 
 func TestArraySliceTypes(t *testing.T) {
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer pool.AssertSize(t, 0)
 
-	valids := []bool{true, true, true, false, true, true}
+	{
+		valids := []bool{true, true, true, false, true, true}
 
-	for _, tc := range []struct {
-		values  interface{}
-		builder array.Builder
-		append  func(b array.Builder, vs interface{})
-	}{
-		{
-			values:  []bool{true, false, true, false, true, false},
-			builder: array.NewBooleanBuilder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.BooleanBuilder).AppendValues(vs.([]bool), valids) },
-		},
-		{
-			values:  []uint8{1, 2, 3, 0, 4, 5},
-			builder: array.NewUint8Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Uint8Builder).AppendValues(vs.([]uint8), valids) },
-		},
-		{
-			values:  []uint16{1, 2, 3, 0, 4, 5},
-			builder: array.NewUint16Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Uint16Builder).AppendValues(vs.([]uint16), valids) },
-		},
-		{
-			values:  []uint32{1, 2, 3, 0, 4, 5},
-			builder: array.NewUint32Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Uint32Builder).AppendValues(vs.([]uint32), valids) },
-		},
-		{
-			values:  []uint64{1, 2, 3, 0, 4, 5},
-			builder: array.NewUint64Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Uint64Builder).AppendValues(vs.([]uint64), valids) },
-		},
-		{
-			values:  []int8{1, 2, 3, 0, 4, 5},
-			builder: array.NewInt8Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Int8Builder).AppendValues(vs.([]int8), valids) },
-		},
-		{
-			values:  []int16{1, 2, 3, 0, 4, 5},
-			builder: array.NewInt16Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Int16Builder).AppendValues(vs.([]int16), valids) },
-		},
-		{
-			values:  []int32{1, 2, 3, 0, 4, 5},
-			builder: array.NewInt32Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Int32Builder).AppendValues(vs.([]int32), valids) },
-		},
-		{
-			values:  []int64{1, 2, 3, 0, 4, 5},
-			builder: array.NewInt64Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Int64Builder).AppendValues(vs.([]int64), valids) },
-		},
-		{
-			values:  []float32{1, 2, 3, 0, 4, 5},
-			builder: array.NewFloat32Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Float32Builder).AppendValues(vs.([]float32), valids) },
-		},
-		{
-			values:  []float64{1, 2, 3, 0, 4, 5},
-			builder: array.NewFloat64Builder(pool),
-			append:  func(b array.Builder, vs interface{}) { b.(*array.Float64Builder).AppendValues(vs.([]float64), valids) },
-		},
-	} {
-		t.Run("", func(t *testing.T) {
-			defer tc.builder.Release()
+		for _, tc := range []struct {
+			values  interface{}
+			builder array.Builder
+			append  func(b array.Builder, vs interface{})
+		}{
+			{
+				values:  []bool{true, false, true, false, true, false},
+				builder: array.NewBooleanBuilder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.BooleanBuilder).AppendValues(vs.([]bool), valids) },
+			},
+			{
+				values:  []uint8{1, 2, 3, 0, 4, 5},
+				builder: array.NewUint8Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Uint8Builder).AppendValues(vs.([]uint8), valids) },
+			},
+			{
+				values:  []uint16{1, 2, 3, 0, 4, 5},
+				builder: array.NewUint16Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Uint16Builder).AppendValues(vs.([]uint16), valids) },
+			},
+			{
+				values:  []uint32{1, 2, 3, 0, 4, 5},
+				builder: array.NewUint32Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Uint32Builder).AppendValues(vs.([]uint32), valids) },
+			},
+			{
+				values:  []uint64{1, 2, 3, 0, 4, 5},
+				builder: array.NewUint64Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Uint64Builder).AppendValues(vs.([]uint64), valids) },
+			},
+			{
+				values:  []int8{1, 2, 3, 0, 4, 5},
+				builder: array.NewInt8Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Int8Builder).AppendValues(vs.([]int8), valids) },
+			},
+			{
+				values:  []int16{1, 2, 3, 0, 4, 5},
+				builder: array.NewInt16Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Int16Builder).AppendValues(vs.([]int16), valids) },
+			},
+			{
+				values:  []int32{1, 2, 3, 0, 4, 5},
+				builder: array.NewInt32Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Int32Builder).AppendValues(vs.([]int32), valids) },
+			},
+			{
+				values:  []int64{1, 2, 3, 0, 4, 5},
+				builder: array.NewInt64Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Int64Builder).AppendValues(vs.([]int64), valids) },
+			},
+			{
+				values:  []float32{1, 2, 3, 0, 4, 5},
+				builder: array.NewFloat32Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Float32Builder).AppendValues(vs.([]float32), valids) },
+			},
+			{
+				values:  []float64{1, 2, 3, 0, 4, 5},
+				builder: array.NewFloat64Builder(pool),
+				append:  func(b array.Builder, vs interface{}) { b.(*array.Float64Builder).AppendValues(vs.([]float64), valids) },
+			},
+		} {
+			t.Run("", func(t *testing.T) {
+				defer tc.builder.Release()
 
-			b := tc.builder
-			tc.append(b, tc.values)
+				b := tc.builder
+				tc.append(b, tc.values)
 
-			arr := b.NewArray()
-			defer arr.Release()
+				arr := b.NewArray()
+				defer arr.Release()
 
-			if got, want := arr.Len(), len(valids); got != want {
-				t.Fatalf("invalid length: got=%d, want=%d", got, want)
-			}
+				if got, want := arr.Len(), len(valids); got != want {
+					t.Fatalf("invalid length: got=%d, want=%d", got, want)
+				}
 
-			slice := array.NewSlice(arr, 2, 5)
-			defer slice.Release()
+				slice := array.NewSlice(arr, 2, 5)
+				defer slice.Release()
 
-			if got, want := slice.Len(), 3; got != want {
-				t.Fatalf("invalid slice length: got=%d, want=%d", got, want)
-			}
+				if got, want := slice.Len(), 3; got != want {
+					t.Fatalf("invalid slice length: got=%d, want=%d", got, want)
+				}
 
-			shortSlice := array.NewSlice(arr, 2, 3)
-			defer shortSlice.Release()
+				shortSlice := array.NewSlice(arr, 2, 3)
+				defer shortSlice.Release()
 
-			sliceOfShortSlice := array.NewSlice(shortSlice, 0, 1)
-			defer sliceOfShortSlice.Release()
+				sliceOfShortSlice := array.NewSlice(shortSlice, 0, 1)
+				defer sliceOfShortSlice.Release()
 
-			if got, want := sliceOfShortSlice.Len(), 1; got != want {
-				t.Fatalf("invalid short slice length: got=%d, want=%d", got, want)
-			}
-		})
+				if got, want := sliceOfShortSlice.Len(), 1; got != want {
+					t.Fatalf("invalid short slice length: got=%d, want=%d", got, want)
+				}
+			})
+		}
 	}
+	runtime.GC()
 }

--- a/arrow/compute/exec/span_test.go
+++ b/arrow/compute/exec/span_test.go
@@ -406,7 +406,8 @@ func TestArraySpan_MakeData(t *testing.T) {
 				}
 				got := a.MakeData()
 				want := tt.want(mem)
-				if !reflect.DeepEqual(got, want) {
+
+				if !got.Equal(want) {
 					t.Errorf("ArraySpan.MakeData() = %v, want %v", got, want)
 				}
 				want.Release()

--- a/arrow/extensions/bool8_test.go
+++ b/arrow/extensions/bool8_test.go
@@ -60,7 +60,7 @@ func TestBool8ExtensionBuilder(t *testing.T) {
 	require.NoError(t, err)
 	defer arr1.Release()
 
-	require.Equal(t, arr, arr1)
+	require.True(t, array.Equal(arr, arr1))
 }
 
 func TestBool8ExtensionRecordBuilder(t *testing.T) {
@@ -83,7 +83,7 @@ func TestBool8ExtensionRecordBuilder(t *testing.T) {
 	require.NoError(t, err)
 	defer record1.Release()
 
-	require.Equal(t, record, record1)
+	require.True(t, array.RecordEqual(record, record1))
 
 	require.NoError(t, builder.UnmarshalJSON([]byte(`{"bool8":true}`)))
 	record = builder.NewRecordBatch()

--- a/arrow/extensions/uuid_test.go
+++ b/arrow/extensions/uuid_test.go
@@ -74,7 +74,7 @@ func TestUUIDExtensionRecordBuilder(t *testing.T) {
 	require.Equal(t, "[{\"uuid\":\""+testUUID.String()+"\"}\n,{\"uuid\":null}\n,{\"uuid\":\""+testUUID.String()+"\"}\n]", string(b))
 	record1, _, err := array.RecordFromJSON(memory.DefaultAllocator, schema, bytes.NewReader(b))
 	require.NoError(t, err)
-	require.Equal(t, record, record1)
+	require.True(t, array.RecordEqual(record, record1))
 }
 
 func TestUUIDStringRoundTrip(t *testing.T) {

--- a/arrow/memory/buffer_cleanup.go
+++ b/arrow/memory/buffer_cleanup.go
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.24
+
+package memory
+
+import "runtime"
+
+type cleanup = runtime.Cleanup
+
+func addCleanup[T, S any](ptr *T, cleanup func(S), arg S) cleanup {
+	return runtime.AddCleanup(ptr, cleanup, arg)
+}

--- a/arrow/memory/buffer_cleanup.go
+++ b/arrow/memory/buffer_cleanup.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.24
+//go:build go1.24 && !tinygo
 
 package memory
 

--- a/arrow/memory/buffer_cleanup_go1_23.go
+++ b/arrow/memory/buffer_cleanup_go1_23.go
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.24
+
+package memory
+
+type cleanup struct{}
+
+func (cleanup) Stop() {}
+
+func addCleanup[T, S any](*T, func(S), S) cleanup {
+	return cleanup{}
+}

--- a/arrow/memory/buffer_cleanup_go1_23.go
+++ b/arrow/memory/buffer_cleanup_go1_23.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !go1.24
+//go:build !go1.24 || tinygo
 
 package memory
 

--- a/parquet/metadata/cleanup_bloom_filter.go
+++ b/parquet/metadata/cleanup_bloom_filter.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.24
+//go:build go1.24 && !tinygo
 
 package metadata
 

--- a/parquet/metadata/cleanup_bloom_filter_go1.23.go
+++ b/parquet/metadata/cleanup_bloom_filter_go1.23.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !go1.24
+//go:build !go1.24 || tinygo
 
 package metadata
 


### PR DESCRIPTION
### Rationale for this change
Experimenting with using AddCleanup for automatic cleanup of the Buffers without requiring `Retain` and `Release` everywhere even for custom Allocators.

### What changes are included in this PR?
Changes to the underlying Buffer object to leverage AddCleanup when using go1.24 or higher.

### Are these changes tested?
Yes, though more tests need to be added to ensure more complex scenarios don't fail.

### Are there any user-facing changes?

