### PR TITLE
fix: go's atomic operations require 64bit alignment in structs on ARM

### DIFF
--- a/arrow/ipc/reader.go
+++ b/arrow/ipc/reader.go
@@ -38,7 +38,7 @@ import (
 type Reader struct {
 	// refCount needs to be 64-bit aligned
 	// https://pkg.go.dev/sync/atomic#pkg-note-BUG
-	refCount int64
+	refCount atomic.Int64
 
 	r      MessageReader
 	schema *arrow.Schema
@@ -73,13 +73,14 @@ func NewReaderFromMessageReader(r MessageReader, opts ...Option) (reader *Reader
 
 	rr := &Reader{
 		r:        r,
-		refCount: 1,
+		refCount: atomic.Int64{},
 		// types:    make(dictTypeMap),
 		memo:               dictutils.NewMemo(),
 		mem:                cfg.alloc,
 		ensureNativeEndian: cfg.ensureNativeEndian,
 		expectedSchema:     cfg.schema,
 	}
+	rr.refCount.Add(1)
 
 	if !cfg.noAutoSchema {
 		if err := rr.readSchema(cfg.schema); err != nil {
@@ -144,16 +145,16 @@ func (r *Reader) readSchema(schema *arrow.Schema) error {
 // Retain increases the reference count by 1.
 // Retain may be called simultaneously from multiple goroutines.
 func (r *Reader) Retain() {
-	atomic.AddInt64(&r.refCount, 1)
+	r.refCount.Add(1)
 }
 
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 // Release may be called simultaneously from multiple goroutines.
 func (r *Reader) Release() {
-	debug.Assert(atomic.LoadInt64(&r.refCount) > 0, "too many releases")
+	debug.Assert(r.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&r.refCount, -1) == 0 {
+	if r.refCount.Add(-1) == 0 {
 		if r.rec != nil {
 			r.rec.Release()
 			r.rec = nil

--- a/arrow/ipc/reader.go
+++ b/arrow/ipc/reader.go
@@ -36,12 +36,15 @@ import (
 // Reader expects a schema (plus any dictionaries) as the first messages
 // in the stream, followed by records.
 type Reader struct {
+	// refCount needs to be 64-bit aligned
+	// https://pkg.go.dev/sync/atomic#pkg-note-BUG
+	refCount int64
+
 	r      MessageReader
 	schema *arrow.Schema
 
-	refCount int64
-	rec      arrow.Record
-	err      error
+	rec arrow.Record
+	err error
 
 	// types dictTypeMap
 	memo               dictutils.Memo
@@ -280,6 +283,4 @@ func (r *Reader) Read() (arrow.Record, error) {
 	return r.rec, nil
 }
 
-var (
-	_ array.RecordReader = (*Reader)(nil)
-)
+var _ array.RecordReader = (*Reader)(nil)

--- a/arrow/ipc/reader.go
+++ b/arrow/ipc/reader.go
@@ -36,15 +36,12 @@ import (
 // Reader expects a schema (plus any dictionaries) as the first messages
 // in the stream, followed by records.
 type Reader struct {
-	// refCount needs to be 64-bit aligned
-	// https://pkg.go.dev/sync/atomic#pkg-note-BUG
-	refCount atomic.Int64
-
 	r      MessageReader
 	schema *arrow.Schema
 
-	rec arrow.Record
-	err error
+	refCount atomic.Int64
+	rec      arrow.Record
+	err      error
 
 	// types dictTypeMap
 	memo               dictutils.Memo

--- a/parquet/internal/bmi/bmi.go
+++ b/parquet/internal/bmi/bmi.go
@@ -19,14 +19,20 @@
 // BMI2.
 package bmi
 
-import "math/bits"
+import (
+	"math/bits"
+)
 
 type funcs struct {
 	extractBits func(uint64, uint64) uint64
 	gtbitmap    func([]int16, int16) uint64
 }
 
-var funclist funcs
+// fallback until arch specific init() is called:
+var funclist = funcs{
+	extractBits: extractBitsGo,
+	gtbitmap:    greaterThanBitmapGo,
+}
 
 // ExtractBits performs a Parallel Bit extract as per the PEXT instruction for
 // x86/x86-64 cpus to use the second parameter as a mask to extract the bits from


### PR DESCRIPTION
### Rationale for this change

I've tried to run a pqarrow based writer/reader on a RaspberryPi. This lead to an almost immediate crash however, due to an unaligned struct member in `ipc.Reader`.

I did not check yet if there are other structs that might have similar issues. It would probably be nice to 

### What changes are included in this PR?

Swapping the struct field order is enough to fix the issue. See also the link in the diff.

### Are these changes tested?

Yes, no additional unit tests due to hardware constraints, but my program runs through now.

### Are there any user-facing changes?

Less crashing?

### Other note

I noticed that this will also crash if I do not pass the `noasm` build tag, which is probably also a little unfortunate. This seems to be because the `funclist` in `parquet/internal/bmi/bmi.go` is empty. If you want I can add a default, so the funclist is always initialized with the fallback go implementation, unless overwritten.