### PR TITLE
fix(parquet/pqarrow): fix propagation of FieldIds for nested fields

### DIFF
--- a/parquet/file/file_writer.go
+++ b/parquet/file/file_writer.go
@@ -217,6 +217,9 @@ func (fw *Writer) Close() (err error) {
 	return nil
 }
 
+// FileMetadata returns the current state of the FileMetadata that would be written
+// if this file were to be closed. If the file has already been closed, then this
+// will return the FileMetaData which was written to the file.
 func (fw *Writer) FileMetadata() (*metadata.FileMetaData, error) {
 	return fw.metadata.Snapshot()
 }

--- a/parquet/pqarrow/file_writer.go
+++ b/parquet/pqarrow/file_writer.go
@@ -339,6 +339,9 @@ func (fw *FileWriter) WriteColumnData(data arrow.Array) error {
 	return fw.WriteColumnChunked(chunked, 0, int64(data.Len()))
 }
 
+// FileMetadata returns the current state of the FileMetadata that would be written
+// if this file were to be closed. If the file has already been closed, then this
+// will return the FileMetaData which was written to the file.
 func (fw *FileWriter) FileMetadata() (*metadata.FileMetaData, error) {
 	return fw.wr.FileMetadata()
 }

--- a/parquet/pqarrow/schema_test.go
+++ b/parquet/pqarrow/schema_test.go
@@ -292,7 +292,7 @@ func TestConvertArrowFloat16(t *testing.T) {
 	}
 }
 
-func TestCoerceTImestampV1(t *testing.T) {
+func TestCoerceTimestampV1(t *testing.T) {
 	parquetFields := make(schema.FieldList, 0)
 	arrowFields := make([]arrow.Field, 0)
 
@@ -311,7 +311,7 @@ func TestCoerceTImestampV1(t *testing.T) {
 	}
 }
 
-func TestAutoCoerceTImestampV1(t *testing.T) {
+func TestAutoCoerceTimestampV1(t *testing.T) {
 	parquetFields := make(schema.FieldList, 0)
 	arrowFields := make([]arrow.Field, 0)
 
@@ -402,7 +402,7 @@ func TestListStructBackwardCompatible(t *testing.T) {
 					schema.StringLogicalType{}, parquet.Types.ByteArray, -1, 3)),
 				schema.MustPrimitive(schema.NewPrimitiveNodeLogical("class", parquet.Repetitions.Optional,
 					schema.StringLogicalType{}, parquet.Types.ByteArray, -1, 4)),
-			}, -1)),
+			}, 5)),
 		}, schema.NewListLogicalType(), 1)),
 	}, -1)))
 
@@ -417,7 +417,7 @@ func TestListStructBackwardCompatible(t *testing.T) {
 						Metadata: arrow.NewMetadata([]string{"PARQUET:field_id"}, []string{"3"})},
 					arrow.Field{Name: "class", Type: arrow.BinaryTypes.String, Nullable: true,
 						Metadata: arrow.NewMetadata([]string{"PARQUET:field_id"}, []string{"4"})},
-				), Nullable: true, Metadata: arrow.NewMetadata([]string{"PARQUET:field_id"}, []string{"-1"})}),
+				), Nullable: true, Metadata: arrow.NewMetadata([]string{"PARQUET:field_id"}, []string{"5"})}),
 				Nullable: true, Metadata: arrow.NewMetadata([]string{"PARQUET:field_id"}, []string{"1"})},
 		}, nil)
 


### PR DESCRIPTION
### Rationale for this change
While implementing things for iceberg-go, I found that an Arrow schema with nested fields (struct/map/list) that contains metadata values for FieldID is not respected when writing a file using `pqarrow`. 

### What changes are included in this PR?
Fixes the propagation of field ids when constructing a Parquet file from an arrow schema that contains nested fields, while also adding a `FileMetadata` function to the FileWriter and `pqarrow.FileWriter` so that you can inspect the metadata of a written file without having to read it back into memory.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No
