### PR TITLE
fix(parquet/pqarrow): fix definition levels with non-nullable lists

### DIFF
--- a/parquet/pqarrow/path_builder.go
+++ b/parquet/pqarrow/path_builder.go
@@ -395,7 +395,7 @@ func (p *pathBuilder) Visit(arr arrow.Array) error {
 			repLevel:        p.info.maxRepLevel,
 			defLevelIfEmpty: p.info.maxDefLevel - 1,
 		})
-		p.nullableInParent = ok
+		p.nullableInParent = arr.DataType().(arrow.ListLikeType).ElemField().Nullable
 		return p.Visit(larr.ListValues())
 	case arrow.FIXED_SIZE_LIST:
 		p.maybeAddNullable(arr)

--- a/parquet/pqarrow/path_builder_test.go
+++ b/parquet/pqarrow/path_builder_test.go
@@ -39,7 +39,8 @@ func TestNonNullableSingleList(t *testing.T) {
 	// So:
 	// def level 0: a null entry
 	// def level 1: a non-null entry
-	bldr := array.NewListBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int64)
+	bldr := array.NewBuilder(memory.DefaultAllocator,
+		arrow.ListOfNonNullable(arrow.PrimitiveTypes.Int64)).(*array.ListBuilder)
 	defer bldr.Release()
 
 	vb := bldr.ValueBuilder().(*array.Int64Builder)
@@ -67,7 +68,7 @@ func TestNonNullableSingleList(t *testing.T) {
 	result, err := mp.write(0, ctx)
 	require.NoError(t, err)
 
-	assert.Equal(t, []int16{2, 2, 2, 2, 2, 2}, result.defLevels)
+	assert.Equal(t, []int16{1, 1, 1, 1, 1, 1}, result.defLevels)
 	assert.Equal(t, []int16{0, 0, 1, 0, 1, 1}, result.repLevels)
 	assert.Len(t, result.postListVisitedElems, 1)
 	assert.EqualValues(t, 0, result.postListVisitedElems[0].start)


### PR DESCRIPTION
### Rationale for this change
Related to https://github.com/apache/arrow/issues/38503, it was found in https://github.com/apache/iceberg-go/issues/357 that the Parquet file being written by pqarrow was incompatible with pyarrow in some testing. After some digging I determined the cause. So we should fix this to finally put #38503 to bed

### What changes are included in this PR?
Fixing the computation of definition levels when writing from Arrow data with lists of non-nullable elements. Previously we were basing the `nullableInParent` on whether it was a list or a map, assuming that the element was *always* nullable in a list. This, of course, is incorrect and we need to actually *check* the nullability of the list element to compute the correct definition level. This way we don't produce incongruous levels that are larger than what the max definition level should be.

### Are these changes tested?
Yes, I've updated the corresponding test, which wasn't *actually* testing a non-nullable element until now.

### Are there any user-facing changes?
Only fixing writing of files.
