### PR TITLE
fix: move from atomic.(Add|Load|Store) to atomic.Int64{}

### DIFF
--- a/arrow/array/binary.go
+++ b/arrow/array/binary.go
@@ -45,7 +45,7 @@ type Binary struct {
 // NewBinaryData constructs a new Binary array from data.
 func NewBinaryData(data arrow.ArrayData) *Binary {
 	a := &Binary{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -189,7 +189,7 @@ type LargeBinary struct {
 
 func NewLargeBinaryData(data arrow.ArrayData) *LargeBinary {
 	a := &LargeBinary{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -208,6 +208,7 @@ func (a *LargeBinary) ValueStr(i int) string {
 	}
 	return base64.StdEncoding.EncodeToString(a.Value(i))
 }
+
 func (a *LargeBinary) ValueString(i int) string {
 	b := a.Value(i)
 	return *(*string)(unsafe.Pointer(&b))
@@ -333,7 +334,7 @@ type BinaryView struct {
 
 func NewBinaryViewData(data arrow.ArrayData) *BinaryView {
 	a := &BinaryView{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }

--- a/arrow/array/boolean.go
+++ b/arrow/array/boolean.go
@@ -44,7 +44,7 @@ func NewBoolean(length int, data *memory.Buffer, nullBitmap *memory.Buffer, null
 
 func NewBooleanData(data arrow.ArrayData) *Boolean {
 	a := &Boolean{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }

--- a/arrow/array/bufferbuilder_byte.go
+++ b/arrow/array/bufferbuilder_byte.go
@@ -23,7 +23,9 @@ type byteBufferBuilder struct {
 }
 
 func newByteBufferBuilder(mem memory.Allocator) *byteBufferBuilder {
-	return &byteBufferBuilder{bufferBuilder: bufferBuilder{refCount: 1, mem: mem}}
+	bbb := &byteBufferBuilder{bufferBuilder: bufferBuilder{mem: mem}}
+	bbb.bufferBuilder.refCount.Add(1)
+	return bbb
 }
 
 func (b *byteBufferBuilder) Values() []byte   { return b.Bytes() }

--- a/arrow/array/bufferbuilder_numeric.gen.go
+++ b/arrow/array/bufferbuilder_numeric.gen.go
@@ -29,7 +29,9 @@ type int64BufferBuilder struct {
 }
 
 func newInt64BufferBuilder(mem memory.Allocator) *int64BufferBuilder {
-	return &int64BufferBuilder{bufferBuilder: bufferBuilder{refCount: 1, mem: mem}}
+	b := &int64BufferBuilder{bufferBuilder: bufferBuilder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 // AppendValues appends the contents of v to the buffer, growing the buffer as needed.
@@ -62,7 +64,9 @@ type int32BufferBuilder struct {
 }
 
 func newInt32BufferBuilder(mem memory.Allocator) *int32BufferBuilder {
-	return &int32BufferBuilder{bufferBuilder: bufferBuilder{refCount: 1, mem: mem}}
+	b := &int32BufferBuilder{bufferBuilder: bufferBuilder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 // AppendValues appends the contents of v to the buffer, growing the buffer as needed.
@@ -95,7 +99,9 @@ type int8BufferBuilder struct {
 }
 
 func newInt8BufferBuilder(mem memory.Allocator) *int8BufferBuilder {
-	return &int8BufferBuilder{bufferBuilder: bufferBuilder{refCount: 1, mem: mem}}
+	b := &int8BufferBuilder{bufferBuilder: bufferBuilder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 // AppendValues appends the contents of v to the buffer, growing the buffer as needed.

--- a/arrow/array/bufferbuilder_numeric.gen.go.tmpl
+++ b/arrow/array/bufferbuilder_numeric.gen.go.tmpl
@@ -30,7 +30,9 @@ type {{$TypeNamePrefix}}BufferBuilder struct {
 }
 
 func new{{.Name}}BufferBuilder(mem memory.Allocator) *{{$TypeNamePrefix}}BufferBuilder {
-	return &{{$TypeNamePrefix}}BufferBuilder{bufferBuilder:bufferBuilder{refCount: 1, mem:mem}}
+	b := &{{$TypeNamePrefix}}BufferBuilder{bufferBuilder:bufferBuilder{mem:mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 // AppendValues appends the contents of v to the buffer, growing the buffer as needed.

--- a/arrow/array/builder.go
+++ b/arrow/array/builder.go
@@ -102,7 +102,7 @@ type Builder interface {
 
 // builder provides common functionality for managing the validity bitmap (nulls) when building arrays.
 type builder struct {
-	refCount   int64
+	refCount   atomic.Int64
 	mem        memory.Allocator
 	nullBitmap *memory.Buffer
 	nulls      int
@@ -113,7 +113,7 @@ type builder struct {
 // Retain increases the reference count by 1.
 // Retain may be called simultaneously from multiple goroutines.
 func (b *builder) Retain() {
-	atomic.AddInt64(&b.refCount, 1)
+	b.refCount.Add(1)
 }
 
 // Len returns the number of elements in the array builder.

--- a/arrow/array/concat.go
+++ b/arrow/array/concat.go
@@ -517,7 +517,9 @@ func concatListView(data []arrow.ArrayData, offsetType arrow.FixedWidthDataType,
 // concat is the implementation for actually performing the concatenation of the arrow.ArrayData
 // objects that we can call internally for nested types.
 func concat(data []arrow.ArrayData, mem memory.Allocator) (arr arrow.ArrayData, err error) {
-	out := &Data{refCount: 1, dtype: data[0].DataType(), nulls: 0}
+	out := &Data{dtype: data[0].DataType(), nulls: 0}
+	out.refCount.Add(1)
+
 	defer func() {
 		if pErr := recover(); pErr != nil {
 			err = utils.FormatRecoveredError("arrow/concat", pErr)

--- a/arrow/array/decimal.go
+++ b/arrow/array/decimal.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync/atomic"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/bitutil"
@@ -45,7 +44,7 @@ func newDecimalData[T interface {
 	decimal.Num[T]
 }](data arrow.ArrayData) *baseDecimal[T] {
 	a := &baseDecimal[T]{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -148,11 +147,13 @@ func NewDecimal256Data(data arrow.ArrayData) *Decimal256 {
 	return newDecimalData[decimal.Decimal256](data)
 }
 
-type Decimal32Builder = baseDecimalBuilder[decimal.Decimal32]
-type Decimal64Builder = baseDecimalBuilder[decimal.Decimal64]
-type Decimal128Builder struct {
-	*baseDecimalBuilder[decimal.Decimal128]
-}
+type (
+	Decimal32Builder  = baseDecimalBuilder[decimal.Decimal32]
+	Decimal64Builder  = baseDecimalBuilder[decimal.Decimal64]
+	Decimal128Builder struct {
+		*baseDecimalBuilder[decimal.Decimal128]
+	}
+)
 
 func (b *Decimal128Builder) NewDecimal128Array() *Decimal128 {
 	return b.NewDecimalArray()
@@ -182,18 +183,20 @@ func newDecimalBuilder[T interface {
 	decimal.DecimalTypes
 	decimal.Num[T]
 }, DT arrow.DecimalType](mem memory.Allocator, dtype DT) *baseDecimalBuilder[T] {
-	return &baseDecimalBuilder[T]{
-		builder: builder{refCount: 1, mem: mem},
+	bdb := &baseDecimalBuilder[T]{
+		builder: builder{mem: mem},
 		dtype:   dtype,
 	}
+	bdb.builder.refCount.Add(1)
+	return bdb
 }
 
 func (b *baseDecimalBuilder[T]) Type() arrow.DataType { return b.dtype }
 
 func (b *baseDecimalBuilder[T]) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil

--- a/arrow/array/extension.go
+++ b/arrow/array/extension.go
@@ -86,7 +86,7 @@ func NewExtensionArrayWithStorage(dt arrow.ExtensionType, storage arrow.Array) a
 // underlying data built for the storage array.
 func NewExtensionData(data arrow.ArrayData) ExtensionArray {
 	base := ExtensionArrayBase{}
-	base.refCount = 1
+	base.refCount.Add(1)
 	base.setData(data.(*Data))
 
 	// use the ExtensionType's ArrayType to construct the correctly typed object

--- a/arrow/array/fixedsize_binary.go
+++ b/arrow/array/fixedsize_binary.go
@@ -37,7 +37,7 @@ type FixedSizeBinary struct {
 // NewFixedSizeBinaryData constructs a new fixed-size binary array from data.
 func NewFixedSizeBinaryData(data arrow.ArrayData) *FixedSizeBinary {
 	a := &FixedSizeBinary{bytewidth: int32(data.DataType().(arrow.FixedWidthDataType).BitWidth() / 8)}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -52,6 +52,7 @@ func (a *FixedSizeBinary) Value(i int) []byte {
 	)
 	return a.valueBytes[beg:end]
 }
+
 func (a *FixedSizeBinary) ValueStr(i int) string {
 	if a.IsNull(i) {
 		return NullValueStr
@@ -83,7 +84,6 @@ func (a *FixedSizeBinary) setData(data *Data) {
 	if vals != nil {
 		a.valueBytes = vals.Bytes()
 	}
-
 }
 
 func (a *FixedSizeBinary) GetOneForMarshal(i int) interface{} {
@@ -118,6 +118,4 @@ func arrayEqualFixedSizeBinary(left, right *FixedSizeBinary) bool {
 	return true
 }
 
-var (
-	_ arrow.Array = (*FixedSizeBinary)(nil)
-)
+var _ arrow.Array = (*FixedSizeBinary)(nil)

--- a/arrow/array/float16.go
+++ b/arrow/array/float16.go
@@ -33,7 +33,7 @@ type Float16 struct {
 
 func NewFloat16Data(data arrow.ArrayData) *Float16 {
 	a := &Float16{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }

--- a/arrow/array/interval.go
+++ b/arrow/array/interval.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync/atomic"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/bitutil"
@@ -51,7 +50,7 @@ type MonthInterval struct {
 
 func NewMonthIntervalData(data arrow.ArrayData) *MonthInterval {
 	a := &MonthInterval{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -140,7 +139,9 @@ type MonthIntervalBuilder struct {
 }
 
 func NewMonthIntervalBuilder(mem memory.Allocator) *MonthIntervalBuilder {
-	return &MonthIntervalBuilder{builder: builder{refCount: 1, mem: mem}}
+	mib := &MonthIntervalBuilder{builder: builder{mem: mem}}
+	mib.refCount.Add(1)
+	return mib
 }
 
 func (b *MonthIntervalBuilder) Type() arrow.DataType { return arrow.FixedWidthTypes.MonthInterval }
@@ -148,9 +149,9 @@ func (b *MonthIntervalBuilder) Type() arrow.DataType { return arrow.FixedWidthTy
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *MonthIntervalBuilder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -348,7 +349,7 @@ type DayTimeInterval struct {
 
 func NewDayTimeIntervalData(data arrow.ArrayData) *DayTimeInterval {
 	a := &DayTimeInterval{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -440,7 +441,9 @@ type DayTimeIntervalBuilder struct {
 }
 
 func NewDayTimeIntervalBuilder(mem memory.Allocator) *DayTimeIntervalBuilder {
-	return &DayTimeIntervalBuilder{builder: builder{refCount: 1, mem: mem}}
+	dtb := &DayTimeIntervalBuilder{builder: builder{mem: mem}}
+	dtb.refCount.Add(1)
+	return dtb
 }
 
 func (b *DayTimeIntervalBuilder) Type() arrow.DataType { return arrow.FixedWidthTypes.DayTimeInterval }
@@ -448,9 +451,9 @@ func (b *DayTimeIntervalBuilder) Type() arrow.DataType { return arrow.FixedWidth
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *DayTimeIntervalBuilder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -647,7 +650,7 @@ type MonthDayNanoInterval struct {
 
 func NewMonthDayNanoIntervalData(data arrow.ArrayData) *MonthDayNanoInterval {
 	a := &MonthDayNanoInterval{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -741,7 +744,9 @@ type MonthDayNanoIntervalBuilder struct {
 }
 
 func NewMonthDayNanoIntervalBuilder(mem memory.Allocator) *MonthDayNanoIntervalBuilder {
-	return &MonthDayNanoIntervalBuilder{builder: builder{refCount: 1, mem: mem}}
+	mb := &MonthDayNanoIntervalBuilder{builder: builder{mem: mem}}
+	mb.refCount.Add(1)
+	return mb
 }
 
 func (b *MonthDayNanoIntervalBuilder) Type() arrow.DataType {
@@ -751,9 +756,9 @@ func (b *MonthDayNanoIntervalBuilder) Type() arrow.DataType {
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *MonthDayNanoIntervalBuilder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil

--- a/arrow/array/map.go
+++ b/arrow/array/map.go
@@ -37,7 +37,7 @@ var _ ListLike = (*Map)(nil)
 // NewMapData returns a new Map array value, from data
 func NewMapData(data arrow.ArrayData) *Map {
 	a := &Map{List: &List{}}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }

--- a/arrow/array/null.go
+++ b/arrow/array/null.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync/atomic"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/internal/debug"
@@ -37,7 +36,7 @@ type Null struct {
 // NewNull returns a new Null array value of size n.
 func NewNull(n int) *Null {
 	a := &Null{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	data := NewData(
 		arrow.Null, n,
 		[]*memory.Buffer{nil},
@@ -53,7 +52,7 @@ func NewNull(n int) *Null {
 // NewNullData returns a new Null array value, from data.
 func NewNullData(data arrow.ArrayData) *Null {
 	a := &Null{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -95,7 +94,9 @@ type NullBuilder struct {
 
 // NewNullBuilder returns a builder, using the provided memory allocator.
 func NewNullBuilder(mem memory.Allocator) *NullBuilder {
-	return &NullBuilder{builder: builder{refCount: 1, mem: mem}}
+	nb := &NullBuilder{builder: builder{mem: mem}}
+	nb.refCount.Add(1)
+	return nb
 }
 
 func (b *NullBuilder) Type() arrow.DataType { return arrow.Null }
@@ -103,9 +104,9 @@ func (b *NullBuilder) Type() arrow.DataType { return arrow.Null }
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *NullBuilder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil

--- a/arrow/array/numeric_generic.go
+++ b/arrow/array/numeric_generic.go
@@ -34,7 +34,7 @@ type numericArray[T arrow.IntType | arrow.UintType | arrow.FloatType] struct {
 
 func newNumericData[T arrow.IntType | arrow.UintType | arrow.FloatType](data arrow.ArrayData) numericArray[T] {
 	a := numericArray[T]{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }

--- a/arrow/array/numericbuilder.gen.go
+++ b/arrow/array/numericbuilder.gen.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -42,7 +41,9 @@ type Int64Builder struct {
 }
 
 func NewInt64Builder(mem memory.Allocator) *Int64Builder {
-	return &Int64Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Int64Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Int64Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Int64 }
@@ -50,9 +51,9 @@ func (b *Int64Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Int64
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Int64Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -281,7 +282,9 @@ type Uint64Builder struct {
 }
 
 func NewUint64Builder(mem memory.Allocator) *Uint64Builder {
-	return &Uint64Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Uint64Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Uint64Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Uint64 }
@@ -289,9 +292,9 @@ func (b *Uint64Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Uint
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Uint64Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -520,7 +523,9 @@ type Float64Builder struct {
 }
 
 func NewFloat64Builder(mem memory.Allocator) *Float64Builder {
-	return &Float64Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Float64Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Float64Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Float64 }
@@ -528,9 +533,9 @@ func (b *Float64Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Flo
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Float64Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -759,7 +764,9 @@ type Int32Builder struct {
 }
 
 func NewInt32Builder(mem memory.Allocator) *Int32Builder {
-	return &Int32Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Int32Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Int32Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Int32 }
@@ -767,9 +774,9 @@ func (b *Int32Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Int32
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Int32Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -998,7 +1005,9 @@ type Uint32Builder struct {
 }
 
 func NewUint32Builder(mem memory.Allocator) *Uint32Builder {
-	return &Uint32Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Uint32Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Uint32Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Uint32 }
@@ -1006,9 +1015,9 @@ func (b *Uint32Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Uint
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Uint32Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -1237,7 +1246,9 @@ type Float32Builder struct {
 }
 
 func NewFloat32Builder(mem memory.Allocator) *Float32Builder {
-	return &Float32Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Float32Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Float32Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Float32 }
@@ -1245,9 +1256,9 @@ func (b *Float32Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Flo
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Float32Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -1476,7 +1487,9 @@ type Int16Builder struct {
 }
 
 func NewInt16Builder(mem memory.Allocator) *Int16Builder {
-	return &Int16Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Int16Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Int16Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Int16 }
@@ -1484,9 +1497,9 @@ func (b *Int16Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Int16
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Int16Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -1715,7 +1728,9 @@ type Uint16Builder struct {
 }
 
 func NewUint16Builder(mem memory.Allocator) *Uint16Builder {
-	return &Uint16Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Uint16Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Uint16Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Uint16 }
@@ -1723,9 +1738,9 @@ func (b *Uint16Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Uint
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Uint16Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -1954,7 +1969,9 @@ type Int8Builder struct {
 }
 
 func NewInt8Builder(mem memory.Allocator) *Int8Builder {
-	return &Int8Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Int8Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Int8Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Int8 }
@@ -1962,9 +1979,9 @@ func (b *Int8Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Int8 }
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Int8Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -2193,7 +2210,9 @@ type Uint8Builder struct {
 }
 
 func NewUint8Builder(mem memory.Allocator) *Uint8Builder {
-	return &Uint8Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Uint8Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Uint8Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Uint8 }
@@ -2201,9 +2220,9 @@ func (b *Uint8Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Uint8
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Uint8Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -2433,7 +2452,9 @@ type Time32Builder struct {
 }
 
 func NewTime32Builder(mem memory.Allocator, dtype *arrow.Time32Type) *Time32Builder {
-	return &Time32Builder{builder: builder{refCount: 1, mem: mem}, dtype: dtype}
+	b := &Time32Builder{builder: builder{mem: mem}, dtype: dtype}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Time32Builder) Type() arrow.DataType { return b.dtype }
@@ -2441,9 +2462,9 @@ func (b *Time32Builder) Type() arrow.DataType { return b.dtype }
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Time32Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -2673,7 +2694,9 @@ type Time64Builder struct {
 }
 
 func NewTime64Builder(mem memory.Allocator, dtype *arrow.Time64Type) *Time64Builder {
-	return &Time64Builder{builder: builder{refCount: 1, mem: mem}, dtype: dtype}
+	b := &Time64Builder{builder: builder{mem: mem}, dtype: dtype}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Time64Builder) Type() arrow.DataType { return b.dtype }
@@ -2681,9 +2704,9 @@ func (b *Time64Builder) Type() arrow.DataType { return b.dtype }
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Time64Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -2912,7 +2935,9 @@ type Date32Builder struct {
 }
 
 func NewDate32Builder(mem memory.Allocator) *Date32Builder {
-	return &Date32Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Date32Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Date32Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Date32 }
@@ -2920,9 +2945,9 @@ func (b *Date32Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Date
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Date32Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -3151,7 +3176,9 @@ type Date64Builder struct {
 }
 
 func NewDate64Builder(mem memory.Allocator) *Date64Builder {
-	return &Date64Builder{builder: builder{refCount: 1, mem: mem}}
+	b := &Date64Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *Date64Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Date64 }
@@ -3159,9 +3186,9 @@ func (b *Date64Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.Date
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *Date64Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil
@@ -3391,7 +3418,9 @@ type DurationBuilder struct {
 }
 
 func NewDurationBuilder(mem memory.Allocator, dtype *arrow.DurationType) *DurationBuilder {
-	return &DurationBuilder{builder: builder{refCount: 1, mem: mem}, dtype: dtype}
+	b := &DurationBuilder{builder: builder{mem: mem}, dtype: dtype}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *DurationBuilder) Type() arrow.DataType { return b.dtype }
@@ -3399,9 +3428,9 @@ func (b *DurationBuilder) Type() arrow.DataType { return b.dtype }
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *DurationBuilder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil

--- a/arrow/array/numericbuilder.gen.go.tmpl
+++ b/arrow/array/numericbuilder.gen.go.tmpl
@@ -38,14 +38,18 @@ type {{.Name}}Builder struct {
 
 {{if .Opt.Parametric}}
 func New{{.Name}}Builder(mem memory.Allocator, dtype *arrow.{{.Name}}Type) *{{.Name}}Builder {
-	return &{{.Name}}Builder{builder: builder{refCount:1, mem: mem}, dtype: dtype}
+	b := &{{.Name}}Builder{builder: builder{mem: mem}, dtype: dtype}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *{{.Name}}Builder) Type() arrow.DataType { return b.dtype }
 
 {{else}}
 func New{{.Name}}Builder(mem memory.Allocator) *{{.Name}}Builder {
-	return &{{.Name}}Builder{builder: builder{refCount:1, mem: mem}}
+	b := &{{.Name}}Builder{builder: builder{mem: mem}}
+	b.refCount.Add(1)
+	return b
 }
 
 func (b *{{.Name}}Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.{{.Name}} }
@@ -54,9 +58,9 @@ func (b *{{.Name}}Builder) Type() arrow.DataType { return arrow.PrimitiveTypes.{
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 func (b *{{.Name}}Builder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		if b.nullBitmap != nil {
 			b.nullBitmap.Release()
 			b.nullBitmap = nil

--- a/arrow/array/numericbuilder.gen_test.go
+++ b/arrow/array/numericbuilder.gen_test.go
@@ -230,6 +230,28 @@ func TestInt64Builder_Resize(t *testing.T) {
 	assert.Equal(t, 5, ab.Len())
 }
 
+func TestInt64BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewInt64Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewInt64Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
+}
+
 func TestUint64StringRoundTrip(t *testing.T) {
 	// 1. create array
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -430,6 +452,28 @@ func TestUint64Builder_Resize(t *testing.T) {
 
 	ab.Resize(32)
 	assert.Equal(t, 5, ab.Len())
+}
+
+func TestUint64BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewUint64Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewUint64Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
 }
 
 func TestFloat64StringRoundTrip(t *testing.T) {
@@ -858,6 +902,28 @@ func TestInt32Builder_Resize(t *testing.T) {
 	assert.Equal(t, 5, ab.Len())
 }
 
+func TestInt32BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewInt32Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewInt32Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
+}
+
 func TestUint32StringRoundTrip(t *testing.T) {
 	// 1. create array
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -1058,6 +1124,28 @@ func TestUint32Builder_Resize(t *testing.T) {
 
 	ab.Resize(32)
 	assert.Equal(t, 5, ab.Len())
+}
+
+func TestUint32BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewUint32Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewUint32Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
 }
 
 func TestFloat32StringRoundTrip(t *testing.T) {
@@ -1486,6 +1574,28 @@ func TestInt16Builder_Resize(t *testing.T) {
 	assert.Equal(t, 5, ab.Len())
 }
 
+func TestInt16BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewInt16Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewInt16Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
+}
+
 func TestUint16StringRoundTrip(t *testing.T) {
 	// 1. create array
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -1686,6 +1796,28 @@ func TestUint16Builder_Resize(t *testing.T) {
 
 	ab.Resize(32)
 	assert.Equal(t, 5, ab.Len())
+}
+
+func TestUint16BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewUint16Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewUint16Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
 }
 
 func TestInt8StringRoundTrip(t *testing.T) {
@@ -1890,6 +2022,28 @@ func TestInt8Builder_Resize(t *testing.T) {
 	assert.Equal(t, 5, ab.Len())
 }
 
+func TestInt8BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewInt8Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewInt8Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
+}
+
 func TestUint8StringRoundTrip(t *testing.T) {
 	// 1. create array
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -2090,6 +2244,28 @@ func TestUint8Builder_Resize(t *testing.T) {
 
 	ab.Resize(32)
 	assert.Equal(t, 5, ab.Len())
+}
+
+func TestUint8BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewUint8Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewUint8Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
 }
 
 func TestTime32StringRoundTrip(t *testing.T) {
@@ -2299,6 +2475,28 @@ func TestTime32Builder_Resize(t *testing.T) {
 	assert.Equal(t, 5, ab.Len())
 }
 
+func TestTime32BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewTime32Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewTime32Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
+}
+
 func TestTime64StringRoundTrip(t *testing.T) {
 	// 1. create array
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -2506,6 +2704,28 @@ func TestTime64Builder_Resize(t *testing.T) {
 	assert.Equal(t, 5, ab.Len())
 }
 
+func TestTime64BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewTime64Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewTime64Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
+}
+
 func TestDate32StringRoundTrip(t *testing.T) {
 	// 1. create array
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -2706,6 +2926,28 @@ func TestDate32Builder_Resize(t *testing.T) {
 
 	ab.Resize(32)
 	assert.Equal(t, 5, ab.Len())
+}
+
+func TestDate32BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewDate32Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewDate32Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
 }
 
 func TestDate64StringRoundTrip(t *testing.T) {
@@ -2917,6 +3159,28 @@ func TestDate64Builder_Resize(t *testing.T) {
 	assert.Equal(t, 5, ab.Len())
 }
 
+func TestDate64BuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewDate64Builder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewDate64Array()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
+}
+
 func TestDurationStringRoundTrip(t *testing.T) {
 	// 1. create array
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -3122,4 +3386,26 @@ func TestDurationBuilder_Resize(t *testing.T) {
 
 	ab.Resize(32)
 	assert.Equal(t, 5, ab.Len())
+}
+
+func TestDurationBuilderUnmarshalJSON(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewDurationBuilder(mem)
+	defer bldr.Release()
+
+	jsonstr := `[0, 1, "+Inf", 2, 3, "NaN", "NaN", 4, 5, "-Inf"]`
+
+	err := bldr.UnmarshalJSON([]byte(jsonstr))
+	assert.NoError(t, err)
+
+	arr := bldr.NewDurationArray()
+	defer arr.Release()
+
+	assert.NotNil(t, arr)
+
+	assert.False(t, math.IsInf(float64(arr.Value(0)), 0), arr.Value(0))
+	assert.True(t, math.IsInf(float64(arr.Value(2)), 1), arr.Value(2))
+	assert.True(t, math.IsNaN(float64(arr.Value(5))), arr.Value(5))
 }

--- a/arrow/array/record.go
+++ b/arrow/array/record.go
@@ -43,7 +43,7 @@ type RecordReader interface {
 
 // simpleRecords is a simple iterator over a collection of records.
 type simpleRecords struct {
-	refCount int64
+	refCount atomic.Int64
 
 	schema *arrow.Schema
 	recs   []arrow.Record
@@ -53,11 +53,11 @@ type simpleRecords struct {
 // NewRecordReader returns a simple iterator over the given slice of records.
 func NewRecordReader(schema *arrow.Schema, recs []arrow.Record) (RecordReader, error) {
 	rs := &simpleRecords{
-		refCount: 1,
-		schema:   schema,
-		recs:     recs,
-		cur:      nil,
+		schema: schema,
+		recs:   recs,
+		cur:    nil,
 	}
+	rs.refCount.Add(1)
 
 	for _, rec := range rs.recs {
 		rec.Retain()
@@ -76,16 +76,16 @@ func NewRecordReader(schema *arrow.Schema, recs []arrow.Record) (RecordReader, e
 // Retain increases the reference count by 1.
 // Retain may be called simultaneously from multiple goroutines.
 func (rs *simpleRecords) Retain() {
-	atomic.AddInt64(&rs.refCount, 1)
+	rs.refCount.Add(1)
 }
 
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 // Release may be called simultaneously from multiple goroutines.
 func (rs *simpleRecords) Release() {
-	debug.Assert(atomic.LoadInt64(&rs.refCount) > 0, "too many releases")
+	debug.Assert(rs.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&rs.refCount, -1) == 0 {
+	if rs.refCount.Add(-1) == 0 {
 		if rs.cur != nil {
 			rs.cur.Release()
 		}
@@ -113,7 +113,7 @@ func (rs *simpleRecords) Err() error { return nil }
 
 // simpleRecord is a basic, non-lazy in-memory record batch.
 type simpleRecord struct {
-	refCount int64
+	refCount atomic.Int64
 
 	schema *arrow.Schema
 
@@ -127,11 +127,12 @@ type simpleRecord struct {
 // NewRecord panics if rows is larger than the height of the columns.
 func NewRecord(schema *arrow.Schema, cols []arrow.Array, nrows int64) arrow.Record {
 	rec := &simpleRecord{
-		refCount: 1,
-		schema:   schema,
-		rows:     nrows,
-		arrs:     make([]arrow.Array, len(cols)),
+		schema: schema,
+		rows:   nrows,
+		arrs:   make([]arrow.Array, len(cols)),
 	}
+	rec.refCount.Add(1)
+
 	copy(rec.arrs, cols)
 	for _, arr := range rec.arrs {
 		arr.Retain()
@@ -211,16 +212,16 @@ func (rec *simpleRecord) validate() error {
 // Retain increases the reference count by 1.
 // Retain may be called simultaneously from multiple goroutines.
 func (rec *simpleRecord) Retain() {
-	atomic.AddInt64(&rec.refCount, 1)
+	rec.refCount.Add(1)
 }
 
 // Release decreases the reference count by 1.
 // When the reference count goes to zero, the memory is freed.
 // Release may be called simultaneously from multiple goroutines.
 func (rec *simpleRecord) Release() {
-	debug.Assert(atomic.LoadInt64(&rec.refCount) > 0, "too many releases")
+	debug.Assert(rec.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&rec.refCount, -1) == 0 {
+	if rec.refCount.Add(-1) == 0 {
 		for _, arr := range rec.arrs {
 			arr.Release()
 		}
@@ -274,7 +275,7 @@ func (rec *simpleRecord) MarshalJSON() ([]byte, error) {
 // RecordBuilder eases the process of building a Record, iteratively, from
 // a known Schema.
 type RecordBuilder struct {
-	refCount int64
+	refCount atomic.Int64
 	mem      memory.Allocator
 	schema   *arrow.Schema
 	fields   []Builder
@@ -283,11 +284,11 @@ type RecordBuilder struct {
 // NewRecordBuilder returns a builder, using the provided memory allocator and a schema.
 func NewRecordBuilder(mem memory.Allocator, schema *arrow.Schema) *RecordBuilder {
 	b := &RecordBuilder{
-		refCount: 1,
-		mem:      mem,
-		schema:   schema,
-		fields:   make([]Builder, schema.NumFields()),
+		mem:    mem,
+		schema: schema,
+		fields: make([]Builder, schema.NumFields()),
 	}
+	b.refCount.Add(1)
 
 	for i := 0; i < schema.NumFields(); i++ {
 		b.fields[i] = NewBuilder(b.mem, schema.Field(i).Type)
@@ -299,14 +300,14 @@ func NewRecordBuilder(mem memory.Allocator, schema *arrow.Schema) *RecordBuilder
 // Retain increases the reference count by 1.
 // Retain may be called simultaneously from multiple goroutines.
 func (b *RecordBuilder) Retain() {
-	atomic.AddInt64(&b.refCount, 1)
+	b.refCount.Add(1)
 }
 
 // Release decreases the reference count by 1.
 func (b *RecordBuilder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		for _, f := range b.fields {
 			f.Release()
 		}

--- a/arrow/array/string.go
+++ b/arrow/array/string.go
@@ -44,7 +44,7 @@ type String struct {
 // NewStringData constructs a new String array from data.
 func NewStringData(data arrow.ArrayData) *String {
 	a := &String{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -191,7 +191,7 @@ type LargeString struct {
 // NewStringData constructs a new String array from data.
 func NewLargeStringData(data arrow.ArrayData) *LargeString {
 	a := &LargeString{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -332,7 +332,7 @@ type StringView struct {
 
 func NewStringViewData(data arrow.ArrayData) *StringView {
 	a := &StringView{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }

--- a/arrow/array/union.go
+++ b/arrow/array/union.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"reflect"
 	"strings"
-	"sync/atomic"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/bitutil"
@@ -246,7 +245,7 @@ func NewSparseUnion(dt *arrow.SparseUnionType, length int, children []arrow.Arra
 // NewSparseUnionData constructs a SparseUnion array from the given ArrayData object.
 func NewSparseUnionData(data arrow.ArrayData) *SparseUnion {
 	a := &SparseUnion{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -506,7 +505,7 @@ func NewDenseUnion(dt *arrow.DenseUnionType, length int, children []arrow.Array,
 // NewDenseUnionData constructs a DenseUnion array from the given ArrayData object.
 func NewDenseUnionData(data arrow.ArrayData) *DenseUnion {
 	a := &DenseUnion{}
-	a.refCount = 1
+	a.refCount.Add(1)
 	a.setData(data.(*Data))
 	return a
 }
@@ -741,7 +740,7 @@ func newUnionBuilder(mem memory.Allocator, children []Builder, typ arrow.UnionTy
 		children = make([]Builder, 0)
 	}
 	b := unionBuilder{
-		builder:         builder{refCount: 1, mem: mem},
+		builder:         builder{mem: mem},
 		mode:            typ.Mode(),
 		codes:           typ.TypeCodes(),
 		children:        children,
@@ -750,6 +749,7 @@ func newUnionBuilder(mem memory.Allocator, children []Builder, typ arrow.UnionTy
 		childFields:     make([]arrow.Field, len(children)),
 		typesBuilder:    newInt8BufferBuilder(mem),
 	}
+	b.refCount.Add(1)
 
 	b.typeIDtoChildID[0] = arrow.InvalidUnionChildID
 	for i := 1; i < len(b.typeIDtoChildID); i *= 2 {
@@ -795,9 +795,9 @@ func (b *unionBuilder) reserve(elements int, resize func(int)) {
 }
 
 func (b *unionBuilder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		for _, c := range b.children {
 			c.Release()
 		}
@@ -854,7 +854,6 @@ func (b *unionBuilder) nextTypeID() arrow.UnionTypeCode {
 	id := b.denseTypeID
 	b.denseTypeID++
 	return id
-
 }
 
 func (b *unionBuilder) newData() *Data {
@@ -1228,9 +1227,9 @@ func (b *DenseUnionBuilder) Append(nextType arrow.UnionTypeCode) {
 }
 
 func (b *DenseUnionBuilder) Release() {
-	debug.Assert(atomic.LoadInt64(&b.refCount) > 0, "too many releases")
+	debug.Assert(b.refCount.Load() > 0, "too many releases")
 
-	if atomic.AddInt64(&b.refCount, -1) == 0 {
+	if b.refCount.Add(-1) == 0 {
 		for _, c := range b.children {
 			c.Release()
 		}


### PR DESCRIPTION
### Rationale for this change

This is a follow-up to https://github.com/apache/arrow-go/pull/323.

ARM 32-bit requires atomic operations to be 32-bit aligned. This has not been the case in a rather large amount of cases in the code base. Failing to align causes crashes during runtime.

### What changes are included in this PR?

I replaced all uses of `atomic.LoadInt64`, `atomic.StoreInt64` and `atomic.AddInt64` with `atomic.Int64{}` and its methods. This type has built-in alignment, so it does not matter in which order struct fields appear, which makes it generally harder to screw up alignment during changes.

### Are these changes tested?

Briefly on the 32-bit architecture with the same program mentioned in #323. The best way to move forward here would be to also add a 32bit CI environment to make sure `arrow` builds and tests there. But I guess this is out of scope for this PR.

I've noticed that `go vet ./...` produces many warnings over the project, most of them already there before this PR. The new ones are all of the kind:

```
arrow/array/dictionary.go:614:42: literal copies lock value from bldr: github.com/apache/arrow-go/v18/arrow/array.dictionaryBuilder contains github.com/apache/arrow-go/v18/arrow/array.builder contains sync/atomic.Int64 contains sync/atomic.noCopy
```

I.e. false positives due to initialization in another struct and then copying it in a constructor function.

### Are there any user-facing changes?

In the hope that everything was done right: no.