### PR TITLE
feat(nested): export StructType metadata

### DIFF
--- a/arrow/datatype_nested.go
+++ b/arrow/datatype_nested.go
@@ -404,6 +404,13 @@ type StructType struct {
 //
 // StructOf panics if there is a field with an invalid DataType.
 func StructOf(fs ...Field) *StructType {
+	return StructOfWithMetadata(Metadata{}, fs...)
+}
+
+// StructOfWithMetadata returns the struct type with fields fs and metadata.
+//
+// StructOfWithMetadata panics if there is a field with an invalid DataType.
+func StructOfWithMetadata(metadata Metadata, fs ...Field) *StructType {
 	n := len(fs)
 	if n == 0 {
 		return &StructType{}
@@ -412,6 +419,7 @@ func StructOf(fs ...Field) *StructType {
 	t := &StructType{
 		fields: make([]Field, n),
 		index:  make(map[string][]int, n),
+		meta:   metadata,
 	}
 	for i, f := range fs {
 		if f.Type == nil {
@@ -521,6 +529,10 @@ func (t *StructType) Fingerprint() string {
 
 func (*StructType) Layout() DataTypeLayout {
 	return DataTypeLayout{Buffers: []BufferSpec{SpecBitmap()}}
+}
+
+func (t *StructType) Metadata() Metadata {
+	return t.meta
 }
 
 type MapType struct {

--- a/arrow/datatype_nested_test.go
+++ b/arrow/datatype_nested_test.go
@@ -83,8 +83,9 @@ func TestListOf(t *testing.T) {
 
 func TestStructOf(t *testing.T) {
 	for _, tc := range []struct {
-		fields []Field
-		want   DataType
+		fields   []Field
+		want     DataType
+		metadata Metadata
 	}{
 		{
 			fields: nil,
@@ -190,9 +191,22 @@ func TestStructOf(t *testing.T) {
 				index: map[string][]int{"f1": {0, 2}, "f2": {1}},
 			},
 		},
+		{
+			metadata: NewMetadata([]string{"k"}, []string{"v"}),
+			fields: []Field{
+				{Name: "f1", Type: PrimitiveTypes.Int32},
+			},
+			want: &StructType{
+				fields: []Field{
+					{Name: "f1", Type: PrimitiveTypes.Int32},
+				},
+				index: map[string][]int{"f1": {0}},
+				meta:  NewMetadata([]string{"k"}, []string{"v"}),
+			},
+		},
 	} {
 		t.Run("", func(t *testing.T) {
-			got := StructOf(tc.fields...)
+			got := StructOfWithMetadata(tc.metadata, tc.fields...)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Fatalf("got=%#v, want=%#v", got, tc.want)
 			}


### PR DESCRIPTION
### Rationale for this change

`StructType` contains private `meta Metadata` field, which is not exported and only used in tests. Analogous to `Schema` and `Field` structs, I want to keep metadata of `StructType`, and it seems that it being not export is an oversight.

### What changes are included in this PR?

* Add `StructType.Metadata` method
* Add `StructOfWithMetadata` method
* Rewire `StructOf` to call `StructOfWithMetadata` with empty metadata struct

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes