### PR TITLE
chore: Enable GitHub discussions on arrow-go repository

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -29,11 +29,13 @@ github:
     rebase: false
     squash: true
   features:
+    discussions: true
     issues: true
   protected_branches:
     main:
       required_linear_history: true
 notifications:
+  discussions: user@arrow.apache.org
   commits: commits@arrow.apache.org
   issues_status: issues@arrow.apache.org
   issues_comment: github@arrow.apache.org


### PR DESCRIPTION
### Rationale for this change

We have enabled GitHub discussions on all other repositories for Arrow.

### What changes are included in this PR?

Changes to `.asf.yaml` to enable GitHub discussions.

### Are these changes tested?

No relevant.

### Are there any user-facing changes?

No