### PR TITLE
Compress: add MarshalText and UnmarshalText

### DIFF
--- a/parquet/compress/compress.go
+++ b/parquet/compress/compress.go
@@ -33,6 +33,14 @@ func (c Compression) String() string {
 	return parquet.CompressionCodec(c).String()
 }
 
+func (c Compression) MarshalText() ([]byte, error) {
+	return parquet.CompressionCodec(c).MarshalText()
+}
+
+func (c *Compression) UnmarshalText(text []byte) error {
+	return (*parquet.CompressionCodec)(c).UnmarshalText(text)
+}
+
 // DefaultCompressionLevel will use flate.DefaultCompression since many of the compression libraries
 // use that to denote "use the default".
 const DefaultCompressionLevel = flate.DefaultCompression

--- a/parquet/compress/compress_test.go
+++ b/parquet/compress/compress_test.go
@@ -139,18 +139,39 @@ func TestCompressReaderWriter(t *testing.T) {
 	}
 }
 
+var marshalTests = []struct {
+	text  string
+	codec compress.Compression
+}{
+	{"UNCOMPRESSED", compress.Codecs.Uncompressed},
+	{"SNAPPY", compress.Codecs.Snappy},
+	{"GZIP", compress.Codecs.Gzip},
+	{"LZO", compress.Codecs.Lzo},
+	{"BROTLI", compress.Codecs.Brotli},
+	{"LZ4", compress.Codecs.Lz4},
+	{"ZSTD", compress.Codecs.Zstd},
+	{"LZ4_RAW", compress.Codecs.Lz4Raw},
+}
+
 func TestMarshalText(t *testing.T) {
-	compression := compress.Codecs.Zstd
-	data, err := compression.MarshalText()
-	assert.NoError(t, err)
-	assert.Equal(t, "ZSTD", string(data))
+	for _, tt := range marshalTests {
+		t.Run(tt.text, func(t *testing.T) {
+			data, err := tt.codec.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.text, string(data))
+		})
+	}
 }
 
 func TestUnmarshalText(t *testing.T) {
-	var compression compress.Compression
-	err := compression.UnmarshalText([]byte("ZSTD"))
-	assert.NoError(t, err)
-	assert.Equal(t, compress.Codecs.Zstd, compression)
+	for _, tt := range marshalTests {
+		t.Run(tt.text, func(t *testing.T) {
+			var compression compress.Compression
+			err := compression.UnmarshalText([]byte(tt.text))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.codec, compression)
+		})
+	}
 }
 
 func TestUnmarshalTextError(t *testing.T) {

--- a/parquet/compress/compress_test.go
+++ b/parquet/compress/compress_test.go
@@ -138,3 +138,23 @@ func TestCompressReaderWriter(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalText(t *testing.T) {
+	compression := compress.Codecs.Zstd
+	data, err := compression.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, "ZSTD", string(data))
+}
+
+func TestUnmarshalText(t *testing.T) {
+	var compression compress.Compression
+	err := compression.UnmarshalText([]byte("ZSTD"))
+	assert.NoError(t, err)
+	assert.Equal(t, compress.Codecs.Zstd, compression)
+}
+
+func TestUnmarshalTextError(t *testing.T) {
+	var compression compress.Compression
+	err := compression.UnmarshalText([]byte("NO SUCH CODEC"))
+	assert.EqualError(t, err, "not a valid CompressionCodec string")
+}


### PR DESCRIPTION
### Rationale for this change

Right now, there is no public API to convert a string like `"ZSTD"` to a compression codec. There is only https://pkg.go.dev/github.com/apache/arrow-go/v18@v18.2.0/parquet/internal/gen-go/parquet#CompressionCodecFromString but that can't be used since it's in an `internal` package.

Adding `UnmarshalText` can be used for applications taking such a string as configuration option. Adding `MarshalText` isn't strictly needed since it overlaps with `String()` but makes sense for symmetry.

### What changes are included in this PR?

Add `UnmarshalText` and `MarshalText` as thin wrappers around the same methods from the internal https://pkg.go.dev/github.com/apache/arrow-go/v18@v18.2.0/parquet/internal/gen-go/parquet#CompressionCodec type.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Minor new API for `Compression` type