### PR TITLE
GH-46087: [FlightSQL] Allow returning column remarks in FlightSQL's CommandGetTables

### DIFF
--- a/arrow/flight/flightsql/column_metadata.go
+++ b/arrow/flight/flightsql/column_metadata.go
@@ -50,6 +50,7 @@ const (
 	IsCaseSensitiveKey = "ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE"
 	IsReadOnlyKey      = "ARROW:FLIGHT:SQL:IS_READ_ONLY"
 	IsSearchableKey    = "ARROW:FLIGHT:SQL:IS_SEARCHABLE"
+	RemarksKey         = "ARROW:FLIGHT:SQL:REMARKS"
 )
 
 // ColumnMetadata is a helper object for managing and querying the
@@ -128,6 +129,10 @@ func (c *ColumnMetadata) IsReadOnly() (bool, bool) {
 
 func (c *ColumnMetadata) IsSearchable() (bool, bool) {
 	return c.findBoolVal(IsSearchableKey)
+}
+
+func (c *ColumnMetadata) Remarks() (string, bool) {
+	return c.findStrVal(RemarksKey)
 }
 
 // ColumnMetadataBuilder is a convenience builder for constructing
@@ -213,5 +218,11 @@ func (c *ColumnMetadataBuilder) IsReadOnly(v bool) *ColumnMetadataBuilder {
 func (c *ColumnMetadataBuilder) IsSearchable(v bool) *ColumnMetadataBuilder {
 	c.keys = append(c.keys, IsSearchableKey)
 	c.vals = append(c.vals, boolToStr(v))
+	return c
+}
+
+func (c *ColumnMetadataBuilder) Remarks(remarks string) *ColumnMetadataBuilder {
+	c.keys = append(c.keys, RemarksKey)
+	c.vals = append(c.vals, remarks)
 	return c
 }

--- a/arrow/internal/flight_integration/scenario.go
+++ b/arrow/internal/flight_integration/scenario.go
@@ -2228,7 +2228,7 @@ func getQuerySchema() *arrow.Schema {
 				IsSearchable(true).
 				CatalogName("catalog_test").
 				Precision(100).
-        Remarks("test column").
+				Remarks("test column").
 				Build().Data}}, nil)
 }
 
@@ -2243,7 +2243,7 @@ func getQueryWithTransactionSchema() *arrow.Schema {
 				SchemaName("schema_test").
 				IsSearchable(true).
 				CatalogName("catalog_test").
-        Remarks("test column").
+				Remarks("test column").
 				Precision(100).Build().Data}}, nil)
 }
 

--- a/arrow/internal/flight_integration/scenario.go
+++ b/arrow/internal/flight_integration/scenario.go
@@ -2228,6 +2228,7 @@ func getQuerySchema() *arrow.Schema {
 				IsSearchable(true).
 				CatalogName("catalog_test").
 				Precision(100).
+        Remarks("test column").
 				Build().Data}}, nil)
 }
 
@@ -2242,6 +2243,7 @@ func getQueryWithTransactionSchema() *arrow.Schema {
 				SchemaName("schema_test").
 				IsSearchable(true).
 				CatalogName("catalog_test").
+        Remarks("test column").
 				Precision(100).Build().Data}}, nil)
 }
 


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow/pull/46110

### What changes are included in this PR?

A new column metadata value

### Are these changes tested?

No; there seem to be no tests that'd verify that `ColumnMetadata` works; should I add unit tests specifically for the new methods?

### Are there any user-facing changes?

Yes, two new methods