### PR TITLE
Fix panic when WriteDataPage fails

### DIFF
--- a/parquet/file/column_writer.go
+++ b/parquet/file/column_writer.go
@@ -422,9 +422,12 @@ func (w *columnWriter) FlushBufferedDataPages() (err error) {
 		}
 	}
 
-	for _, p := range w.pages {
+	for i, p := range w.pages {
 		defer p.Release()
 		if err = w.WriteDataPage(p); err != nil {
+			// To keep pages in consistent state,
+			// remove the pages that will be released using above defer call.
+			w.pages = w.pages[i+1:]
 			return err
 		}
 	}


### PR DESCRIPTION
### Rationale for this change
We saw crash with call stack:
```
error: runtime error: invalid memory address or nil pointer dereference
runtime.gopanic
	runtime/panic.go:792
runtime.panicmem
	runtime/panic.go:262
runtime.sigpanic
	runtime/signal_unix.go:925
github.com/apache/arrow-go/v18/arrow/memory.(*Buffer).Bytes
	github.com/apache/arrow-go/v18@v18.2.0/arrow/memory/buffer.go:106
github.com/apache/arrow-go/v18/parquet/file.(*page).Data
	github.com/apache/arrow-go/v18@v18.2.0/parquet/file/page_reader.go:90
github.com/apache/arrow-go/v18/parquet/file.(*columnWriter).TotalBytesWritten
	github.com/apache/arrow-go/v18@v18.2.0/parquet/file/column_writer.go:203
github.com/apache/arrow-go/v18/parquet/file.(*rowGroupWriter).Close
	github.com/apache/arrow-go/v18@v18.2.0/parquet/file/row_group_writer.go:237
github.com/apache/arrow-go/v18/parquet/file.(*Writer).FlushWithFooter
	github.com/apache/arrow-go/v18@v18.2.0/parquet/file/file_writer.go:229
github.com/apache/arrow-go/v18/parquet/file.(*Writer).Close
	github.com/apache/arrow-go/v18@v18.2.0/parquet/file/file_writer.go:215
```

On code inspection, i see that if `WriteDataPage` fails, `w.pages` will still be holding released `Buffer/Page`s.
On error handling, we close the parquet file, which tries to access `w.pages` through `TotalBytesWritten()` - causing crash.

### What changes are included in this PR?
The PR includes a bug fix which removes the to-be released pages from `w.pages`.

### Are these changes tested?
Added unit test.

Without the fix: test panics
```
=== RUN   TestWriteDataFailure
--- FAIL: TestWriteDataFailure (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1026e4184]

goroutine 21 [running]:
testing.tRunner.func1.2({0x1031c7de0, 0x104016500})
	/opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1737 +0x334
panic({0x1031c7de0?, 0x104016500?})
	/opt/homebrew/Cellar/go/1.24.1/libexec/src/runtime/panic.go:792 +0x124
github.com/apache/arrow-go/v18/arrow/memory.(*Buffer).Bytes(...)
	/Users/ashishnegi/work/repos/arrow-go/arrow/memory/buffer.go:112
github.com/apache/arrow-go/v18/parquet/file.(*page).Data(...)
	/Users/ashishnegi/work/repos/arrow-go/parquet/file/page_reader.go:90
github.com/apache/arrow-go/v18/parquet/file.(*columnWriter).TotalBytesWritten(...)
	/Users/ashishnegi/work/repos/arrow-go/parquet/file/column_writer.go:209
github.com/apache/arrow-go/v18/parquet/file_test.TestWriteDataFailure(0x14000103180)
	/Users/ashishnegi/work/repos/arrow-go/parquet/file/column_writer_test.go:121 +0x4b4
testing.tRunner(0x14000103180, 0x10339e3d8)
	/opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x374
FAIL	github.com/apache/arrow-go/v18/parquet/file	0.764s
```

With the fix:
```
=== RUN   TestWriteDataFailure
--- PASS: TestWriteDataFailure (0.00s)
```

### Are there any user-facing changes?
No

