### PR TITLE
fix: TestDeltaByteArray implementation and fix

### DIFF
--- a/parquet/file/file_reader_test.go
+++ b/parquet/file/file_reader_test.go
@@ -860,11 +860,9 @@ func TestDeltaByteArray(t *testing.T) {
 
 	for rr.Next() {
 		rec := rr.Record()
-		defer rec.Release()
-
-		for i := 0; i < int(rec.NumCols()); i++ {
+		for i := range int(rec.NumCols()) {
 			vals := rec.Column(i)
-			for j := 0; j < vals.Len(); j++ {
+			for j := range vals.Len() {
 				if vals.IsNull(j) {
 					require.Equal(t, records[j][i], "")
 					continue

--- a/parquet/file/file_reader_test.go
+++ b/parquet/file/file_reader_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/csv"
 	"fmt"
 	"io"
 	"os"
@@ -819,4 +820,54 @@ func TestLZ4RawLargerFileRead(t *testing.T) {
 		[]byte("a9ee2527-821b-4b71-a926-03f73c3fc8b7"),
 	}
 	require.Equal(t, expectedValsHead, vals[:len(expectedValsHead)])
+}
+
+func TestDeltaByteArray(t *testing.T) {
+	dir := os.Getenv("PARQUET_TEST_DATA")
+	if dir == "" {
+		t.Skip("no path supplied with PARQUET_TEST_DATA")
+	}
+	require.DirExists(t, dir)
+
+	expected, err := os.ReadFile(path.Join(dir, "delta_byte_array_expect.csv"))
+	require.NoError(t, err)
+	csvReader := csv.NewReader(bytes.NewReader(expected))
+
+	records, err := csvReader.ReadAll()
+	require.NoError(t, err)
+
+	records = records[1:] // skip header
+
+	props := parquet.NewReaderProperties(memory.DefaultAllocator)
+	fileReader, err := file.OpenParquetFile(path.Join(dir, "delta_byte_array.parquet"),
+		false, file.WithReadProps(props))
+	require.NoError(t, err)
+	defer fileReader.Close()
+
+	arrowReader, err := pqarrow.NewFileReader(
+		fileReader,
+		pqarrow.ArrowReadProperties{BatchSize: 1024},
+		memory.DefaultAllocator,
+	)
+	require.NoError(t, err)
+
+	rr, err := arrowReader.GetRecordReader(context.Background(), nil, nil)
+	require.NoError(t, err)
+	defer rr.Release()
+
+	for rr.Next() {
+		rec := rr.Record()
+		defer rec.Release()
+
+		for i := 0; i < int(rec.NumCols()); i++ {
+			vals := rec.Column(i)
+			for j := 0; j < vals.Len(); j++ {
+				if vals.IsNull(j) {
+					require.Equal(t, records[j][i], "")
+					continue
+				}
+				require.Equal(t, records[j][i], vals.ValueStr(j))
+			}
+		}
+	}
 }

--- a/parquet/file/file_reader_test.go
+++ b/parquet/file/file_reader_test.go
@@ -844,6 +844,9 @@ func TestDeltaByteArray(t *testing.T) {
 	require.NoError(t, err)
 	defer fileReader.Close()
 
+	nrows := fileReader.MetaData().NumRows
+	assert.Equal(t, nrows, int64(len(records)), "expected %d rows, got %d", len(records), nrows)
+
 	arrowReader, err := pqarrow.NewFileReader(
 		fileReader,
 		pqarrow.ArrowReadProperties{BatchSize: 1024},

--- a/parquet/internal/encoding/delta_bit_packing.go
+++ b/parquet/internal/encoding/delta_bit_packing.go
@@ -101,6 +101,7 @@ func (d *deltaBitPackDecoder[T]) SetData(nvalues int, data []byte) error {
 
 	d.valsPerMini = uint32(d.blockSize / d.miniBlocksPerBlock)
 	d.usedFirst = false
+	d.nvals = int(d.totalValues)
 	return nil
 }
 
@@ -197,7 +198,7 @@ func (d *deltaBitPackDecoder[T]) Discard(n int) (int, error) {
 // Decode retrieves min(remaining values, len(out)) values from the data and returns the number
 // of values actually decoded and any errors encountered.
 func (d *deltaBitPackDecoder[T]) Decode(out []T) (int, error) {
-	max := shared_utils.Min(len(out), int(d.totalValues))
+	max := shared_utils.Min(len(out), int(d.nvals))
 	if max == 0 {
 		return 0, nil
 	}

--- a/parquet/internal/encoding/delta_bit_packing.go
+++ b/parquet/internal/encoding/delta_bit_packing.go
@@ -197,7 +197,7 @@ func (d *deltaBitPackDecoder[T]) Discard(n int) (int, error) {
 // Decode retrieves min(remaining values, len(out)) values from the data and returns the number
 // of values actually decoded and any errors encountered.
 func (d *deltaBitPackDecoder[T]) Decode(out []T) (int, error) {
-	max := shared_utils.Min(len(out), int(d.nvals))
+	max := shared_utils.Min(len(out), int(d.totalValues))
 	if max == 0 {
 		return 0, nil
 	}

--- a/parquet/internal/encoding/delta_byte_array.go
+++ b/parquet/internal/encoding/delta_byte_array.go
@@ -171,7 +171,7 @@ func (d *DeltaByteArrayDecoder) SetData(nvalues int, data []byte) error {
 		return err
 	}
 
-	d.prefixLengths = make([]int32, nvalues)
+	d.prefixLengths = make([]int32, prefixLenDec.ValuesLeft())
 	// decode all the prefix lengths first so we know how many bytes it took to get the
 	// prefix lengths for nvalues
 	prefixLenDec.Decode(d.prefixLengths)


### PR DESCRIPTION
This exact test seems to be passing on v17 version. More investigation is needed

### Rationale for this change

After updating from v17 to v18 I noticed a test case failing that was passing before.


### What changes are included in this PR?

This PR contains a test case to reproduce the issue. A reference PR for version v17 can be found here
- https://github.com/apache/arrow/pull/46353


### Are these changes tested?

The PR itself just contains the test

### Are there any user-facing changes?

