### PR TITLE
feat(arrow/cdata): Add ReleaseCArrowArrayStream function

### DIFF
--- a/arrow/cdata/cdata.go
+++ b/arrow/cdata/cdata.go
@@ -1035,3 +1035,7 @@ func releaseArr(arr *CArrowArray) {
 func releaseSchema(schema *CArrowSchema) {
 	C.ArrowSchemaRelease(schema)
 }
+
+func releaseStream(stream *CArrowArrayStream) {
+	C.ArrowArrayStreamRelease(stream)
+}

--- a/arrow/cdata/cdata_test.go
+++ b/arrow/cdata/cdata_test.go
@@ -768,7 +768,7 @@ func TestRecordBatch(t *testing.T) {
 
 func TestRecordReaderStream(t *testing.T) {
 	stream := arrayStreamTest()
-	defer releaseStream(stream)
+	defer ReleaseCArrowArrayStream(stream)
 
 	rdr := ImportCArrayStream(stream, nil)
 	i := 0
@@ -852,7 +852,7 @@ func TestExportRecordReaderStreamLifetime(t *testing.T) {
 
 	// C Stream is holding on to memory
 	assert.NotEqual(t, 0, mem.CurrentAlloc())
-	releaseStream(out)
+	ReleaseCArrowArrayStream(out)
 }
 
 func TestEmptyListExport(t *testing.T) {

--- a/arrow/cdata/cdata_test_framework.go
+++ b/arrow/cdata/cdata_test_framework.go
@@ -98,10 +98,6 @@ func exportInt32TypeSchema() CArrowSchema {
 	return s
 }
 
-func releaseStream(s *CArrowArrayStream) {
-	C.ArrowArrayStreamRelease(s)
-}
-
 func schemaIsReleased(s *CArrowSchema) bool {
 	return C.ArrowSchemaIsReleased(s) == 1
 }

--- a/arrow/cdata/interface.go
+++ b/arrow/cdata/interface.go
@@ -268,7 +268,8 @@ func ExportArrowArray(arr arrow.Array, out *CArrowArray, outSchema *CArrowSchema
 // callbacks to be a working ArrowArrayStream utilizing the passed in RecordReader. The
 // CArrowArrayStream takes ownership of the RecordReader until the consumer calls the release
 // callback, as such it is unnecessary to call Release on the passed in reader unless it has
-// previously been retained.
+// previously been retained. To call that release callback and prevent a memory leak, you can
+// call ReleaseCArrowArrayStream on the CArrowArrayStream once it is no longer needed.
 //
 // WARNING: the output ArrowArrayStream MUST BE ZERO INITIALIZED, or the Go garbage
 // collector may error at runtime, due to CGO rules ("the current implementation may
@@ -283,6 +284,9 @@ func ReleaseCArrowArray(arr *CArrowArray) { releaseArr(arr) }
 
 // ReleaseCArrowSchema calls ArrowSchemaRelease on the passed in cdata schema
 func ReleaseCArrowSchema(schema *CArrowSchema) { releaseSchema(schema) }
+
+// ReleaseCArrowArrayStream calls ArrowArrayStreamRelease on the passed in cdata stream
+func ReleaseCArrowArrayStream(stream *CArrowArrayStream) { releaseStream(stream) }
 
 // RecordMessage is a simple container for a record batch channel to stream for
 // using the Async C Data Interface via ExportAsyncRecordBatchStream.


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow-go/issues/371

@zeroshade 

### What changes are included in this PR?

A new `ReleaseCArrowArrayStream` function to facilitate triggering the release callback of a `CArrowArrayStream`.

### Are these changes tested?

```
$ go test ./arrow/cdata -tags=test -count=1

ok      github.com/apache/arrow-go/v18/arrow/cdata      5.413s
```

### Are there any user-facing changes?

Yes, a new function is added.