### PR TITLE
fix: list_columns.parquet testing

### DIFF
--- a/parquet/pqarrow/column_readers.go
+++ b/parquet/pqarrow/column_readers.go
@@ -93,7 +93,7 @@ func (lr *leafReader) IsOrHasRepeatedChild() bool { return false }
 
 func (lr *leafReader) LoadBatch(nrecords int64) (err error) {
 	lr.releaseOut()
-	lr.recordRdr.ResetValues()
+	lr.recordRdr.Reset()
 
 	if err := lr.recordRdr.Reserve(nrecords); err != nil {
 		return err


### PR DESCRIPTION
### Rationale for this change

add list_columns.parquet testing. `rr.Next()` is returning true when we've already reached the end of the file. This leads to a panic later on


### What changes are included in this PR?

- Test that proves list_columns.parquet is not working as expected.
- Use known path for partquet_testing if var is not defined. This ensures test can be run as usual but still enables custom locations for parquet_test_data. It also guarantees failure if not run correctly.

### Are these changes tested?

That is the goal of the PR


### Are there any user-facing changes?

no?
