### PR TITLE
chore: Use apache/arrow-js for JS in integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -374,6 +374,11 @@ jobs:
         with:
           repository: apache/arrow-java
           path: java
+      - name: Checkout Arrow JavaScript
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: apache/arrow-js
+          path: js
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
@@ -397,6 +402,7 @@ jobs:
             -e ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS=go \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_JAVA=1 \
+            -e ARCHERY_INTEGRATION_WITH_JS=1 \
             -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
             -e ARCHERY_INTEGRATION_WITH_RUST=1 \
             conda-integration


### PR DESCRIPTION
### Rationale for this change

We split js/ in apache/arrow to apache/arrow-js.

### What changes are included in this PR?

Use apache/arrow-js not apache/arrow for JS.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

Closes #388.