### PR TITLE
fix(parquet/pqarrow): Fix propagation of field-ids for Lists

### DIFF
--- a/parquet/pqarrow/encode_dictionary_test.go
+++ b/parquet/pqarrow/encode_dictionary_test.go
@@ -688,7 +688,9 @@ func TestArrowWriteNestedSubfieldDictionary(t *testing.T) {
 	dictValues := array.NewDictionaryArray(dictType, indices, dict)
 	defer dictValues.Release()
 
-	data := array.NewData(arrow.ListOf(dictType), 3, []*memory.Buffer{nil, offsets.Data().Buffers()[1]},
+	data := array.NewData(arrow.ListOfField(arrow.Field{
+		Name: "element", Type: dictType, Nullable: true,
+		Metadata: arrow.NewMetadata([]string{"PARQUET:field_id"}, []string{"-1"})}), 3, []*memory.Buffer{nil, offsets.Data().Buffers()[1]},
 		[]arrow.ArrayData{dictValues.Data()}, 0, 0)
 	defer data.Release()
 	values := array.NewListData(data)

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -1011,19 +1011,19 @@ func getNestedFactory(origin, inferred arrow.DataType) func(fieldList []arrow.Fi
 		switch origin.ID() {
 		case arrow.LIST:
 			return func(list []arrow.Field) arrow.DataType {
-				return arrow.ListOf(list[0].Type)
+				return arrow.ListOfField(list[0])
 			}
 		case arrow.FIXED_SIZE_LIST:
 			sz := origin.(*arrow.FixedSizeListType).Len()
 			return func(list []arrow.Field) arrow.DataType {
-				return arrow.FixedSizeListOf(sz, list[0].Type)
+				return arrow.FixedSizeListOfField(sz, list[0])
 			}
 		}
 	case arrow.MAP:
 		if origin.ID() == arrow.MAP {
 			return func(list []arrow.Field) arrow.DataType {
 				valType := list[0].Type.(*arrow.StructType)
-				return arrow.MapOf(valType.Field(0).Type, valType.Field(1).Type)
+				return arrow.MapOfFields(valType.Field(0), valType.Field(1))
 			}
 		}
 	}


### PR DESCRIPTION
### Rationale for this change
An issue was found in apache/iceberg-go when attempting to retrieve data from a table containing a List Column that had a struct as the element. It was failing to propagate the element-id for the fields when fetching. I tracked it down to the schema handling here.

### What changes are included in this PR?
Changes the `getNestedFactory` method in pqarrow/schema.go to use `ListOfField` instead of `ListOf` so that it preserves the metadata, i.e. the field id.

### Are these changes tested?
Yes, a test has been added to cover this scenario.

### Are there any user-facing changes?
Previously this situation would result in a field-id of -1, now users will see the field-id get propagated correctly.
