### PR TITLE
chore: bump Windows GitHub hosted runner to windows-2022

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,8 +222,8 @@ jobs:
         run: |
           ci/scripts/test.sh $(pwd)
   windows:
-    name: AMD64 Windows 2019 Go ${{ matrix.go }}
-    runs-on: windows-2019
+    name: AMD64 Windows 2022 Go ${{ matrix.go }}
+    runs-on: windows-2022
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -250,7 +250,7 @@ jobs:
         run: ci/scripts/test.sh $(pwd)
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} CGO
-    runs-on: windows-2019
+    runs-on: windows-2022
     timeout-minutes: 20
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Rationale for this change

GitHub is deprecating Windows hosted runners for 2019, see:
- https://github.com/actions/runner-images/issues/12045

We did update on the main Apache Arrow repo already, see:
- https://github.com/apache/arrow/pull/46694

### What changes are included in this PR?

Update the runner version

### Are these changes tested?

Yes via CI.

### Are there any user-facing changes?

No

Closes: https://github.com/apache/arrow-go/issues/406