### PR TITLE
ci(benchmark): Fix benchmark runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,8 +29,7 @@ permissions:
   contents: read
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
-    container: debian:12
+    runs-on: ubuntu-latest    
     strategy:
       matrix:
         go: ['1.22.7']


### PR DESCRIPTION
### Rationale for this change
Fixes #408 

### What changes are included in this PR?
Run the benchmark directly on the runner instead of using a container

Using a branch on the repo itself instead of a fork so that it has access to the secrets to actually run the benchmark and confirm this fixes the issue.

