### PR TITLE
ci: fix flaky test

### DIFF
--- a/parquet/metadata/bloom_filter_reader_test.go
+++ b/parquet/metadata/bloom_filter_reader_test.go
@@ -52,6 +52,7 @@ func (suite *BloomFilterBuilderSuite) SetupTest() {
 
 func (suite *BloomFilterBuilderSuite) TearDownTest() {
 	runtime.GC() // we use setfinalizer to clean up the buffers, so run the GC
+	runtime.GC()
 	suite.mem.AssertSize(suite.T(), 0)
 }
 


### PR DESCRIPTION
### Rationale for this change
Fixing flaky bloom filter memory check test

### What changes are included in this PR?
Added an additional runtime.GC() call to ensure the releases are called.

