### PR TITLE
ci: make additional checks to prevent flaky EOF

### DIFF
--- a/arrow/flight/flightsql/example/sql_batch_reader.go
+++ b/arrow/flight/flightsql/example/sql_batch_reader.go
@@ -21,7 +21,6 @@ package example
 
 import (
 	"database/sql"
-	"errors"
 	"io"
 	"reflect"
 	"strconv"
@@ -266,7 +265,7 @@ func (r *SqlBatchReader) Next() bool {
 
 	rows := 0
 	for rows < maxBatchSize && r.rows.Next() {
-		if err := r.rows.Scan(r.rowdest...); err != nil && !errors.Is(err, io.EOF) {
+		if err := r.rows.Scan(r.rowdest...); err != nil && err.Error() != io.EOF.Error() {
 			// Not really useful except for testing Flight SQL clients
 			detail := wrapperspb.StringValue{Value: r.schema.String()}
 			if st, sterr := status.New(codes.Unknown, err.Error()).WithDetails(&detail); sterr != nil {

--- a/arrow/flight/flightsql/example/sqlite_tables_schema_batch_reader.go
+++ b/arrow/flight/flightsql/example/sqlite_tables_schema_batch_reader.go
@@ -175,7 +175,7 @@ func (s *SqliteTablesSchemaBatchReader) Next() bool {
 		for rows.Next() {
 			if err := rows.Scan(&tableName, &name, &typ, &nn); err != nil {
 				rows.Close()
-				if !errors.Is(err, io.EOF) {
+				if err.Error() != io.EOF.Error() {
 					s.err = err
 				}
 				return false

--- a/arrow/flight/record_batch_reader.go
+++ b/arrow/flight/record_batch_reader.go
@@ -18,7 +18,9 @@ package flight
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"sync/atomic"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -256,7 +258,7 @@ func ConcatenateReaders(rdrs []array.RecordReader, ch chan<- StreamChunk) {
 			ch <- StreamChunk{Data: rec}
 		}
 		if e, ok := r.(haserr); ok {
-			if e.Err() != nil {
+			if e.Err() != nil && !errors.Is(e.Err(), io.EOF) {
 				ch <- StreamChunk{Err: e.Err()}
 				return
 			}


### PR DESCRIPTION
### Rationale for this change
Additional checks for `io.EOF` to avoid flaky tests
