### PR TITLE
feat: support avro decoded time struct

### DIFF
--- a/arrow/avro/reader_types.go
+++ b/arrow/avro/reader_types.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -871,5 +872,11 @@ func appendTimestampData(b *array.TimestampBuilder, data interface{}) {
 		case int64:
 			b.Append(arrow.Timestamp(v))
 		}
+	case time.Time:
+		v, err := arrow.TimestampFromTime(dt, b.Type().(*arrow.TimestampType).Unit)
+		if err != nil {
+			panic(err)
+		}
+		b.Append(v)
 	}
 }


### PR DESCRIPTION
### Rationale for this change
#415

### What changes are included in this PR?
Suggestion to add support for supporting time.Time decoded value on timestamps for arrow record creation

### Are these changes tested?
I have some tests in my own project where with this change:
```									
"type" : [ "null", {"type" : "long","logicalType" : "timestamp-millis"}]
is converted to:
arrow.TimestampType{Unit: arrow.Millisecond, TimeZone: "UTC"}
```

### Are there any user-facing changes?
No API changes, just broader compatability.
