### PR TITLE
feat(parquet/variant): Parse JSON into variant

### DIFF
--- a/arrow/decimal/decimal.go
+++ b/arrow/decimal/decimal.go
@@ -496,7 +496,7 @@ func startsExponent(s byte) bool {
 
 func parseDigitsRun(s string) (digits, rest string) {
 	pos := strings.IndexFunc(s, func(r rune) bool {
-		return !(r >= '0' && r <= '9')
+		return r < '0' || r > '9'
 	})
 	if pos == -1 {
 		return s, ""

--- a/arrow/decimal/decimal.go
+++ b/arrow/decimal/decimal.go
@@ -22,6 +22,8 @@ import (
 	"math"
 	"math/big"
 	"math/bits"
+	"strconv"
+	"strings"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
@@ -471,3 +473,107 @@ var (
 	_ Num[Decimal128] = Decimal128{}
 	_ Num[Decimal256] = Decimal256{}
 )
+
+type decComponents struct {
+	wholeDigits string
+	fractDigits string
+	exp         int32
+	sign        byte
+	hasExponent bool
+}
+
+func isSign(s byte) bool {
+	return s == '-' || s == '+'
+}
+
+func isDot(s byte) bool {
+	return s == '.'
+}
+
+func startsExponent(s byte) bool {
+	return s == 'e' || s == 'E'
+}
+
+func parseDigitsRun(s string) (digits, rest string) {
+	pos := strings.IndexFunc(s, func(r rune) bool {
+		return !(r >= '0' && r <= '9')
+	})
+	if pos == -1 {
+		return s, ""
+	}
+
+	return s[:pos], s[pos:]
+}
+
+func parseDecimalComponents(s string) (d decComponents, valid bool) {
+	if len(s) == 0 {
+		return
+	}
+
+	if isSign(s[0]) {
+		d.sign = s[0]
+		s = s[1:]
+	}
+
+	// first run of digits
+	d.wholeDigits, s = parseDigitsRun(s)
+	if len(s) == 0 {
+		return d, len(d.wholeDigits) > 0
+	}
+
+	if isDot(s[0]) {
+		s = s[1:]
+		// second run of digits
+		d.fractDigits, s = parseDigitsRun(s)
+	}
+
+	if len(d.wholeDigits) == 0 && len(d.fractDigits) == 0 {
+		// need at least some digits (whole or fractional)
+		return
+	}
+
+	if len(s) == 0 {
+		return d, true
+	}
+
+	// optional exponent
+	if startsExponent(s[0]) {
+		s = s[1:]
+		if len(s) > 0 && s[0] == '+' {
+			s = s[1:]
+		}
+		d.hasExponent = true
+		exp, err := strconv.Atoi(s)
+		if err != nil {
+			return d, false
+		}
+		d.exp = int32(exp)
+	}
+	return d, len(s) == 0
+}
+
+func PrecScaleFromString(s string) (prec, scale int32, err error) {
+	if len(s) == 0 {
+		return 0, 0, errors.New("empty string cannot be parsed as decimal")
+	}
+
+	// parse the string into components
+	d, valid := parseDecimalComponents(s)
+	if !valid {
+		return 0, 0, fmt.Errorf("the string '%s' is not a valid decimal number", s)
+	}
+
+	// remove leading zeros
+	digits := strings.TrimLeft(d.wholeDigits, "0")
+	significantDigits := len(d.fractDigits) + len(digits)
+	prec = int32(significantDigits)
+
+	if d.hasExponent {
+		adjustedExponent := d.exp
+		scale = -adjustedExponent + int32(len(d.fractDigits))
+	} else {
+		scale = int32(len(d.fractDigits))
+	}
+
+	return
+}

--- a/parquet/variant/builder.go
+++ b/parquet/variant/builder.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/decimal"
+	"github.com/apache/arrow-go/v18/internal/json"
 	"github.com/google/uuid"
 	"golang.org/x/exp/constraints"
 )
@@ -905,4 +906,118 @@ func Encode[T variantPrimitiveType](v T, opt ...AppendOpt) ([]byte, error) {
 	}
 
 	return val.value, nil
+}
+
+func ParseJSON(data string, allowDuplicateKeys bool) (Value, error) {
+	var b Builder
+	b.SetAllowDuplicates(allowDuplicateKeys)
+
+	dec := json.NewDecoder(strings.NewReader(data))
+	dec.UseNumber() // to handle JSON numbers as json.Number
+
+	if err := b.buildJSON(dec); err != nil {
+		return Value{}, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	return b.Build()
+}
+
+func (b *Builder) buildJSON(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("unexpected end of JSON input")
+		}
+		return fmt.Errorf("failed to decode JSON token: %w", err)
+	}
+
+	switch v := tok.(type) {
+	case json.Delim:
+		switch v {
+		case '{':
+			start, fields := b.Offset(), make([]FieldEntry, 0)
+			for dec.More() {
+				key, err := dec.Token()
+				if err != nil {
+					if errors.Is(err, io.EOF) {
+						return fmt.Errorf("unexpected end of JSON input")
+					}
+					return fmt.Errorf("failed to decode JSON key: %w", err)
+				}
+
+				switch key := key.(type) {
+				case string:
+					fields = append(fields, b.NextField(start, key))
+					if err := b.buildJSON(dec); err != nil {
+						return err
+					}
+				default:
+					return fmt.Errorf("expected string key in JSON object, got %T", key)
+				}
+			}
+			tok, err = dec.Token()
+			if err != nil {
+				return fmt.Errorf("failed to decode JSON object end: %w", err)
+			}
+			if tok != json.Delim('}') {
+				return fmt.Errorf("expected end of JSON object, got %v", tok)
+			}
+			return b.FinishObject(start, fields)
+		case '[':
+			start, offsets := b.Offset(), make([]int, 0)
+			for dec.More() {
+				offsets = append(offsets, b.NextElement(start))
+				if err := b.buildJSON(dec); err != nil {
+					return err
+				}
+			}
+			tok, err = dec.Token()
+			if err != nil {
+				return fmt.Errorf("failed to decode JSON array end: %w", err)
+			}
+			if tok != json.Delim(']') {
+				return fmt.Errorf("expected end of JSON array, got %v", tok)
+			}
+			return b.FinishArray(start, offsets)
+		default:
+			return fmt.Errorf("unexpected JSON delimiter: %v", v)
+		}
+	case string:
+		return b.AppendString(v)
+	case bool:
+		return b.AppendBool(v)
+	case nil:
+		return b.AppendNull()
+	case json.Number:
+		num, err := v.Int64()
+		if err == nil {
+			return b.AppendInt(num)
+		}
+
+		if !b.tryParseDecimal(v.String()) {
+			fnum, err := v.Float64()
+			if err == nil {
+				return b.AppendFloat64(fnum)
+			}
+			return fmt.Errorf("failed to parse JSON number: %w", err)
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("unexpected JSON token type: %T", v)
+	}
+}
+
+func (b *Builder) tryParseDecimal(input string) bool {
+	prec, scale, err := decimal.PrecScaleFromString(input)
+	if err != nil {
+		return false
+	}
+
+	n, err := decimal.Decimal128FromString(input, prec, scale)
+	if err != nil {
+		return false
+	}
+
+	return b.AppendDecimal16(uint8(scale), n) == nil
 }

--- a/parquet/variant/builder.go
+++ b/parquet/variant/builder.go
@@ -922,6 +922,31 @@ func ParseJSON(data string, allowDuplicateKeys bool) (Value, error) {
 	return b.Build()
 }
 
+func ParseJSONBytes(data []byte, allowDuplicateKeys bool) (Value, error) {
+	var b Builder
+	b.SetAllowDuplicates(allowDuplicateKeys)
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber() // to handle JSON numbers as json.Number
+
+	if err := b.buildJSON(dec); err != nil {
+		return Value{}, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	return b.Build()
+}
+
+func Unmarshal(dec *json.Decoder, allowDuplicateKeys bool) (Value, error) {
+	var b Builder
+	b.SetAllowDuplicates(allowDuplicateKeys)
+
+	if err := b.buildJSON(dec); err != nil {
+		return Value{}, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return b.Build()
+}
+
 func (b *Builder) buildJSON(dec *json.Decoder) error {
 	tok, err := dec.Token()
 	if err != nil {
@@ -982,6 +1007,8 @@ func (b *Builder) buildJSON(dec *json.Decoder) error {
 		default:
 			return fmt.Errorf("unexpected JSON delimiter: %v", v)
 		}
+	case float64:
+		return b.AppendFloat64(v)
 	case string:
 		return b.AppendString(v)
 	case bool:


### PR DESCRIPTION
### Rationale for this change
Next step on the route to fully support reading/writing Variants in Parquet is to support Parsing JSON into variants since we already can marshal to JSON.

### What changes are included in this PR?
Adding a `ParseJSON` function to the `parquet/variant` package.

### Are these changes tested?
Yes, unit tests are added.

### Are there any user-facing changes?
Just the new functions
