### PR TITLE
feat(parquet/pqarrow): Correctly handle Variant types in schema

### DIFF
--- a/arrow/extensions/variant.go
+++ b/arrow/extensions/variant.go
@@ -168,6 +168,14 @@ func (v *VariantType) Value() arrow.Field {
 	return v.StorageType().(*arrow.StructType).Field(v.valueFieldIdx)
 }
 
+func (v *VariantType) TypedValue() arrow.Field {
+	if v.typedValueFieldIdx == -1 {
+		return arrow.Field{}
+	}
+
+	return v.StorageType().(*arrow.StructType).Field(v.typedValueFieldIdx)
+}
+
 func (*VariantType) ExtensionName() string { return "parquet.variant" }
 
 func (v *VariantType) String() string {

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -865,8 +865,6 @@ func mapToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *sc
 }
 
 func variantToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *schemaTree, _, out *SchemaField) error {
-	// this is for unshredded variants. shredded variants may have more fields
-	// TODO: implement support for shredded variants
 	switch n.NumFields() {
 	case 2, 3:
 	default:

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -253,11 +253,19 @@ func variantToNode(t *extensions.VariantType, field arrow.Field, props *parquet.
 		return nil, err
 	}
 
-	//TODO: implement shredding
+	fields := schema.FieldList{metadataNode, valueNode}
+
+	typedField := t.TypedValue()
+	if typedField.Type != nil {
+		typedNode, err := fieldToNode("typed_value", typedField, props, arrProps)
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, typedNode)
+	}
 
 	return schema.NewGroupNodeLogical(field.Name, repFromNullable(field.Nullable),
-		schema.FieldList{metadataNode, valueNode}, schema.VariantLogicalType{},
-		fieldIDFromMeta(field.Metadata))
+		fields, schema.VariantLogicalType{}, fieldIDFromMeta(field.Metadata))
 }
 
 func structToNode(field arrow.Field, props *parquet.WriterProperties, arrprops ArrowWriterProperties) (schema.Node, error) {
@@ -859,8 +867,10 @@ func mapToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *sc
 func variantToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *schemaTree, _, out *SchemaField) error {
 	// this is for unshredded variants. shredded variants may have more fields
 	// TODO: implement support for shredded variants
-	if n.NumFields() != 2 {
-		return errors.New("VARIANT group must have exactly 2 children")
+	switch n.NumFields() {
+	case 2, 3:
+	default:
+		return errors.New("VARIANT group must have exactly 2 or 3 children")
 	}
 
 	var err error


### PR DESCRIPTION
### Rationale for this change
Updating the `pqarrow` package to handle the variant extension type when converting between arrow and parquet schemas.

### What changes are included in this PR?
Replacing the TODOs with implementations to handle shredded variant structures in schema conversion.

### Are these changes tested?
A unit test is added for shredded variant handling.

### Are there any user-facing changes?
Only that this is now supported instead of erroring.
