### PR TITLE
feat(parquet/pqarrow): read/write variant

### DIFF
--- a/parquet/file/record_reader.go
+++ b/parquet/file/record_reader.go
@@ -555,6 +555,7 @@ func (rr *recordReader) ReadRecordData(numRecords int64) (int64, error) {
 		// no repetition levels, skip delimiting logic. each level
 		// represents null or not null entry
 		recordsRead = utils.Min(rr.levelsWritten-rr.levelsPos, numRecords)
+		valuesToRead = recordsRead
 		// this is advanced by delimitRecords which we skipped
 		rr.levelsPos += recordsRead
 	} else {


### PR DESCRIPTION
### Rationale for this change
resolves #310

### What changes are included in this PR?
Updating the `pqarrow` package to support full round trip read/write of Variant values via `arrow/extensions/variant`

### Are these changes tested?
Yes, unit tests are added for both shredded and unshredded variants.

### Are there any user-facing changes?
 just the new features.
