### PR TITLE
fix(arrow/flight/flightsql): drain channel in flightSqlServer.DoGet

### DIFF
--- a/arrow/flight/flightsql/server.go
+++ b/arrow/flight/flightsql/server.go
@@ -916,6 +916,14 @@ func (f *flightSqlServer) DoGet(request *flight.Ticket, stream flight.FlightServ
 		return err
 	}
 
+	defer func() {
+		for chunk := range cc {
+			if chunk.Data != nil {
+				chunk.Data.Release()
+			}
+		}
+	}()
+
 	wr := flight.NewRecordWriter(stream, ipc.WithSchema(sc))
 	defer wr.Close()
 


### PR DESCRIPTION
### Rationale for this change
This PR fixes #435. 
If writing to the RecordWriter fails, the current implementation does not drain the channel when an error occurs while writing to the record writer.

### What changes are included in this PR?
We add a deferred function that will drain the channel and call `.Release()` on the underlying `StreamChunks` in order to be able to release the RecordReader.

### Are these changes tested?
@zeroshade as you suggested, I'll gladly accept a recommendation for the test setup. 

### Are there any user-facing changes?
No.
