### PR TITLE
fix(arrow/compute/exprs): fix literalToDatum for precision types

### DIFF
--- a/arrow/compute/exprs/exec.go
+++ b/arrow/compute/exprs/exec.go
@@ -379,6 +379,36 @@ func literalToDatum(mem memory.Allocator, lit expr.Literal, ext ExtensionIDSet) 
 		case *types.VarCharType:
 			return compute.NewDatum(scalar.NewExtensionScalar(
 				scalar.NewStringScalar(v.Value.(string)), varChar(int32(t.Length)))), nil
+		case *types.PrecisionTimeType:
+			dt, _, err := FromSubstraitType(t, ext)
+			if err != nil {
+				return nil, err
+			}
+
+			switch dt.ID() {
+			case arrow.TIME32:
+				return &compute.ScalarDatum{Value: scalar.NewTime32Scalar(
+					arrow.Time32(v.Value.(int64)), dt)}, nil
+			case arrow.TIME64:
+				return &compute.ScalarDatum{Value: scalar.NewTime64Scalar(
+					arrow.Time64(v.Value.(int64)), dt)}, nil
+			}
+		case *types.PrecisionTimestampType:
+			dt, _, err := FromSubstraitType(t, ext)
+			if err != nil {
+				return nil, err
+			}
+
+			return &compute.ScalarDatum{Value: scalar.NewTimestampScalar(
+				arrow.Timestamp(v.Value.(int64)), dt)}, nil
+		case *types.PrecisionTimestampTzType:
+			dt, _, err := FromSubstraitType(t, ext)
+			if err != nil {
+				return nil, err
+			}
+
+			return &compute.ScalarDatum{Value: scalar.NewTimestampScalar(
+				arrow.Timestamp(v.Value.(int64)), dt)}, nil
 		}
 	}
 

--- a/arrow/compute/exprs/exec_test.go
+++ b/arrow/compute/exprs/exec_test.go
@@ -519,6 +519,43 @@ func Test_Types(t *testing.T) {
 			},
 		},
 		{
+			name: "expect arrow.TIME64 (ns) ok",
+			schema: func() *arrow.Schema {
+				field := arrow.Field{
+					Name:     "col",
+					Type:     &arrow.Time64Type{Unit: arrow.Nanosecond},
+					Nullable: true,
+				}
+
+				return arrow.NewSchema([]arrow.Field{field}, nil)
+			},
+			record: func(rq *require.Assertions, schema *arrow.Schema) arrow.Record {
+				b := array.NewTime64Builder(memory.DefaultAllocator, &arrow.Time64Type{Unit: arrow.Nanosecond})
+				defer b.Release()
+
+				t1, err := arrow.Time64FromString("10:00:00.000000", arrow.Nanosecond)
+				rq.NoError(err, "Failed to create Time64 value")
+
+				b.AppendValues([]arrow.Time64{t1}, []bool{true})
+
+				return array.NewRecord(schema, []arrow.Array{b.NewArray()}, 1)
+			},
+			val: func(rq *require.Assertions) expr.Literal {
+				v, err := arrow.Time64FromString("11:00:00.000000", arrow.Nanosecond)
+				rq.NoError(err, "Failed to create Time64 value")
+
+				pt := &types.PrecisionTime{
+					Precision: int32(arrow.Nanosecond) * 3,
+					Value:     int64(v),
+				}
+
+				lit, err := expr.NewLiteral(pt, true)
+				rq.NoError(err, "Failed to create literal")
+
+				return lit
+			},
+		},
+		{
 			name: "expect arrow.TIMESTAMP (ns) ok",
 			schema: func() *arrow.Schema {
 				field := arrow.Field{


### PR DESCRIPTION
### Rationale for this change
While #404 fixed support for substrait precision types on inputs, it did not address support for literals that use the Precision types. 

Fixes #446

### What changes are included in this PR?
Fix `literalToDatum` so that it properly supports the precision types for literals.

### Are these changes tested?
Yes, a unit test is added.

### Are there any user-facing changes?
Just the increased support
