### PR TITLE
fix(arrow/array): update timestamp json format

### DIFF
--- a/arrow/array/timestamp.go
+++ b/arrow/array/timestamp.go
@@ -93,7 +93,7 @@ func (a *Timestamp) ValueStr(i int) string {
 	}
 
 	toTime, _ := a.DataType().(*arrow.TimestampType).GetToTimeFunc()
-	return toTime(a.values[i]).Format("2006-01-02 15:04:05.999999999Z0700")
+	return toTime(a.values[i]).Format(time.RFC3339Nano)
 }
 
 func (a *Timestamp) GetOneForMarshal(i int) interface{} {

--- a/arrow/array/timestamp_test.go
+++ b/arrow/array/timestamp_test.go
@@ -248,8 +248,8 @@ func TestTimestampValueStr(t *testing.T) {
 	arr := b.NewArray()
 	defer arr.Release()
 
-	assert.Equal(t, "1968-11-30 13:30:45-0700", arr.ValueStr(0))
-	assert.Equal(t, "2016-02-29 10:42:23-0700", arr.ValueStr(1))
+	assert.Equal(t, "1968-11-30T13:30:45-07:00", arr.ValueStr(0))
+	assert.Equal(t, "2016-02-29T10:42:23-07:00", arr.ValueStr(1))
 }
 
 func TestTimestampEquality(t *testing.T) {
@@ -278,16 +278,16 @@ func TestTimestampEquality(t *testing.T) {
 
 	// No timezone, "wall clock" semantics
 	// These timestamps have no actual timezone, but we still represent as UTC per Go conventions
-	assert.Equal(t, "1968-11-30 20:30:45Z", arrs[0].ValueStr(0))
-	assert.Equal(t, "2016-02-29 17:42:23Z", arrs[0].ValueStr(1))
+	assert.Equal(t, "1968-11-30T20:30:45Z", arrs[0].ValueStr(0))
+	assert.Equal(t, "2016-02-29T17:42:23Z", arrs[0].ValueStr(1))
 
 	// UTC timezone, "instant" semantics
-	assert.Equal(t, "1968-11-30 20:30:45Z", arrs[1].ValueStr(0))
-	assert.Equal(t, "2016-02-29 17:42:23Z", arrs[1].ValueStr(1))
+	assert.Equal(t, "1968-11-30T20:30:45Z", arrs[1].ValueStr(0))
+	assert.Equal(t, "2016-02-29T17:42:23Z", arrs[1].ValueStr(1))
 
 	// America/Phoenix timezone, "instant" semantics
-	assert.Equal(t, "1968-11-30 13:30:45-0700", arrs[2].ValueStr(0))
-	assert.Equal(t, "2016-02-29 10:42:23-0700", arrs[2].ValueStr(1))
+	assert.Equal(t, "1968-11-30T13:30:45-07:00", arrs[2].ValueStr(0))
+	assert.Equal(t, "2016-02-29T10:42:23-07:00", arrs[2].ValueStr(1))
 
 	// Despite timezone and semantics, the physical values are equivalent
 	assert.Equal(t, arrs[0].Value(0), arrs[1].Value(0))

--- a/arrow/avro/testdata/testdata.go
+++ b/arrow/avro/testdata/testdata.go
@@ -50,16 +50,16 @@ func (b ByteArray) MarshalJSON() ([]byte, error) {
 type TimestampMicros int64
 
 func (t TimestampMicros) MarshalJSON() ([]byte, error) {
-	ts := time.Unix(0, int64(t)*int64(time.Microsecond)).UTC().Format("2006-01-02 15:04:05.000000")
+	ts := time.Unix(0, int64(t)*int64(time.Microsecond)).UTC().Format(time.RFC3339Nano)
 	// arrow record marshaller trims trailing zero digits from timestamp so we do the same
-	return json.Marshal(fmt.Sprintf("%sZ", strings.TrimRight(ts, "0.")))
+	return json.Marshal(ts)
 }
 
 type TimestampMillis int64
 
 func (t TimestampMillis) MarshalJSON() ([]byte, error) {
-	ts := time.Unix(0, int64(t)*int64(time.Millisecond)).UTC().Format("2006-01-02 15:04:05.000")
-	return json.Marshal(fmt.Sprintf("%sZ", strings.TrimRight(ts, "0.")))
+	ts := time.Unix(0, int64(t)*int64(time.Millisecond)).UTC().Format(time.RFC3339Nano)
+	return json.Marshal(ts)
 }
 
 type TimeMillis time.Duration


### PR DESCRIPTION
### Rationale for this change
resolves #445

### What changes are included in this PR?
Use `time.RFC3339Nano` for the format to output the time value

### Are these changes tested?
Yes

### Are there any user-facing changes?
Changes the format of timestamp strings for `ValueStr` and marshalling to JSON to match JSON and Go conventions.
