### PR TITLE
refactor: switch golang.org/x/exp to standard library packages

### DIFF
--- a/arrow/compute/exec/kernel.go
+++ b/arrow/compute/exec/kernel.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	"fmt"
 	"hash/maphash"
+	"slices"
 	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/bitutil"
 	"github.com/apache/arrow-go/v18/arrow/internal/debug"
 	"github.com/apache/arrow-go/v18/arrow/memory"
-	"golang.org/x/exp/slices"
 )
 
 var hashSeed = maphash.MakeSeed()

--- a/arrow/compute/exec/utils.go
+++ b/arrow/compute/exec/utils.go
@@ -19,8 +19,10 @@
 package exec
 
 import (
+	"cmp"
 	"fmt"
 	"math"
+	"slices"
 	"sync/atomic"
 	"unsafe"
 
@@ -28,8 +30,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/bitutil"
 	"github.com/apache/arrow-go/v18/arrow/memory"
-	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/slices"
 )
 
 // GetSpanValues returns a properly typed slice by reinterpreting
@@ -51,14 +51,14 @@ func GetSpanOffsets[T int32 | int64](span *ArraySpan, i int) []T {
 	return ret[span.Offset:]
 }
 
-func Min[T constraints.Ordered](a, b T) T {
+func Min[T cmp.Ordered](a, b T) T {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-func Max[T constraints.Ordered](a, b T) T {
+func Max[T cmp.Ordered](a, b T) T {
 	if a > b {
 		return a
 	}

--- a/arrow/compute/registry.go
+++ b/arrow/compute/registry.go
@@ -19,11 +19,11 @@
 package compute
 
 import (
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/apache/arrow-go/v18/arrow/internal/debug"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 type FunctionRegistry interface {
@@ -138,7 +138,7 @@ func (reg *funcRegistry) GetFunctionNames() (out []string) {
 	reg.mx.RLock()
 	defer reg.mx.RUnlock()
 
-	out = append(out, maps.Keys(reg.nameToFunction)...)
+	out = append(out, slices.Collect(maps.Keys(reg.nameToFunction))...)
 	slices.Sort(out)
 	return
 }

--- a/arrow/compute/registry_test.go
+++ b/arrow/compute/registry_test.go
@@ -21,13 +21,13 @@ package compute_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/compute/exec"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 )
 
 var registry compute.FunctionRegistry

--- a/arrow/flight/cookie_middleware.go
+++ b/arrow/flight/cookie_middleware.go
@@ -18,12 +18,12 @@ package flight
 
 import (
 	"context"
+	"maps"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/exp/maps"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/internal/utils/math.go
+++ b/internal/utils/math.go
@@ -17,20 +17,21 @@
 package utils
 
 import (
+	"cmp"
 	"math"
 	"math/bits"
 
 	"golang.org/x/exp/constraints"
 )
 
-func Min[T constraints.Ordered](a, b T) T {
+func Min[T cmp.Ordered](a, b T) T {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-func Max[T constraints.Ordered](a, b T) T {
+func Max[T cmp.Ordered](a, b T) T {
 	if a > b {
 		return a
 	}


### PR DESCRIPTION
### Rationale for this change

This change migrates several of usages of `golang.org/x/exp` packages to use the standard library equivalents that have been introduced into newer go versions.


### What changes are included in this PR?


### Are these changes tested?

Tested with `go test ./...`. I get the exact same behavior (including some failures) as on master.

### Are there any user-facing changes?

n/a
