### PR TITLE
fix(array): add nil checks in Data.Release() for childData

### DIFF
--- a/arrow/array/data.go
+++ b/arrow/array/data.go
@@ -147,7 +147,9 @@ func (d *Data) Release() {
 		}
 
 		for _, b := range d.childData {
-			b.Release()
+			if b != nil {
+				b.Release()
+			}
 		}
 
 		if d.dictionary != nil {


### PR DESCRIPTION
### Rationale for this change

My program crashed with below log

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x53beb92]

goroutine 294 [running]:
github.com/apache/arrow-go/v18/arrow/array.(*Data).Release(0xc02586a5b0)
        /root/go/pkg/mod/github.com/apache/arrow-go/v18@v18.4.0/arrow/array/data.go:150 +0x172
github.com/apache/arrow-go/v18/arrow/array.concat.func1()
        /root/go/pkg/mod/github.com/apache/arrow-go/v18@v18.4.0/arrow/array/concat.go:528 +0x9c
github.com/apache/arrow-go/v18/arrow/array.concat({0xc14ae66008, 0x100, 0x100}, {0x83213c0, 0xb026080})
        /root/go/pkg/mod/github.com/apache/arrow-go/v18@v18.4.0/arrow/array/concat.go:652 +0x3f7d
github.com/apache/arrow-go/v18/arrow/array.Concatenate({0xc104861908, 0x100, 0x12f}, {0x83213c0, 0xb026080})
        /root/go/pkg/mod/github.com/apache/arrow-go/v18@v18.4.0/arrow/array/concat.go:55 +0x585
...
```

### What changes are included in this PR?

Add nil check in Data.Release() for childData to avoid crash.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
