### PR TITLE
fix(arrow/compute): Fix scalar comparison batches

### DIFF
--- a/arrow/compute/internal/kernels/scalar_comparisons.go
+++ b/arrow/compute/internal/kernels/scalar_comparisons.go
@@ -147,7 +147,7 @@ func comparePrimitiveScalarArray[T arrow.FixedWidthType](op cmpScalarLeft[T, T])
 		}
 
 		for j := 0; j < nbatches; j++ {
-			op(leftVal, right, tmpOutSlice)
+			op(leftVal, right[:batchSize], tmpOutSlice)
 			right = right[batchSize:]
 			packBits(tmpOutput, out)
 			out = out[batchSize/8:]


### PR DESCRIPTION
### Rationale for this change
Fixes #464

### What changes are included in this PR?
Ensure the size of the slice used in scalar comparisons stays within the expected batch size

### Are these changes tested?
Yes a test is added.

### Are there any user-facing changes?
A condition that previously resulted in panic will now succeed
