### PR TITLE
Use ParseFloat with json.Number in Int64/Uint64 Builders' UnmarshalOne

### DIFF
--- a/arrow/array/numericbuilder.gen.go
+++ b/arrow/array/numericbuilder.gen.go
@@ -230,7 +230,7 @@ func (b *Int64Builder) UnmarshalOne(dec *json.Decoder) error {
 	case float64:
 		b.Append(int64(v))
 	case json.Number:
-		f, err := strconv.ParseInt(v.String(), 10, 8*8)
+		f, err := strconv.ParseFloat(v.String(), 8*8)
 		if err != nil {
 			return &json.UnmarshalTypeError{
 				Value:  v.String(),
@@ -471,7 +471,7 @@ func (b *Uint64Builder) UnmarshalOne(dec *json.Decoder) error {
 	case float64:
 		b.Append(uint64(v))
 	case json.Number:
-		f, err := strconv.ParseUint(v.String(), 10, 8*8)
+		f, err := strconv.ParseFloat(v.String(), 8*8)
 		if err != nil {
 			return &json.UnmarshalTypeError{
 				Value:  v.String(),

--- a/arrow/array/numericbuilder.gen.go.tmpl
+++ b/arrow/array/numericbuilder.gen.go.tmpl
@@ -393,7 +393,7 @@ func (b *{{.Name}}Builder) UnmarshalOne(dec *json.Decoder) error {
 	case float64:
 		b.Append({{.name}}(v))
 	case json.Number:
-{{if or (eq .Name "Float32") (eq .Name "Float64") -}}
+{{if or (eq .Name "Float32") (eq .Name "Float64") (eq .Name "Int64") (eq .Name "Uint64")-}}
 		f, err := strconv.ParseFloat(v.String(), {{.Size}}*8)
 {{else if eq (printf "%.1s" .Name) "U" -}}
 		f, err := strconv.ParseUint(v.String(), 10, {{.Size}}*8)


### PR DESCRIPTION
### Rationale for this change
Addresses [#474](https://github.com/apache/arrow-go/issues/474#issue-3325545839)

### What changes are included in this PR?
Replaced `strconv.ParseInt`/`strconv.ParseUint` with `strconv.ParseFloat` in Int64/Uint64Builder.UnmarshalOne

### Are these changes tested?
Existing tests pass.

### Are there any user-facing changes?
No
