### PR TITLE
fix(parquet/pqarrow): Fix null_count column stats

### DIFF
--- a/parquet/pqarrow/encode_dict_compute.go
+++ b/parquet/pqarrow/encode_dict_compute.go
@@ -117,7 +117,9 @@ func writeDictionaryArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, lea
 		}
 
 		nonNullCount := indices.Len() - indices.NullN()
-		pageStats.IncNulls(int64(len(defLevels) - nonNullCount))
+		nullCount := max(int64(len(defLevels)-nonNullCount), 0)
+
+		pageStats.IncNulls(nullCount)
 		pageStats.IncNumValues(int64(nonNullCount))
 		return pageStats.UpdateFromArrow(referencedDict, false)
 	}


### PR DESCRIPTION
### Rationale for this change
When dictionary encoding is enabled and and repetitions are set to `required`, the `null_count` statistic is negative because `defLevels` is always 0.

### What changes are included in this PR?
This PR sets the null count to 0 if `defLevels - nonNullCount < 0`

### Are these changes tested?
Yes. I've added a new test that exposes another bug. I started with the `fullTypeList` variable like [this test](https://github.com/apache/arrow-go/blob/c6ce2ef4e55009a786cf04b3845eba5170c98066/parquet/pqarrow/encode_dictionary_test.go#L43) and discovered that not all types are supported. 

If an unsupported type is encoded as a dictionary, it results in a nasty panic in the typed dictionary encoder because the types don't line up.

### Are there any user-facing changes?
Yes, the stats written to parquet files are currently wrong for these sorts of columns. This PR should fix that!
