### PR TITLE
chore: Use apache/arrow-dotnet for integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -379,6 +379,11 @@ jobs:
         with:
           repository: apache/arrow-js
           path: js
+      - name: Checkout Arrow .NET
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: apache/arrow-dotnet
+          path: dotnet
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
@@ -400,6 +405,7 @@ jobs:
           archery docker run \
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
             -e ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS=go \
+            -e ARCHERY_INTEGRATION_WITH_DOTNET=1 \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_JAVA=1 \
             -e ARCHERY_INTEGRATION_WITH_JS=1 \


### PR DESCRIPTION
### Rationale for this change

Fixes #494

The .NET implementation is extracted to apache/arrow-dotnet.

### What changes are included in this PR?

Use apache/arrow-dotnet.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.