### PR TITLE
feat: Add support for specifying `Timestamp` `valueStr` output format

### DIFF
--- a/arrow/avro/testdata/testdata.go
+++ b/arrow/avro/testdata/testdata.go
@@ -51,7 +51,6 @@ type TimestampMicros int64
 
 func (t TimestampMicros) MarshalJSON() ([]byte, error) {
 	ts := time.Unix(0, int64(t)*int64(time.Microsecond)).UTC().Format(time.RFC3339Nano)
-	// arrow record marshaller trims trailing zero digits from timestamp so we do the same
 	return json.Marshal(ts)
 }
 


### PR DESCRIPTION
### Rationale for this change

See discussion in https://github.com/apache/arrow-go/pull/450

### What changes are included in this PR?

Allow setting the formatting of timestamps when using `ValueStr` (or JSON marshalling)

### Are these changes tested?

Yes - re-added the original test that was modified in https://github.com/apache/arrow-go/pull/450

### Are there any user-facing changes?

Yes - users will now be able to revert back to the old format before https://github.com/apache/arrow-go/pull/450, to avoid unintentional breakage
