### PR TITLE
chore(ci): fix verify_rc finding latest go

### DIFF
--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -146,14 +146,14 @@ latest_go_version() {
     options+=("--header" "Authorization: Bearer ${GITHUB_TOKEN}")
   fi
   curl \
-    "${options[@]}" \
-    https://api.github.com/repos/golang/go/git/matching-refs/tags/go |
-    grep -o '"ref": "refs/tags/go.*"' |
-    tail -n 1 |
-    sed \
-      -e 's,^"ref": "refs/tags/go,,g' \
-      -e 's/"$//g'
+   "${options[@]}" \
+   https://api.github.com/repos/golang/go/git/matching-refs/tags/go |
+  jq -r ' .[] | .ref' |
+  sort -V |
+  tail -1 |
+  sed 's,refs/tags/go,,g'
 }
+
 
 ensure_go() {
   if [ "${VERIFY_FORCE_USE_GO_BINARY}" -le 0 ]; then


### PR DESCRIPTION
### Rationale for this change
We were assuming the latest go was the last one in the list, turns out it's a bad assumption.

### What changes are included in this PR?
Fixing the `latest_go_version` function in `verify_rc.sh`

### Are these changes tested?
Yes
