### PR TITLE
fix(arrow/compute): fix scalar comparison panic

### DIFF
--- a/arrow/compute/internal/kernels/scalar_comparisons.go
+++ b/arrow/compute/internal/kernels/scalar_comparisons.go
@@ -110,7 +110,7 @@ func comparePrimitiveArrayScalar[T arrow.FixedWidthType](op cmpScalarRight[T, T]
 		}
 
 		for j := 0; j < nbatches; j++ {
-			op(left, rightVal, tmpOutSlice)
+			op(left[:batchSize], rightVal, tmpOutSlice)
 			left = left[batchSize:]
 			packBits(tmpOutput, out)
 			out = out[batchSize/8:]


### PR DESCRIPTION
### Rationale for this change
fixes #503 

### What changes are included in this PR?
Properly limit the slice when calling `op` in `comparePrimitiveArrayScalar` like we do for `comparePrimitiveScalarArray` as per #464 

### Are these changes tested?
Yes, the unit test is updated to account for this situation

### Are there any user-facing changes?
scenario will no longer panic
