### PR TITLE
fix(parquet/pqarrow): unsupported dictionary types in pqarrow

### DIFF
--- a/parquet/internal/encoding/byte_array_encoder.go
+++ b/parquet/internal/encoding/byte_array_encoder.go
@@ -123,6 +123,7 @@ func (enc *DictByteArrayEncoder) PutSpaced(in []parquet.ByteArray, validBits []b
 }
 
 func (enc *DictByteArrayEncoder) NormalizeDict(values arrow.Array) (arrow.Array, error) {
+	values.Retain()
 	return values, nil
 }
 

--- a/parquet/internal/encoding/byte_array_encoder.go
+++ b/parquet/internal/encoding/byte_array_encoder.go
@@ -122,6 +122,10 @@ func (enc *DictByteArrayEncoder) PutSpaced(in []parquet.ByteArray, validBits []b
 	})
 }
 
+func (enc *DictByteArrayEncoder) NormalizeDict(values arrow.Array) (arrow.Array, error) {
+	return values, nil
+}
+
 // PutDictionary allows pre-seeding a dictionary encoder with
 // a dictionary from an Arrow Array.
 //

--- a/parquet/internal/encoding/fixed_len_byte_array_encoder.go
+++ b/parquet/internal/encoding/fixed_len_byte_array_encoder.go
@@ -146,6 +146,10 @@ func (enc *DictFixedLenByteArrayEncoder) PutSpaced(in []parquet.FixedLenByteArra
 	})
 }
 
+func (enc *DictFixedLenByteArrayEncoder) NormalizeDict(values arrow.Array) (arrow.Array, error) {
+	return values, nil
+}
+
 // PutDictionary allows pre-seeding a dictionary encoder with
 // a dictionary from an Arrow Array.
 //

--- a/parquet/internal/encoding/fixed_len_byte_array_encoder.go
+++ b/parquet/internal/encoding/fixed_len_byte_array_encoder.go
@@ -147,6 +147,7 @@ func (enc *DictFixedLenByteArrayEncoder) PutSpaced(in []parquet.FixedLenByteArra
 }
 
 func (enc *DictFixedLenByteArrayEncoder) NormalizeDict(values arrow.Array) (arrow.Array, error) {
+	values.Retain()
 	return values, nil
 }
 

--- a/parquet/internal/encoding/typed_encoder.go
+++ b/parquet/internal/encoding/typed_encoder.go
@@ -17,11 +17,13 @@
 package encoding
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/compute"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/internal/bitutils"
 	shared_utils "github.com/apache/arrow-go/v18/internal/utils"
@@ -151,9 +153,18 @@ func (enc *typedDictEncoder[T]) PutSpaced(in []T, validBits []byte, validBitsOff
 	})
 }
 
-type arrvalues[T int32 | int64 | float32 | float64] interface {
+type arrvalues[T arrow.ValueType] interface {
 	arrow.TypedArray[T]
 	Values() []T
+}
+
+func (enc *typedDictEncoder[T]) NormalizeDict(values arrow.Array) (arrow.Array, error) {
+	if _, ok := values.(arrvalues[T]); ok {
+		return values, nil
+	}
+
+	ctx := compute.WithAllocator(context.Background(), enc.mem)
+	return compute.CastToType(ctx, values, arrow.GetDataType[T]())
 }
 
 func (enc *typedDictEncoder[T]) PutDictionary(values arrow.Array) error {
@@ -162,10 +173,20 @@ func (enc *typedDictEncoder[T]) PutDictionary(values arrow.Array) error {
 	}
 
 	enc.dictEncodedSize += values.Len() * int(unsafe.Sizeof(T(0)))
-	data := values.(arrvalues[T]).Values()
-
 	typedMemo := enc.memo.(TypedMemoTable[T])
-	for _, val := range data {
+	data, ok := values.(arrvalues[T])
+	if !ok {
+		var err error
+		ctx := compute.WithAllocator(context.Background(), enc.mem)
+		values, err = compute.CastToType(ctx, values, arrow.GetDataType[T]())
+		if err != nil {
+			return err
+		}
+		defer values.Release()
+		data = values.(arrvalues[T])
+	}
+
+	for _, val := range data.Values() {
 		if _, _, err := typedMemo.InsertOrGet(val); err != nil {
 			return err
 		}

--- a/parquet/internal/encoding/typed_encoder.go
+++ b/parquet/internal/encoding/typed_encoder.go
@@ -160,6 +160,7 @@ type arrvalues[T arrow.ValueType] interface {
 
 func (enc *typedDictEncoder[T]) NormalizeDict(values arrow.Array) (arrow.Array, error) {
 	if _, ok := values.(arrvalues[T]); ok {
+		values.Retain()
 		return values, nil
 	}
 

--- a/parquet/internal/encoding/types.go
+++ b/parquet/internal/encoding/types.go
@@ -117,9 +117,7 @@ type DictEncoder interface {
 	// native type. e.g. a dictionary of type int8 will be cast to an int32
 	// dictionary for parquet storage.
 	//
-	// The returned array must be released by the caller if different from
-	// the input array. If no normalization is needed, the input array
-	// may be returned as-is.
+	// The returned array must always be released by the caller.
 	NormalizeDict(arrow.Array) (arrow.Array, error)
 }
 

--- a/parquet/internal/encoding/types.go
+++ b/parquet/internal/encoding/types.go
@@ -113,6 +113,14 @@ type DictEncoder interface {
 	// of [0,dictSize) and is not validated. Returns an error if a non-integral
 	// array is passed.
 	PutIndices(arrow.Array) error
+	// NormalizeDict takes an arrow array and normalizes it to a parquet
+	// native type. e.g. a dictionary of type int8 will be cast to an int32
+	// dictionary for parquet storage.
+	//
+	// The returned array must be released by the caller if different from
+	// the input array. If no normalization is needed, the input array
+	// may be returned as-is.
+	NormalizeDict(arrow.Array) (arrow.Array, error)
 }
 
 var bufferPool = sync.Pool{

--- a/parquet/pqarrow/encode_arrow_test.go
+++ b/parquet/pqarrow/encode_arrow_test.go
@@ -1353,6 +1353,9 @@ var fullTypeList = []arrow.DataType{
 
 var dictEncodingSupportedTypeList = []arrow.DataType{
 	arrow.PrimitiveTypes.Int8,
+	arrow.PrimitiveTypes.Uint8,
+	arrow.PrimitiveTypes.Int16,
+	arrow.PrimitiveTypes.Uint16,
 	arrow.PrimitiveTypes.Int32,
 	arrow.PrimitiveTypes.Int64,
 	arrow.PrimitiveTypes.Float32,

--- a/parquet/pqarrow/encode_arrow_test.go
+++ b/parquet/pqarrow/encode_arrow_test.go
@@ -1352,6 +1352,7 @@ var fullTypeList = []arrow.DataType{
 }
 
 var dictEncodingSupportedTypeList = []arrow.DataType{
+	arrow.PrimitiveTypes.Int8,
 	arrow.PrimitiveTypes.Int32,
 	arrow.PrimitiveTypes.Int64,
 	arrow.PrimitiveTypes.Float32,

--- a/parquet/pqarrow/encode_dict_compute.go
+++ b/parquet/pqarrow/encode_dict_compute.go
@@ -90,12 +90,22 @@ func writeDictionaryArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, lea
 		pageStats   = cw.PageStatistics()
 	)
 
+	normalized, err := dictEncoder.NormalizeDict(dict)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if normalized != dict {
+			normalized.Release()
+		}
+	}()
+
 	updateStats := func() error {
 		var referencedDict arrow.Array
 
 		ctx := compute.WithAllocator(context.Background(), ctx.props.mem)
 		// if dictionary is the same dictionary we already have, just use that
-		if preserved != nil && preserved == dict {
+		if preserved != nil && preserved == normalized {
 			referencedDict = preserved
 		} else {
 			referencedIndices, err := compute.UniqueArray(ctx, indices)
@@ -104,10 +114,10 @@ func writeDictionaryArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, lea
 			}
 
 			// on first run, we might be able to re-use the existing dict
-			if referencedIndices.Len() == dict.Len() {
-				referencedDict = dict
+			if referencedIndices.Len() == normalized.Len() {
+				referencedDict = normalized
 			} else {
-				referencedDict, err = compute.TakeArrayOpts(ctx, dict, referencedIndices, compute.TakeOptions{BoundsCheck: false})
+				referencedDict, err = compute.TakeArrayOpts(ctx, normalized, referencedIndices, compute.TakeOptions{BoundsCheck: false})
 				if err != nil {
 					return err
 				}
@@ -126,7 +136,7 @@ func writeDictionaryArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, lea
 
 	switch {
 	case preserved == nil:
-		if err := dictEncoder.PutDictionary(dict); err != nil {
+		if err := dictEncoder.PutDictionary(normalized); err != nil {
 			return err
 		}
 
@@ -134,7 +144,7 @@ func writeDictionaryArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, lea
 		// memo table will be out of sync with the indices in the arrow array
 		// the easiest solution for this uncommon case is to fallback to plain
 		// encoding
-		if dictEncoder.NumEntries() != dict.Len() {
+		if dictEncoder.NumEntries() != normalized.Len() {
 			cw.FallbackToPlain()
 			return writeDense()
 		}
@@ -145,7 +155,7 @@ func writeDictionaryArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, lea
 			}
 		}
 
-	case !array.Equal(dict, preserved):
+	case !array.Equal(normalized, preserved):
 		// dictionary has changed
 		cw.FallbackToPlain()
 		return writeDense()

--- a/parquet/pqarrow/encode_dict_compute.go
+++ b/parquet/pqarrow/encode_dict_compute.go
@@ -94,11 +94,7 @@ func writeDictionaryArrow(ctx *arrowWriteContext, cw file.ColumnChunkWriter, lea
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if normalized != dict {
-			normalized.Release()
-		}
-	}()
+	defer normalized.Release()
 
 	updateStats := func() error {
 		var referencedDict arrow.Array


### PR DESCRIPTION
### Rationale for this change
fixes #490 

### What changes are included in this PR?
When using `PutDictionary` to write an arrow dictionary array to Parquet directly, we will now normalize the data type to a parquet physical storage type to avoid type problems. e.g. A dictionary with `int8` values will get cast to `int32` values before we process it so that all of the remaining encoding code can continue to be based on the physical storage type. This alleviates panics when using `pqarrow` to write Dictionary arrays.

### Are these changes tested?
Yes, the unit tests are updated to include tests for int8/uint8/etc. as dictionary value types.

### Are there any user-facing changes?
No, just fixing panics.
