### PR TITLE
fix(parquet): fix adaptive bloom filter duplicate hash counting, comparison logic, and GC safety

### DIFF
--- a/parquet/metadata/bloom_filter_test.go
+++ b/parquet/metadata/bloom_filter_test.go
@@ -206,8 +206,6 @@ func TestAdaptiveBloomFilterEdgeCases(t *testing.T) {
 		initialDistinct := bf.numDistinct
 		bf.InsertBulk(hashes)
 
-		// numDistinct should only increase by 1, not 3
-		// Currently this will fail because the bug causes it to increment by 3
 		expectedDistinct := initialDistinct + 1
 		if bf.numDistinct != expectedDistinct {
 			t.Errorf("InsertBulk duplicate handling bug: expected numDistinct=%d, got %d",
@@ -256,7 +254,6 @@ func TestAdaptiveBloomFilterEdgeCases(t *testing.T) {
 		runtime.GC()
 
 		// The bloom filter should still work after GC
-		// If the GC issue exists, this might cause a panic or incorrect results
 		for _, h := range hashes {
 			if !bf.CheckHash(h) {
 				t.Errorf("Hash %d not found after GC - potential GC safety issue", h)
@@ -303,8 +300,8 @@ func TestAdaptiveBloomFilterEndToEnd(t *testing.T) {
 			hashes = append(hashes, GetHash(hasher, val))
 		}
 
-		// Test bulk insertion with some duplicates to verify our fix
-		duplicatedHashes := append(hashes, hashes[0], hashes[1], hashes[0]) // Add some duplicates
+		// Test bulk insertion with some duplicates
+		duplicatedHashes := append(hashes, hashes[0], hashes[1], hashes[0])
 		bf.InsertBulk(duplicatedHashes)
 
 		// Verify all original values are found


### PR DESCRIPTION
### Rationale for this change

This PR addresses Issue #525 . The adaptive Bloom filter implementation had several bugs that caused incorrect behavior.

### What changes are included in this PR?

Fixed bugs in the adaptive Bloom filter logic
Added targeted unit tests that tests the specific bugs mentioned in the Issue #525 
Added an end-to-end test for the adaptive Bloom filter to ensure correctness

### Are these changes tested?

Newly added tests for the adaptive Bloom filter pass.
All existing test suites continue to pass.

### Are there any user-facing changes?

This PR does not introduce any user-facing API changes.

Closes #525 
