### PR TITLE
chore(parquet/metadata): use constant time compare for signature verify

### DIFF
--- a/parquet/metadata/file.go
+++ b/parquet/metadata/file.go
@@ -19,6 +19,7 @@ package metadata
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"reflect"
@@ -481,7 +482,7 @@ func (f *FileMetaData) VerifySignature(signature []byte) bool {
 	var buf bytes.Buffer
 	buf.Grow(enc.CiphertextSizeDelta() + len(data))
 	encryptedLen := enc.SignedFooterEncrypt(&buf, data, []byte(key), []byte(aad), nonce)
-	return bytes.Equal(buf.Bytes()[encryptedLen-encryption.GcmTagLength:], tag)
+	return subtle.ConstantTimeCompare(buf.Bytes()[encryptedLen-encryption.GcmTagLength:], tag) == 0
 }
 
 // WriteTo will serialize and write out this file metadata, encrypting it if


### PR DESCRIPTION
### Rationale for this change
Doesn't hurt to use a timing resistant comparison for verifying the signature despite the fact that there isn't really a way to exploit it.

### What changes are included in this PR?
Switch `bytes.Equal` to `subtle.ConstantTimeCompare`.

### Are these changes tested?
Existing unit tests cover it.

### Are there any user-facing changes?
No
