### PR TITLE
fix: update iceberg substrait URN

### DIFF
--- a/arrow/compute/exprs/types.go
+++ b/arrow/compute/exprs/types.go
@@ -42,7 +42,7 @@ const (
 	SubstraitComparisonFuncsURI = SubstraitDefaultURIPrefix + "functions_comparison"
 	SubstraitBooleanFuncsURI    = SubstraitDefaultURIPrefix + "functions_boolean"
 
-	SubstraitIcebergSetFuncURI = "https://github.com/apache/iceberg-go/blob/main/table/substrait/functions_set.yaml"
+	SubstraitIcebergSetFuncURN = "extension:apache.iceberg:functions_set"
 	TimestampTzTimezone        = "UTC"
 )
 
@@ -132,7 +132,7 @@ func init() {
 
 	for _, fn := range []string{"is_in"} {
 		err := DefaultExtensionIDRegistry.AddSubstraitScalarToArrow(
-			extensions.ID{URN: SubstraitIcebergSetFuncURI, Name: fn},
+			extensions.ID{URN: SubstraitIcebergSetFuncURN, Name: fn},
 			setLookupFuncSubstraitToArrowFunc)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
### Rationale for this change
Updating the correct URN for the is_in function with substrait based on the updated URN style
