### PR TITLE
optimization: comparison: when DataType is static, skip reflection

### DIFF
--- a/arrow/compare.go
+++ b/arrow/compare.go
@@ -45,8 +45,10 @@ func TypeEqual(left, right DataType, opts ...TypeEqualOption) bool {
 	}
 
 	switch {
+	case left == right:
+		return true
 	case left == nil || right == nil:
-		return left == nil && right == nil
+		return false
 	case left.ID() != right.ID():
 		return false
 	}


### PR DESCRIPTION
### Rationale for this change

Reflection is slow. When working with primitive data types - e.g. PrimitiveType.Float64 - the DataType value is a constant consisting of the (constant) type indicator, and the constant pointer to the only instance of the Float64 type. For such cases, we can do a fast-path for TypeEqual and detect the interface equality without the current path of switching on the type of DataType, and using reflect.DeepEqual.

reflect.DeepEqual makes several allocations and is not particularly fast. This patch cuts out 50-75% of the runtime of `schema.Equals` in our real-world scenario in my testing.

### What changes are included in this PR?

A branch is added to the TypeEqual switch, which returns early when the two types compare equal through shallow comparison. In such a case, deeper comparison must necessarily show equality, as every property is definitionally identical. Detecting this early can make e.g. schema validations significantly faster.

### Are these changes tested?

Yes, though only with our internal schemas. I noticed arrow showing up heavily in our profiles and started hacking on it to make it go away :)

### Are there any user-facing changes?

It runs faster? That's technically user-facing ;)