### PR TITLE
cookie test: use maps.Equal instead of reflect.DeepEquals

### DIFF
--- a/arrow/flight/cookie_middleware_test.go
+++ b/arrow/flight/cookie_middleware_test.go
@@ -21,9 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/textproto"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -85,7 +85,7 @@ func (s *serverAddCookieMiddleware) StartCall(ctx context.Context) context.Conte
 		}
 	}
 
-	if !reflect.DeepEqual(s.expectedCookies, got) {
+	if !maps.Equal(s.expectedCookies, got) {
 		panic(fmt.Sprintf("did not get expected cookies, expected %+v, got %+v", s.expectedCookies, got))
 	}
 


### PR DESCRIPTION
This is a drive-by patch; the test was failing for the other optimization, and I noticed this when I went to take a look and figured I'd just send the patch.

### Rationale for this change

map.Equals, for two values known to both be of type map[string]string, is a strictly faster and smaller operation than reflect.DeepEquals. This patch isn't really necessary, since it's only for a test, but it's good practice.

### Are these changes tested?

The test is passing on my machine, yes.

### Are there any user-facing changes?

No