### PR TITLE
Utilize memory allocator in ReadProperties.GetStream

### DIFF
--- a/internal/utils/buf_reader.go
+++ b/internal/utils/buf_reader.go
@@ -40,7 +40,7 @@ type byteReader struct {
 
 // NewByteReader creates a new ByteReader instance from the given byte slice.
 // It wraps the bytes.NewReader function to implement BufferedReader interface.
-// It is considered not to own the underlying byte slice, so the Free method is a no-op.
+// It is considered not to own the underlying byte slice.
 func NewByteReader(buf []byte) *byteReader {
 	r := bytes.NewReader(buf)
 	return &byteReader{
@@ -113,7 +113,11 @@ func (r *byteReader) BufferSize() int { return len(r.buf) }
 
 func (r *byteReader) Buffered() int { return len(r.buf) - r.pos }
 
-func (r *byteReader) Free() {}
+func (r *byteReader) Free() {
+	r.r = nil
+	r.buf = nil
+	r.pos = 0
+}
 
 // bytesBufferReader is a byte slice with a bytes reader wrapped around it.
 // It uses an allocator to allocate and free the underlying byte slice.

--- a/internal/utils/buf_reader.go
+++ b/internal/utils/buf_reader.go
@@ -111,6 +111,8 @@ func (r *byteReader) Reset(Reader) {}
 
 func (r *byteReader) BufferSize() int { return len(r.buf) }
 
+func (r *byteReader) Buffered() int { return len(r.buf) - r.pos }
+
 func (r *byteReader) Free() {}
 
 // bytesBufferReader is a byte slice with a bytes reader wrapped around it.

--- a/internal/utils/buf_reader.go
+++ b/internal/utils/buf_reader.go
@@ -122,6 +122,9 @@ type bytesBufferReader struct {
 
 // NewBytesBufferReader creates a new bytesBufferReader with the given size and allocator.
 func NewBytesBufferReader(size int, alloc memory.Allocator) *bytesBufferReader {
+	if alloc == nil {
+		alloc = memory.DefaultAllocator
+	}
 	buf := alloc.Allocate(size)
 	return &bytesBufferReader{
 		alloc: alloc,
@@ -159,6 +162,9 @@ type bufferedReader struct {
 // except Peek will expand the internal buffer if needed rather than return
 // an error.
 func NewBufferedReader(rd Reader, sz int, alloc memory.Allocator) *bufferedReader {
+	if alloc == nil {
+		alloc = memory.DefaultAllocator
+	}
 	r := &bufferedReader{
 		alloc: alloc,
 		rd:    rd,

--- a/parquet/file/page_reader.go
+++ b/parquet/file/page_reader.go
@@ -608,6 +608,7 @@ func (p *serializedPageReader) GetDictionaryPage() (*DictionaryPage, error) {
 			io.NewSectionReader(p.r.Outer(), p.dictOffset-p.baseOffset, p.dataOffset-p.baseOffset),
 			readBufSize,
 			p.mem)
+		defer rd.Free()
 		if err := p.readPageHeader(rd, hdr); err != nil {
 			return nil, err
 		}
@@ -818,6 +819,7 @@ func (p *serializedPageReader) Next() bool {
 
 			firstRowIdx := p.rowsSeen
 			p.rowsSeen += int64(dataHeader.GetNumValues())
+
 			data, err := p.decompress(p.r, lenCompressed, buf.Bytes())
 			if err != nil {
 				p.err = err

--- a/parquet/file/page_reader.go
+++ b/parquet/file/page_reader.go
@@ -382,6 +382,9 @@ func (p *serializedPageReader) Close() error {
 		p.dictPageBuffer.Release()
 		p.dataPageBuffer.Release()
 	}
+	if p.r != nil {
+		p.r.Free()
+	}
 	return nil
 }
 
@@ -603,7 +606,8 @@ func (p *serializedPageReader) GetDictionaryPage() (*DictionaryPage, error) {
 		readBufSize := min(int(p.dataOffset-p.baseOffset), p.r.BufferSize())
 		rd := utils.NewBufferedReader(
 			io.NewSectionReader(p.r.Outer(), p.dictOffset-p.baseOffset, p.dataOffset-p.baseOffset),
-			readBufSize)
+			readBufSize,
+			p.mem)
 		if err := p.readPageHeader(rd, hdr); err != nil {
 			return nil, err
 		}

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -114,7 +114,7 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 		colLen += padding
 	}
 
-	stream, err := r.props.GetStream(r.r, colStart, colLen)
+	stream, err := r.props.GetStreamV2(r.r, colStart, colLen)
 	if err != nil {
 		return nil, err
 	}

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -134,11 +134,13 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 	}
 
 	if r.fileDecryptor == nil {
+		stream.Free()
 		return nil, xerrors.New("column in rowgroup is encrypted, but no file decryptor")
 	}
 
 	const encryptedRowGroupsLimit = 32767
 	if i > encryptedRowGroupsLimit {
+		stream.Free()
 		return nil, xerrors.New("encrypted files cannot contain more than 32767 column chunks")
 	}
 

--- a/parquet/internal/testutils/pagebuilder.go
+++ b/parquet/internal/testutils/pagebuilder.go
@@ -136,7 +136,8 @@ type DictionaryPageBuilder struct {
 func NewDictionaryPageBuilder(d *schema.Column) *DictionaryPageBuilder {
 	return &DictionaryPageBuilder{
 		encoding.NewEncoder(d.PhysicalType(), parquet.Encodings.Plain, true, d, mem).(encoding.DictEncoder),
-		0, false}
+		0, false,
+	}
 }
 
 func (d *DictionaryPageBuilder) AppendValues(values interface{}) encoding.Buffer {
@@ -243,9 +244,12 @@ func (m *MockPageReader) Err() error {
 }
 
 func (m *MockPageReader) Reset(parquet.BufferedReader, int64, compress.Compression, *file.CryptoContext) {
+	// no-op
 }
 
-func (m *MockPageReader) SetMaxPageHeaderSize(int) {}
+func (m *MockPageReader) SetMaxPageHeaderSize(int) {
+	// no-op
+}
 
 func (m *MockPageReader) Page() file.Page {
 	return m.TestData().Get("pages").Data().([]file.Page)[m.curpage-1]
@@ -278,8 +282,8 @@ func (m *MockPageReader) Next() bool {
 }
 
 func PaginatePlain(version parquet.DataPageVersion, d *schema.Column, values reflect.Value, defLevels, repLevels []int16,
-	maxDef, maxRep int16, lvlsPerPage int, valuesPerPage []int, enc parquet.Encoding) []file.Page {
-
+	maxDef, maxRep int16, lvlsPerPage int, valuesPerPage []int, enc parquet.Encoding,
+) []file.Page {
 	var (
 		npages      = len(valuesPerPage)
 		defLvlStart = 0

--- a/parquet/reader_properties.go
+++ b/parquet/reader_properties.go
@@ -50,6 +50,8 @@ type BufferedReader interface {
 	Peek(int) ([]byte, error)
 	Discard(int) (int, error)
 	Outer() utils.Reader
+	// Buffered returns the number of bytes already read and stored in the buffer
+	Buffered() int
 	BufferSize() int
 	Reset(utils.Reader)
 	Free()

--- a/parquet/reader_writer_properties_test.go
+++ b/parquet/reader_writer_properties_test.go
@@ -89,16 +89,16 @@ func TestReaderPropsGetStreamWithAllocator(t *testing.T) {
 
 	// no leak on success
 	props := parquet.NewReaderProperties(pool)
-	bufRdr, err := props.GetStream(rdr, 0, int64(len(data)))
+	bufRdr, err := props.GetStreamV2(rdr, 0, int64(len(data)))
 	assert.NoError(t, err)
 	bufRdr.Free()
 
 	// no leak on reader error
-	_, err = props.GetStream(&mockReaderAt{}, 0, 10)
+	_, err = props.GetStreamV2(&mockReaderAt{}, 0, 10)
 	assert.Error(t, err)
 
 	// no leak on insufficient read
-	_, err = props.GetStream(rdr, 0, int64(len(data)+10))
+	_, err = props.GetStreamV2(rdr, 0, int64(len(data)+10))
 	assert.Error(t, err)
 }
 
@@ -113,19 +113,19 @@ func TestReaderPropsGetStreamBufferedWithAllocator(t *testing.T) {
 	props.BufferedStreamEnabled = true
 
 	buf := make([]byte, len(data))
-	bufRdr, err := props.GetStream(rdr, 0, int64(len(data)))
+	bufRdr, err := props.GetStreamV2(rdr, 0, int64(len(data)))
 	assert.NoError(t, err)
 	_, err = bufRdr.Read(buf)
 	assert.NoError(t, err)
 	bufRdr.Free()
 
-	bufRdr, err = props.GetStream(&mockReaderAt{}, 0, 10)
+	bufRdr, err = props.GetStreamV2(&mockReaderAt{}, 0, 10)
 	assert.NoError(t, err)
 	_, err = bufRdr.Read(buf)
 	assert.Error(t, err)
 	bufRdr.Free()
 
-	bufRdr, err = props.GetStream(rdr, 0, int64(len(data)+10))
+	bufRdr, err = props.GetStreamV2(rdr, 0, int64(len(data)+10))
 	assert.NoError(t, err)
 	n, err := bufRdr.Read(buf)
 	assert.NoError(t, err)

--- a/parquet/reader_writer_properties_test.go
+++ b/parquet/reader_writer_properties_test.go
@@ -18,6 +18,7 @@ package parquet_test
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -67,7 +68,67 @@ func TestReaderPropsGetStreamInsufficient(t *testing.T) {
 	buf := memory.NewBufferBytes([]byte(data))
 	rdr := bytes.NewReader(buf.Bytes())
 
-	props := parquet.NewReaderProperties(nil)
-	_, err := props.GetStream(rdr, 12, 15)
+	props1 := parquet.NewReaderProperties(nil)
+	_, err := props1.GetStream(rdr, 12, 15)
 	assert.Error(t, err)
+}
+
+type mockReaderAt struct{}
+
+func (m *mockReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	return 0, errors.New("mock error")
+}
+
+func TestReaderPropsGetStreamWithAllocator(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	data := "data to read"
+	buf := memory.NewBufferBytes([]byte(data))
+	rdr := bytes.NewReader(buf.Bytes())
+
+	// no leak on success
+	props := parquet.NewReaderProperties(pool)
+	bufRdr, err := props.GetStream(rdr, 0, int64(len(data)))
+	assert.NoError(t, err)
+	bufRdr.Free()
+
+	// no leak on reader error
+	_, err = props.GetStream(&mockReaderAt{}, 0, 10)
+	assert.Error(t, err)
+
+	// no leak on insufficient read
+	_, err = props.GetStream(rdr, 0, int64(len(data)+10))
+	assert.Error(t, err)
+}
+
+func TestReaderPropsGetStreamBufferedWithAllocator(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	data := "data to read"
+	rdr := bytes.NewReader(memory.NewBufferBytes([]byte(data)).Bytes())
+
+	props := parquet.NewReaderProperties(pool)
+	props.BufferedStreamEnabled = true
+
+	buf := make([]byte, len(data))
+	bufRdr, err := props.GetStream(rdr, 0, int64(len(data)))
+	assert.NoError(t, err)
+	_, err = bufRdr.Read(buf)
+	assert.NoError(t, err)
+	bufRdr.Free()
+
+	bufRdr, err = props.GetStream(&mockReaderAt{}, 0, 10)
+	assert.NoError(t, err)
+	_, err = bufRdr.Read(buf)
+	assert.Error(t, err)
+	bufRdr.Free()
+
+	bufRdr, err = props.GetStream(rdr, 0, int64(len(data)+10))
+	assert.NoError(t, err)
+	n, err := bufRdr.Read(buf)
+	assert.NoError(t, err)
+	assert.NotEqual(t, len(data)+10, n)
+	bufRdr.Free()
 }


### PR DESCRIPTION
### Rationale for this change
Optimization of memory usage, enables the use of custom allocators when reading column data with both buffered and unbuffered readers.

- Optimization of memory allocation and buffer management. 
- Enable the use of custom allocators when reading column data with both buffered and unbuffered readers.

### What changes are included in this PR?

Page Reader Optimizations:

- Unified V1 and V2 page reading with getPageBytesV1() and getPageBytesV2()
- Added readOrStealData() to optimize buffer stealing vs direct reads
- Strategic buffer reuse based on compression/encryption state

Custom Allocator Support:

- Modified utils.NewBufferedReader to accept memory.Allocator parameter
- Added Free() and Buffered() methods to BufferedReader interface
- Added NewBytesBufferReader for allocator-backed byte buffers
- ReaderProperties.GetStream() now uses the configured allocator for all buffer allocations

### Are these changes tested?

- All existing unit tests pass with refactored implementation
- New TestDecryptColumns validates 8 encryption/compression configurations
- Comprehensive benchmarks test V1/V2 pages, compression, and encryption
- Memory leak tests in TestReaderPropsGetStreamWithAllocator and TestReaderPropsGetStreamBufferedWithAllocator verify proper cleanup

### Are there any user-facing changes?

New Features:

- Users can now provide custom allocators via ReaderProperties to control memory allocation during page reading

Breaking Changes:

- utils.NewBufferedReader now requires a memory.Allocator parameter (pass nil for default)
- BufferedReader interface adds Buffered() int and Free() methods

Closes #540
