### PR TITLE
fix(arrow/ipc): allow reading custom metadata from record batch message

### DIFF
--- a/arrow/ipc/ipc.go
+++ b/arrow/ipc/ipc.go
@@ -72,6 +72,7 @@ type config struct {
 	noAutoSchema       bool
 	emitDictDeltas     bool
 	minSpaceSavings    float64
+	readCustomMetadata bool
 }
 
 func newConfig(opts ...Option) *config {
@@ -92,6 +93,13 @@ func newConfig(opts ...Option) *config {
 // Option is a functional option to configure opening or creating Arrow files
 // and streams.
 type Option func(*config)
+
+// WithCustomRecordBatchMetadata allows returning custom metadata for RecordBatch.
+func WithCustomRecordBatchMetadata(cm bool) Option {
+	return func(cfg *config) {
+		cfg.readCustomMetadata = cm
+	}
+}
 
 // WithFooterOffset specifies the Arrow footer position in bytes.
 func WithFooterOffset(offset int64) Option {


### PR DESCRIPTION
I could not find a method to read the custom metadata out of the RecordBatch message, only the metadata from the schema, so I added an option to read custom metadata from record batch message in ipc reader. This was the api I came up with. I tried to follow the existing methodology of updating the current record batch in Read/Next. Let me know if any api changes should be made or if I am completely missing this functionality somewhere.

### Rationale for this change
Allow reading custom metadata from record batch message similar to the [iter_batches_with_custom_metadata](https://arrow.apache.org/docs/python/generated/pyarrow.ipc.RecordBatchStreamReader.html#pyarrow.ipc.RecordBatchStreamReader.iter_batches_with_custom_metadata) function in the pyarrow library.

### What changes are included in this PR?
Add an ipc.Option (WithCustomRecordBatchMetadata)
Add meta field in ipc.Reader struct to hold metadata
Check WithCustomRecordBatchMetadata option in next() method on Reader and, if true, read metadata from the 

### Are these changes tested?
Existing tests pass; however, I am not sure how to use the current test setup to test these changes because there isn't an api (that I can tell) to write this custom metadata to an ipc either. I will look into that next.
Also wasn't sure where to upload example arrow stream files.
I did create an example of using these changes [here](https://github.com/rkyleg/record-batch-custom-metadata-test). 
If you have any pointers here, I would be happy to write some tests.

### Are there any user-facing changes?
No
