### PR TITLE
Add `TimestampWithOffset` canonical extension type

### DIFF
--- a/arrow/extensions/extensions.go
+++ b/arrow/extensions/extensions.go
@@ -21,11 +21,12 @@ import (
 )
 
 var canonicalExtensionTypes = []arrow.ExtensionType{
+	&JSONType{},
+	&OpaqueType{},
+	&TimestampWithOffsetType{},
+	&VariantType{},
 	NewBool8Type(),
 	NewUUIDType(),
-	&OpaqueType{},
-	&JSONType{},
-	&VariantType{},
 }
 
 func init() {

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -1,0 +1,354 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	_ "bytes"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/internal/json"
+)
+
+// TimestampWithOffsetType represents a timestamp column that stores a timezone offset per row instead of
+// applying the same timezone offset to the entire column.
+type TimestampWithOffsetType struct {
+	arrow.ExtensionBase
+}
+
+// Whether the storageType is compatible with TimestampWithOffset.
+//
+// Returns (time_unit, ok). If ok is false, time unit is garbage.
+func isDataTypeCompatible(storageType arrow.DataType) (arrow.TimeUnit, bool) {
+	timeUnit := arrow.Second
+	switch t := storageType.(type) {
+	case *arrow.StructType:
+		if t.NumFields() != 2 {
+			return timeUnit, false
+		}
+
+		maybeTimestamp := t.Field(0);
+		maybeOffset := t.Field(1);
+
+		timestampOk := false
+		switch timestampType := maybeTimestamp.Type.(type) {
+		case *arrow.TimestampType:
+			if timestampType.TimeZone == "UTC" {
+				timestampOk = true
+				timeUnit = timestampType.TimeUnit()
+			}
+		default:
+		}
+
+		ok := maybeTimestamp.Name == "timestamp" &&
+			timestampOk &&
+			!maybeTimestamp.Nullable &&
+			maybeOffset.Name == "offset_minutes" &&
+			arrow.TypeEqual(maybeOffset.Type, arrow.PrimitiveTypes.Int16) &&
+			!maybeOffset.Nullable
+
+		return timeUnit, ok
+	default:
+		return timeUnit, false
+	}
+}
+
+
+// NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
+// Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=Int16), where T is any TimeUnit.
+func NewTimestampWithOffsetType(unit arrow.TimeUnit) *TimestampWithOffsetType {
+	return &TimestampWithOffsetType{
+		ExtensionBase: arrow.ExtensionBase{
+			Storage: arrow.StructOf(
+				arrow.Field{
+					Name: "timestamp",
+					Type: &arrow.TimestampType{
+						Unit: unit,
+						TimeZone: "UTC",
+					},
+					Nullable: false,
+				},
+				arrow.Field{
+					Name: "offset_minutes",
+					Type: arrow.PrimitiveTypes.Int16,
+					Nullable: false,
+				},
+			),
+		},
+	}
+}
+
+func (b *TimestampWithOffsetType) ArrayType() reflect.Type { return reflect.TypeOf(TimestampWithOffsetArray{}) }
+
+func (b *TimestampWithOffsetType) ExtensionName() string { return "arrow.timestamp_with_offset" }
+
+func (b *TimestampWithOffsetType) String() string { return fmt.Sprintf("extension<%s>", b.ExtensionName()) }
+
+func (e *TimestampWithOffsetType) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`{"name":"%s","metadata":%s}`, e.ExtensionName(), e.Serialize())), nil
+}
+
+func (b *TimestampWithOffsetType) Serialize() string { return "" }
+
+func (b *TimestampWithOffsetType) Deserialize(storageType arrow.DataType, data string) (arrow.ExtensionType, error) {
+	timeUnit, ok := isDataTypeCompatible(storageType)
+	if !ok {
+		return nil, fmt.Errorf("invalid storage type for TimestampWithOffsetType: %s", storageType.Name())
+	}
+	return NewTimestampWithOffsetType(timeUnit), nil
+}
+
+func (b *TimestampWithOffsetType) ExtensionEquals(other arrow.ExtensionType) bool {
+	return b.ExtensionName() == other.ExtensionName()
+}
+
+func (b *TimestampWithOffsetType) TimeUnit() arrow.TimeUnit { 
+	return b.ExtensionBase.Storage.(*arrow.StructType).Fields()[0].Type.(*arrow.TimestampType).TimeUnit()
+}
+
+func (b *TimestampWithOffsetType) NewBuilder(mem memory.Allocator) array.Builder {
+	return NewTimestampWithOffsetBuilder(mem, b.TimeUnit())
+}
+
+// TimestampWithOffsetArray is a simple array of struct
+type TimestampWithOffsetArray struct {
+	array.ExtensionArrayBase
+}
+
+func (a *TimestampWithOffsetArray) String() string {
+	var o strings.Builder
+	o.WriteString("[")
+	for i := 0; i < a.Len(); i++ {
+		if i > 0 {
+			o.WriteString(" ")
+		}
+		switch {
+		case a.IsNull(i):
+			o.WriteString(array.NullValueStr)
+		default:
+			fmt.Fprintf(&o, "\"%s\"", a.Value(i))
+		}
+	}
+	o.WriteString("]")
+	return o.String()
+}
+
+func timeFromFieldValues(utcTimestamp arrow.Timestamp, offsetMinutes int16, unit arrow.TimeUnit) time.Time {
+	hours := offsetMinutes / 60;
+	minutes := offsetMinutes % 60
+	if minutes < 0 {
+		minutes = -minutes
+	}
+
+	loc := time.FixedZone(fmt.Sprintf("UTC%+03d:%02d", hours, minutes), int(offsetMinutes) * 60)
+	return utcTimestamp.ToTime(unit).In(loc)
+}
+
+func fieldValuesFromTime(t time.Time, unit arrow.TimeUnit) (arrow.Timestamp, int16) {
+	// naive "bitwise" conversion to UTC, keeping the underlying date the same
+	utc := t.UTC()
+	naiveUtc := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
+	offsetMinutes := int16(naiveUtc.Sub(t).Minutes())
+	// SAFETY: unit MUST have been validated to a valid arrow.TimeUnit value before
+	// this function. Otherwise, ignoring this error is not safe.
+	timestamp, _ := arrow.TimestampFromTime(utc, unit)
+	return timestamp, offsetMinutes
+}
+
+// Get the raw arrow values at the given index
+//
+// SAFETY: the value at i must not be nil
+func (a *TimestampWithOffsetArray) rawValueUnsafe(i int) (arrow.Timestamp, int16, arrow.TimeUnit) {
+	structs := a.Storage().(*array.Struct)
+
+	timestampField := structs.Field(0)
+	timestamps := timestampField.(*array.Timestamp)
+	offsets := structs.Field(1).(*array.Int16)
+
+	timeUnit := timestampField.DataType().(*arrow.TimestampType).Unit
+	utcTimestamp := timestamps.Value(i)	
+	offsetMinutes := offsets.Value(i)
+
+	return utcTimestamp, offsetMinutes, timeUnit
+}
+
+func (a *TimestampWithOffsetArray) Value(i int) time.Time {
+	if a.IsNull(i) {
+		return time.Unix(0, 0)
+	}
+	utcTimestamp, offsetMinutes, timeUnit := a.rawValueUnsafe(i)
+	return timeFromFieldValues(utcTimestamp, offsetMinutes, timeUnit)
+}
+
+func (a *TimestampWithOffsetArray) Values() []time.Time {
+	values := make([]time.Time, a.Len())
+	for i := range a.Len() {
+		val := a.Value(i)
+		values[i] = val
+	}
+	return values
+}
+
+func (a *TimestampWithOffsetArray) ValueStr(i int) string {
+	switch {
+	case a.IsNull(i):
+		return array.NullValueStr
+	default:
+		return a.Value(i).String()
+	}
+}
+
+func (a *TimestampWithOffsetArray) MarshalJSON() ([]byte, error) {
+	values := make([]interface{}, a.Len())
+	for i := 0; i < a.Len(); i++ {
+		if a.IsValid(i) {
+			utcTimestamp, offsetMinutes, timeUnit := a.rawValueUnsafe(i)
+			values[i] = timeFromFieldValues(utcTimestamp, offsetMinutes, timeUnit)
+		} else {
+			values[i] = nil
+		}
+	}
+	return json.Marshal(values)
+}
+
+func (a *TimestampWithOffsetArray) GetOneForMarshal(i int) interface{} {
+	if a.IsNull(i) {
+		return nil
+	}
+	return a.Value(i)
+}
+
+// TimestampWithOffsetBuilder is a convenience builder for the TimestampWithOffset extension type,
+// allowing arrays to be built with boolean values rather than the underlying storage type.
+type TimestampWithOffsetBuilder struct {
+	*array.ExtensionBuilder
+
+	// The layout used to parse any timestamps from strings. Defaults to time.RFC3339
+	Layout string
+	unit   arrow.TimeUnit
+}
+
+// NewTimestampWithOffsetBuilder creates a new TimestampWithOffsetBuilder, exposing a convenient and efficient interface
+// for writing time.Time values to the underlying storage array.
+func NewTimestampWithOffsetBuilder(mem memory.Allocator, unit arrow.TimeUnit) *TimestampWithOffsetBuilder {
+	return &TimestampWithOffsetBuilder{
+		unit: unit,
+		Layout: time.RFC3339,
+		ExtensionBuilder: array.NewExtensionBuilder(mem, NewTimestampWithOffsetType(unit)),
+	}
+}
+
+func (b *TimestampWithOffsetBuilder) Append(v time.Time) {
+	timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
+	structBuilder := b.ExtensionBuilder.Builder.(*array.StructBuilder)
+
+	structBuilder.Append(true)
+	structBuilder.FieldBuilder(0).(*array.TimestampBuilder).Append(timestamp)
+	structBuilder.FieldBuilder(1).(*array.Int16Builder).Append(int16(offsetMinutes))
+}
+
+func (b *TimestampWithOffsetBuilder) UnsafeAppend(v time.Time) {
+	timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
+	structBuilder := b.ExtensionBuilder.Builder.(*array.StructBuilder)
+
+	structBuilder.Append(true)
+	structBuilder.FieldBuilder(0).(*array.TimestampBuilder).UnsafeAppend(timestamp)
+	structBuilder.FieldBuilder(1).(*array.Int16Builder).UnsafeAppend(int16(offsetMinutes))
+}
+
+// By default, this will try to parse the string using the RFC3339 layout. 
+//
+// You can change the default layout by using builder.SetLayout()
+func (b *TimestampWithOffsetBuilder) AppendValueFromString(s string) error {
+	if s == array.NullValueStr {
+		b.AppendNull()
+		return nil
+	}
+
+	parsed, err := time.Parse(b.Layout, s)
+	if err != nil {
+		return err
+	}
+
+	b.Append(parsed)
+	return nil
+}
+
+func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []bool) {
+	structBuilder := b.ExtensionBuilder.Builder.(*array.StructBuilder)
+	timestamps := structBuilder.FieldBuilder(0).(*array.TimestampBuilder);
+	offsets := structBuilder.FieldBuilder(1).(*array.Int16Builder);
+
+	structBuilder.AppendValues(valids)
+
+	for i, v := range values {
+		timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
+
+		// SAFETY: by this point we know all buffers have available space given the earlier
+		// call to structBuilder.AppendValues which calls Reserve internally
+		if valids[i] {
+			timestamps.UnsafeAppend(timestamp)
+			offsets.UnsafeAppend(offsetMinutes)
+		} else {
+			timestamps.UnsafeAppendBoolToBitmap(false)
+			offsets.UnsafeAppendBoolToBitmap(false)
+		}
+	}
+}
+
+func (b *TimestampWithOffsetBuilder) UnmarshalOne(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("failed to decode json: %w", err)
+	}
+
+	switch raw := tok.(type) {
+	case string:
+		t, err := time.Parse(b.Layout, raw)
+		if err != nil {
+			return fmt.Errorf("failed to parse string \"%s\" as time.Time using layout \"%s\"", raw, b.Layout)
+		}
+		b.Append(t)
+	case nil:
+		b.AppendNull()
+	default:
+		return fmt.Errorf("expected date string")
+	}
+
+	return nil
+}
+
+func (b *TimestampWithOffsetBuilder) Unmarshal(dec *json.Decoder) error {
+	for dec.More() {
+		if err := b.UnmarshalOne(dec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var (
+	_ arrow.ExtensionType          = (*TimestampWithOffsetType)(nil)
+	_ array.CustomExtensionBuilder = (*TimestampWithOffsetType)(nil)
+	_ array.ExtensionArray         = (*TimestampWithOffsetArray)(nil)
+	_ array.Builder 	       = (*TimestampWithOffsetBuilder)(nil)
+)

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -280,7 +280,7 @@ func (a *TimestampWithOffsetArray) rawValueUnsafe(i int) (arrow.Timestamp, int16
 
 func (a *TimestampWithOffsetArray) Value(i int) time.Time {
 	if a.IsNull(i) {
-		return time.Unix(0, 0)
+		return time.Time{}
 	}
 	utcTimestamp, offsetMinutes, timeUnit := a.rawValueUnsafe(i)
 	return timeFromFieldValues(utcTimestamp, offsetMinutes, timeUnit)
@@ -288,11 +288,11 @@ func (a *TimestampWithOffsetArray) Value(i int) time.Time {
 
 // Iterates over the array returning the timestamp at each position.
 //
-// If the timestamp is null, the returned time will be the unix epoch.
+// The second parameter indicates whether the timestamp is valid or not.
 //
 // This will iterate using the fastest method given the underlying storage array
-func (a *TimestampWithOffsetArray) iterValues() iter.Seq[time.Time] {
-	return func(yield func(time.Time) bool) {
+func (a *TimestampWithOffsetArray) iterValues() iter.Seq2[time.Time, bool] {
+	return func(yield func(time.Time, bool) bool) {
 		structs := a.Storage().(*array.Struct)
 		offsets := structs.Field(1)
 		if reeOffsets, isRee := offsets.(*array.RunEndEncoded); isRee {
@@ -318,28 +318,30 @@ func (a *TimestampWithOffsetArray) iterValues() iter.Seq[time.Time] {
 					offsetPhysicalIdx += 1
 				}
 
-				ts := time.Unix(0, 0)
-				if a.IsValid(i) {
+				var ts time.Time
+				valid := a.IsValid(i)
+				if valid {
 					utcTimestamp := timestamps.Value(i)
 					offsetMinutes := offsetValues.Value(offsetPhysicalIdx)
 					v := timeFromFieldValues(utcTimestamp, offsetMinutes, timeUnit)
 					ts = v
 				}
 
-				if !yield(ts) {
+				if !yield(ts, valid) {
 					return
 				}
 			}
 		} else {
 			for i := 0; i < a.Len(); i++ {
-				ts := time.Unix(0, 0)
-				if a.IsValid(i) {
+				var ts time.Time
+				valid := a.IsValid(i)
+				if valid {
 					utcTimestamp, offsetMinutes, timeUnit := a.rawValueUnsafe(i)
 					v := timeFromFieldValues(utcTimestamp, offsetMinutes, timeUnit)
 					ts = v
 				}
 
-				if !yield(ts) {
+				if !yield(ts, valid) {
 					return
 				}
 			}
@@ -348,7 +350,13 @@ func (a *TimestampWithOffsetArray) iterValues() iter.Seq[time.Time] {
 }
 
 func (a *TimestampWithOffsetArray) Values() []time.Time {
-	return slices.Collect(a.iterValues())
+	return slices.Collect(func (yield func (time.Time) bool) {
+		for time := range a.iterValues() {
+			if !yield(time) {
+				return
+			}
+		}
+	})
 }
 
 func (a *TimestampWithOffsetArray) ValueStr(i int) string {
@@ -363,8 +371,8 @@ func (a *TimestampWithOffsetArray) ValueStr(i int) string {
 func (a *TimestampWithOffsetArray) MarshalJSON() ([]byte, error) {
 	values := make([]interface{}, a.Len())
 	i := 0
-	for ts := range a.iterValues() {
-		if ts.Unix() == 0 {
+	for ts, valid := range a.iterValues() {
+		if !valid {
 			values[i] = nil
 		} else {
 			values[i] = &ts

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -133,8 +133,6 @@ type DictIndexType interface {
 // NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
 // Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=Dictionary(I, Int16)), where T is any TimeUnit and I is a
 // valid Dictionary index type.
-//
-// The error will be populated if the index is not a valid dictionary-encoding index type.
 func NewTimestampWithOffsetTypeDictionaryEncoded[I DictIndexType](unit arrow.TimeUnit, index I) *TimestampWithOffsetType {
 	offsetType := arrow.DictionaryType{
 		IndexType: arrow.DataType(index),
@@ -155,8 +153,6 @@ type TimestampWithOffsetRunEndsType interface {
 // NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
 // Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=RunEndEncoded(E, Int16)), where T is any TimeUnit and E is a
 // valid run-ends type.
-//
-// The error will be populated if runEnds is not a valid run-end encoding run-ends type.
 func NewTimestampWithOffsetTypeRunEndEncoded[E TimestampWithOffsetRunEndsType](unit arrow.TimeUnit, runEnds E) *TimestampWithOffsetType {
 	offsetType := arrow.RunEndEncodedOf(arrow.DataType(runEnds), arrow.PrimitiveTypes.Int16)
 

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -239,15 +239,10 @@ func timeFromFieldValues(utcTimestamp arrow.Timestamp, offsetMinutes int16, unit
 }
 
 func fieldValuesFromTime(t time.Time, unit arrow.TimeUnit) (arrow.Timestamp, int16) {
-	// naive "bitwise" conversion to UTC, keeping the underlying date the same
-	utc := t.UTC()
-	naiveUtc := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
-	offsetMinutes := int16(naiveUtc.Sub(t).Minutes())
-
-	// SAFETY: unit MUST have been validated to a valid arrow.TimeUnit value before
-	// this function. Otherwise, ignoring this error is not safe.
-	timestamp, _ := arrow.TimestampFromTime(utc, unit)
-	return timestamp, offsetMinutes
+	_, offsetSeconds := t.Zone()
+	offsetMinutes := int16(offsetSeconds / 60)
+	ts, _ := arrow.TimestampFromTime(t.UTC(), unit)
+	return ts, offsetMinutes
 }
 
 // Get the raw arrow values at the given index

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -445,31 +445,6 @@ func (b *TimestampWithOffsetBuilder) Append(v time.Time) {
 
 }
 
-func (b *TimestampWithOffsetBuilder) UnsafeAppend(v time.Time) {
-	timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
-	offsetMinutes16 := int16(offsetMinutes)
-	structBuilder := b.ExtensionBuilder.Builder.(*array.StructBuilder)
-
-	structBuilder.Append(true)
-	structBuilder.FieldBuilder(0).(*array.TimestampBuilder).UnsafeAppend(timestamp)
-
-	switch offsets := structBuilder.FieldBuilder(1).(type) {
-	case *array.Int16Builder:
-		offsets.UnsafeAppend(offsetMinutes16)
-	case *array.Int16DictionaryBuilder:
-		offsets.Append(offsetMinutes16)
-	case *array.RunEndEncodedBuilder:
-		if offsetMinutes != b.lastOffset {
-			offsets.Append(1)
-			offsets.ValueBuilder().(*array.Int16Builder).Append(offsetMinutes16)
-		} else {
-			offsets.ContinueRun(1)
-		}
-
-		b.lastOffset = offsetMinutes16
-	}
-}
-
 // By default, this will try to parse the string using the RFC3339 layout.
 //
 // You can change the default layout by using builder.SetLayout()
@@ -514,7 +489,7 @@ func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []b
 			timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
 			if valids[i] {
 				timestamps.UnsafeAppend(timestamp)
-				offsets.Append(offsetMinutes)
+				offsets.UnsafeAppend(offsetMinutes)
 			} else {
 				timestamps.UnsafeAppendBoolToBitmap(false)
 				offsets.UnsafeAppendBoolToBitmap(false)
@@ -536,7 +511,7 @@ func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []b
 				b.lastOffset = offsetMinutes16
 			} else {
 				timestamps.UnsafeAppendBoolToBitmap(false)
-				offsets.UnsafeAppendBoolToBitmap(false)
+				offsets.AppendNull()
 			}
 		}
 	}

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -43,7 +43,7 @@ func isOffsetTypeOk(offsetType arrow.DataType) bool {
 	case *arrow.Int16Type:
 		return true
 	case *arrow.DictionaryType:
-		return arrow.IsInteger(offsetType.IndexType.ID()) && arrow.TypeEqual(offsetType.ValueType, arrow.PrimitiveTypes.Int16)
+		return arrow.TypeEqual(offsetType.ValueType, arrow.PrimitiveTypes.Int16)
 	case *arrow.RunEndEncodedType:
 		return offsetType.ValidRunEndsType(offsetType.RunEnds()) &&
 			arrow.TypeEqual(offsetType.Encoded(), arrow.PrimitiveTypes.Int16)

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -130,6 +130,11 @@ type DictIndexType interface {
 		*arrow.Uint8Type | *arrow.Uint16Type | *arrow.Uint32Type | *arrow.Uint64Type
 }
 
+
+type RunEndsType interface {
+	*arrow.Int16Type | *arrow.Int32Type | *arrow.Int64Type
+}
+
 // NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
 // Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=Dictionary(I, Int16)), where T is any TimeUnit and I is a
 // valid Dictionary index type.
@@ -148,11 +153,11 @@ func NewTimestampWithOffsetTypeDictionaryEncoded[I DictIndexType](unit arrow.Tim
 // NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
 // Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=RunEndEncoded(E, Int16)), where T is any TimeUnit and E is a
 // valid run-ends type.
-func NewTimestampWithOffsetTypeRunEndEncoded[E DictIndexType](unit arrow.TimeUnit, runEnds E) *TimestampWithOffsetType {
+func NewTimestampWithOffsetTypeRunEndEncoded[E RunEndsType](unit arrow.TimeUnit, runEnds E) *TimestampWithOffsetType {
 	offsetType := arrow.RunEndEncodedOf(arrow.DataType(runEnds), arrow.PrimitiveTypes.Int16)
 
 	v, _ := NewTimestampWithOffsetTypeCustomOffset(unit, offsetType)
-	// SAFETY: This should never error as DictIndexType always a valid run ends type
+	// SAFETY: This should never error as RunEndsType always a valid run ends type
 
 	return v
 

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -474,45 +474,31 @@ func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []b
 
 	switch offsets := structBuilder.FieldBuilder(1).(type) {
 	case *array.Int16Builder:
-		for i, v := range values {
+		for _, v := range values {
 			timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
-			if valids[i] {
-				timestamps.UnsafeAppend(timestamp)
-				offsets.UnsafeAppend(offsetMinutes)
-			} else {
-				timestamps.UnsafeAppendBoolToBitmap(false)
-				offsets.UnsafeAppendBoolToBitmap(false)
-			}
+			timestamps.UnsafeAppend(timestamp)
+			offsets.UnsafeAppend(offsetMinutes)
 		}
 	case *array.Int16DictionaryBuilder:
-		for i, v := range values {
+		for _, v := range values {
 			timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
-			if valids[i] {
-				timestamps.UnsafeAppend(timestamp)
-				offsets.UnsafeAppend(offsetMinutes)
-			} else {
-				timestamps.UnsafeAppendBoolToBitmap(false)
-				offsets.UnsafeAppendBoolToBitmap(false)
-			}
+			timestamps.UnsafeAppend(timestamp)
+			offsets.UnsafeAppend(offsetMinutes)
 		}
 	case *array.RunEndEncodedBuilder:
 		offsetValuesBuilder := offsets.ValueBuilder().(*array.Int16Builder)
 		for i, v := range values {
 			timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
-			if valids[i] {
-				timestamps.UnsafeAppend(timestamp)
-				offsetMinutes16 := int16(offsetMinutes)
-				if offsetMinutes != b.lastOffset {
-					offsets.Append(1)
-					offsetValuesBuilder.Append(offsetMinutes16)
-				} else {
-					offsets.ContinueRun(1)
-				}
-				b.lastOffset = offsetMinutes16
+			timestamps.UnsafeAppend(timestamp)
+			offsetMinutes16 := int16(offsetMinutes)
+			// If value at i is null, simply continue the run to maximize compression
+			if valids[i] && offsetMinutes != b.lastOffset {
+				offsets.Append(1)
+				offsetValuesBuilder.Append(offsetMinutes16)
 			} else {
-				timestamps.UnsafeAppendBoolToBitmap(false)
-				offsets.AppendNull()
+				offsets.ContinueRun(1)
 			}
+			b.lastOffset = offsetMinutes16
 		}
 	}
 }

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -17,7 +17,6 @@
 package extensions
 
 import (
-	"errors"
 	"fmt"
 	"iter"
 	"math"
@@ -95,13 +94,13 @@ func NewTimestampWithOffsetType(unit arrow.TimeUnit) *TimestampWithOffsetType {
 	return v
 }
 
-// NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
+// NewTimestampWithOffsetTypeCustomOffset creates a new TimestampWithOffsetType with the underlying storage type set correctly to
 // Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=O), where T is any TimeUnit and O is a valid offset type.
 //
 // The error will be populated if the data type is not a valid encoding of the offsets field.
 func NewTimestampWithOffsetTypeCustomOffset(unit arrow.TimeUnit, offsetType arrow.DataType) (*TimestampWithOffsetType, error) {
 	if !isOffsetTypeOk(offsetType) {
-		return nil, errors.New(fmt.Sprintf("Invalid offset type %s", offsetType))
+		return nil, fmt.Errorf("invalid offset type %s", offsetType)
 	}
 
 	return &TimestampWithOffsetType{
@@ -130,12 +129,11 @@ type DictIndexType interface {
 		*arrow.Uint8Type | *arrow.Uint16Type | *arrow.Uint32Type | *arrow.Uint64Type
 }
 
-
 type RunEndsType interface {
 	*arrow.Int16Type | *arrow.Int32Type | *arrow.Int64Type
 }
 
-// NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
+// NewTimestampWithOffsetTypeDictionaryEncoded creates a new TimestampWithOffsetType with the underlying storage type set correctly to
 // Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=Dictionary(I, Int16)), where T is any TimeUnit and I is a
 // valid Dictionary index type.
 func NewTimestampWithOffsetTypeDictionaryEncoded[I DictIndexType](unit arrow.TimeUnit, index I) *TimestampWithOffsetType {
@@ -150,7 +148,7 @@ func NewTimestampWithOffsetTypeDictionaryEncoded[I DictIndexType](unit arrow.Tim
 	return v
 }
 
-// NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
+// NewTimestampWithOffsetTypeRunEndEncoded creates a new TimestampWithOffsetType with the underlying storage type set correctly to
 // Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=RunEndEncoded(E, Int16)), where T is any TimeUnit and E is a
 // valid run-ends type.
 func NewTimestampWithOffsetTypeRunEndEncoded[E RunEndsType](unit arrow.TimeUnit, runEnds E) *TimestampWithOffsetType {
@@ -350,7 +348,7 @@ func (a *TimestampWithOffsetArray) iterValues() iter.Seq2[time.Time, bool] {
 }
 
 func (a *TimestampWithOffsetArray) Values() []time.Time {
-	return slices.Collect(func (yield func (time.Time) bool) {
+	return slices.Collect(func(yield func(time.Time) bool) {
 		for time := range a.iterValues() {
 			if !yield(time) {
 				return
@@ -422,7 +420,7 @@ func NewTimestampWithOffsetBuilder(mem memory.Allocator, unit arrow.TimeUnit, of
 func (b *TimestampWithOffsetBuilder) Append(v time.Time) {
 	timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
 	offsetMinutes16 := int16(offsetMinutes)
-	structBuilder := b.ExtensionBuilder.Builder.(*array.StructBuilder)
+	structBuilder := b.Builder.(*array.StructBuilder)
 
 	structBuilder.Append(true)
 	structBuilder.FieldBuilder(0).(*array.TimestampBuilder).Append(timestamp)
@@ -464,7 +462,7 @@ func (b *TimestampWithOffsetBuilder) AppendValueFromString(s string) error {
 }
 
 func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []bool) {
-	structBuilder := b.ExtensionBuilder.Builder.(*array.StructBuilder)
+	structBuilder := b.Builder.(*array.StructBuilder)
 	timestamps := structBuilder.FieldBuilder(0).(*array.TimestampBuilder)
 
 	structBuilder.AppendValues(valids)

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -145,19 +145,14 @@ func NewTimestampWithOffsetTypeDictionaryEncoded[I DictIndexType](unit arrow.Tim
 	return v
 }
 
-type TimestampWithOffsetRunEndsType interface {
-	*arrow.Int8Type | *arrow.Int16Type | *arrow.Int32Type | *arrow.Int64Type |
-		*arrow.Uint8Type | *arrow.Uint16Type | *arrow.Uint32Type | *arrow.Uint64Type
-}
-
 // NewTimestampWithOffsetType creates a new TimestampWithOffsetType with the underlying storage type set correctly to
 // Struct(timestamp=Timestamp(T, "UTC"), offset_minutes=RunEndEncoded(E, Int16)), where T is any TimeUnit and E is a
 // valid run-ends type.
-func NewTimestampWithOffsetTypeRunEndEncoded[E TimestampWithOffsetRunEndsType](unit arrow.TimeUnit, runEnds E) *TimestampWithOffsetType {
+func NewTimestampWithOffsetTypeRunEndEncoded[E DictIndexType](unit arrow.TimeUnit, runEnds E) *TimestampWithOffsetType {
 	offsetType := arrow.RunEndEncodedOf(arrow.DataType(runEnds), arrow.PrimitiveTypes.Int16)
 
 	v, _ := NewTimestampWithOffsetTypeCustomOffset(unit, offsetType)
-	// SAFETY: This should never error as TimestampWithOffsetRunEndsType is always a valid run ends type
+	// SAFETY: This should never error as DictIndexType always a valid run ends type
 
 	return v
 

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -228,13 +228,18 @@ func (a *TimestampWithOffsetArray) String() string {
 }
 
 func timeFromFieldValues(utcTimestamp arrow.Timestamp, offsetMinutes int16, unit arrow.TimeUnit) time.Time {
-	hours := offsetMinutes / 60
-	minutes := offsetMinutes % 60
-	if minutes < 0 {
-		minutes = -minutes
+	// Derive the sign from the whole offset: integer hours is 0 for any offset
+	// with magnitude below one hour and so cannot carry a negative sign (e.g.
+	// -30 minutes must format as "UTC-00:30", not "UTC+00:30").
+	sign := "+"
+	abs := offsetMinutes
+	if offsetMinutes < 0 {
+		sign = "-"
+		abs = -offsetMinutes
 	}
 
-	loc := time.FixedZone(fmt.Sprintf("UTC%+03d:%02d", hours, minutes), int(offsetMinutes)*60)
+	name := fmt.Sprintf("UTC%s%02d:%02d", sign, abs/60, abs%60)
+	loc := time.FixedZone(name, int(offsetMinutes)*60)
 	return utcTimestamp.ToTime(unit).In(loc)
 }
 
@@ -348,8 +353,8 @@ func (a *TimestampWithOffsetArray) iterValues() iter.Seq2[time.Time, bool] {
 
 func (a *TimestampWithOffsetArray) Values() []time.Time {
 	return slices.Collect(func(yield func(time.Time) bool) {
-		for time := range a.iterValues() {
-			if !yield(time) {
+		for t := range a.iterValues() {
+			if !yield(t) {
 				return
 			}
 		}
@@ -372,7 +377,7 @@ func (a *TimestampWithOffsetArray) MarshalJSON() ([]byte, error) {
 		if !valid {
 			values[i] = nil
 		} else {
-			values[i] = &ts
+			values[i] = ts
 		}
 		i += 1
 	}

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -178,6 +178,10 @@ func (e *TimestampWithOffsetType) MarshalJSON() ([]byte, error) {
 func (b *TimestampWithOffsetType) Serialize() string { return "" }
 
 func (b *TimestampWithOffsetType) Deserialize(storageType arrow.DataType, data string) (arrow.ExtensionType, error) {
+	if data != "" && data != "{}" {
+		return nil, fmt.Errorf("serialized metadata for TimestampWithOffset extension type must be '' or '{}', found: %s", data)
+	}
+
 	timeUnit, offsetType, ok := isDataTypeCompatible(storageType)
 	if !ok {
 		return nil, fmt.Errorf("invalid storage type for TimestampWithOffsetType: %s", storageType.Name())
@@ -447,6 +451,13 @@ func (b *TimestampWithOffsetBuilder) NewExtensionArray() array.ExtensionArray {
 // AppendNull resets the run-end-encoding tracker: the embedded struct builder
 // appends a null offset run, so a following value must start a new run instead
 // of continuing the null run.
+//
+// NOTE(#918): this writes a null into the non-nullable offset_minutes storage
+// field rather than a default value. This is intentional; comparison and JSON
+// round-trip parity for non-nullable inner struct fields is tracked separately
+// in https://github.com/apache/arrow-go/issues/918. Logical values (instant,
+// offset, validity) are preserved, but a full array.RecordEqual round-trip is
+// not guaranteed here.
 func (b *TimestampWithOffsetBuilder) AppendNull() {
 	b.ExtensionBuilder.AppendNull()
 	b.lastOffset = noLastOffset

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -435,6 +435,19 @@ func (b *TimestampWithOffsetBuilder) NewExtensionArray() array.ExtensionArray {
 	return arr
 }
 
+// AppendNull resets the run-end-encoding tracker: the embedded struct builder
+// appends a null offset run, so a following value must start a new run instead
+// of continuing the null run.
+func (b *TimestampWithOffsetBuilder) AppendNull() {
+	b.ExtensionBuilder.AppendNull()
+	b.lastOffset = noLastOffset
+}
+
+func (b *TimestampWithOffsetBuilder) AppendNulls(n int) {
+	b.ExtensionBuilder.AppendNulls(n)
+	b.lastOffset = noLastOffset
+}
+
 func (b *TimestampWithOffsetBuilder) Append(v time.Time) {
 	timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
 	offsetMinutes16 := int16(offsetMinutes)

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -420,6 +420,21 @@ func NewTimestampWithOffsetBuilder(mem memory.Allocator, unit arrow.TimeUnit, of
 	}, nil
 }
 
+// NewArray must route through this type's NewExtensionArray (not the embedded
+// ExtensionBuilder's) so that the run-end-encoding tracker is reset on reuse.
+func (b *TimestampWithOffsetBuilder) NewArray() arrow.Array {
+	return b.NewExtensionArray()
+}
+
+// NewExtensionArray finalizes the current array and resets lastOffset so a
+// reused builder starts a fresh run instead of continuing a run that belonged
+// to the array just finalized (the underlying REE builder is reset too).
+func (b *TimestampWithOffsetBuilder) NewExtensionArray() array.ExtensionArray {
+	arr := b.ExtensionBuilder.NewExtensionArray()
+	b.lastOffset = noLastOffset
+	return arr
+}
+
 func (b *TimestampWithOffsetBuilder) Append(v time.Time) {
 	timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
 	offsetMinutes16 := int16(offsetMinutes)
@@ -465,6 +480,13 @@ func (b *TimestampWithOffsetBuilder) AppendValueFromString(s string) error {
 }
 
 func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []bool) {
+	if valids == nil {
+		valids = make([]bool, len(values))
+		for i := range valids {
+			valids[i] = true
+		}
+	}
+
 	structBuilder := b.Builder.(*array.StructBuilder)
 	timestamps := structBuilder.FieldBuilder(0).(*array.TimestampBuilder)
 
@@ -499,7 +521,7 @@ func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []b
 			// values child and produce an invalid run-end encoded array. lastOffset
 			// is only updated when a new run starts, so a null row never splits a
 			// contiguous run into two adjacent runs sharing the same value.
-			valid := valids == nil || valids[i]
+			valid := valids[i]
 			if b.lastOffset == noLastOffset || (valid && offsetMinutes != b.lastOffset) {
 				offsets.Append(1)
 				offsetValuesBuilder.Append(offsetMinutes)

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -232,10 +232,10 @@ func timeFromFieldValues(utcTimestamp arrow.Timestamp, offsetMinutes int16, unit
 	// with magnitude below one hour and so cannot carry a negative sign (e.g.
 	// -30 minutes must format as "UTC-00:30", not "UTC+00:30").
 	sign := "+"
-	abs := offsetMinutes
-	if offsetMinutes < 0 {
+	abs := int(offsetMinutes)
+	if abs < 0 {
 		sign = "-"
-		abs = -offsetMinutes
+		abs = -abs
 	}
 
 	name := fmt.Sprintf("UTC%s%02d:%02d", sign, abs/60, abs%60)

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -382,6 +382,12 @@ func (a *TimestampWithOffsetArray) GetOneForMarshal(i int) interface{} {
 	return a.Value(i)
 }
 
+// noLastOffset is the sentinel value for TimestampWithOffsetBuilder.lastOffset
+// indicating that no run-end-encoded run has been started yet. It is deliberately
+// outside the range of valid timezone offsets in minutes (roughly [-720, 840]) so
+// it can never compare equal to a real offset.
+const noLastOffset int16 = math.MaxInt16
+
 // TimestampWithOffsetBuilder is a convenience builder for the TimestampWithOffset extension type,
 // allowing arrays to be built with boolean values rather than the underlying storage type.
 type TimestampWithOffsetBuilder struct {
@@ -391,7 +397,9 @@ type TimestampWithOffsetBuilder struct {
 	Layout     string
 	unit       arrow.TimeUnit
 	offsetType arrow.DataType
-	// lastOffset is only used to determine when to start new runs with run-end encoded offsets
+	// lastOffset tracks the offset of the current run when the offsets are run-end
+	// encoded, so we know when to start a new run. It is initialized to noLastOffset
+	// to signal that no run has been started yet.
 	lastOffset int16
 }
 
@@ -406,7 +414,7 @@ func NewTimestampWithOffsetBuilder(mem memory.Allocator, unit arrow.TimeUnit, of
 	return &TimestampWithOffsetBuilder{
 		unit:             unit,
 		offsetType:       offsetType,
-		lastOffset:       math.MaxInt16,
+		lastOffset:       noLastOffset,
 		Layout:           time.RFC3339,
 		ExtensionBuilder: array.NewExtensionBuilder(mem, dataType),
 	}, nil
@@ -483,15 +491,22 @@ func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []b
 		for i, v := range values {
 			timestamp, offsetMinutes := fieldValuesFromTime(v, b.unit)
 			timestamps.UnsafeAppend(timestamp)
-			offsetMinutes16 := int16(offsetMinutes)
-			// If value at i is null, simply continue the run to maximize compression
-			if valids[i] && offsetMinutes != b.lastOffset {
+
+			// A null row's offset is masked by the struct validity bitmap, so we
+			// continue the current run to maximize compression. A run must still be
+			// started when none exists yet (e.g. leading null rows), otherwise
+			// ContinueRun would advance the run-ends without a matching entry in the
+			// values child and produce an invalid run-end encoded array. lastOffset
+			// is only updated when a new run starts, so a null row never splits a
+			// contiguous run into two adjacent runs sharing the same value.
+			valid := valids == nil || valids[i]
+			if b.lastOffset == noLastOffset || (valid && offsetMinutes != b.lastOffset) {
 				offsets.Append(1)
-				offsetValuesBuilder.Append(offsetMinutes16)
+				offsetValuesBuilder.Append(offsetMinutes)
+				b.lastOffset = offsetMinutes
 			} else {
 				offsets.ContinueRun(1)
 			}
-			b.lastOffset = offsetMinutes16
 		}
 	}
 }

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -294,7 +294,11 @@ func (a *TimestampWithOffsetArray) iterValues() iter.Seq2[time.Time, bool] {
 			timestamps := timestampField.(*array.Timestamp)
 
 			offsetValues := reeOffsets.Values().(*array.Int16)
-			offsetPhysicalIdx := 0
+			// Run-ends are absolute over the unsliced offsets child, so a sliced
+			// array must begin at the physical run covering its logical offset and
+			// advance using absolute positions (logicalOffset + i).
+			logicalOffset := reeOffsets.Offset()
+			offsetPhysicalIdx := reeOffsets.GetPhysicalOffset()
 
 			var getRunEnd (func(int) int)
 			switch arr := reeOffsets.RunEndsArr().(type) {
@@ -307,7 +311,7 @@ func (a *TimestampWithOffsetArray) iterValues() iter.Seq2[time.Time, bool] {
 			}
 
 			for i := 0; i < a.Len(); i++ {
-				if i >= getRunEnd(offsetPhysicalIdx) {
+				if logicalOffset+i >= getRunEnd(offsetPhysicalIdx) {
 					offsetPhysicalIdx += 1
 				}
 

--- a/arrow/extensions/timestamp_with_offset.go
+++ b/arrow/extensions/timestamp_with_offset.go
@@ -480,7 +480,10 @@ func (b *TimestampWithOffsetBuilder) AppendValueFromString(s string) error {
 }
 
 func (b *TimestampWithOffsetBuilder) AppendValues(values []time.Time, valids []bool) {
-	if valids == nil {
+	if len(valids) != len(values) && len(valids) != 0 {
+		panic("len(values) != len(valids) && len(valids) != 0")
+	}
+	if len(valids) == 0 {
 		valids = make([]bool, len(values))
 		for i := range valids {
 			valids[i] = true

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -18,10 +18,7 @@ package extensions_test
 
 import (
 	"bytes"
-	_ "bytes"
 	"fmt"
-	"strings"
-	_ "strings"
 	"testing"
 	"time"
 
@@ -29,7 +26,6 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
-	_ "github.com/apache/arrow-go/v18/arrow/ipc"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/internal/json"
 	"github.com/stretchr/testify/assert"
@@ -46,8 +42,33 @@ var testDate2 = testDate1.In(testZone1)
 var testZone2 = time.FixedZone("UTC+06:00", +6*60*60)
 var testDate3 = testDate1.In(testZone2)
 
-func TestTimestampWithOffsetTypeBasics(t *testing.T) {
-	typ := extensions.NewTimestampWithOffsetType(testTimeUnit)
+func dict(index arrow.DataType) arrow.DataType {
+	return &arrow.DictionaryType{
+		IndexType: index,
+		ValueType: arrow.PrimitiveTypes.Int16,
+		Ordered: false,
+	}
+}
+
+// All tests use this in a for loop to make sure everything works for every possible
+// encoding of offsets (primitive, dictionary, run-end)
+var allAllowedOffsetTypes = []arrow.DataType{
+	// primitive offsetType
+	arrow.PrimitiveTypes.Int16,
+
+	// dict-encoded offsetType
+	dict(arrow.PrimitiveTypes.Uint8),
+	dict(arrow.PrimitiveTypes.Uint16),
+	dict(arrow.PrimitiveTypes.Uint32),
+	dict(arrow.PrimitiveTypes.Uint64),
+	dict(arrow.PrimitiveTypes.Int8),
+	dict(arrow.PrimitiveTypes.Int16),
+	dict(arrow.PrimitiveTypes.Int32),
+	dict(arrow.PrimitiveTypes.Int64),
+}
+
+func TestTimestampWithOffsetTypePrimitiveBasics(t *testing.T) {
+	typ := extensions.NewTimestampWithOffsetTypePrimitiveEncoded(testTimeUnit)
 
 	assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
 	assert.True(t, typ.ExtensionEquals(typ))
@@ -74,136 +95,208 @@ func TestTimestampWithOffsetTypeBasics(t *testing.T) {
 	assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
 }
 
+func TestTimestampWithOffsetTypeDictionaryEncodedBasics(t *testing.T) {
+	invalidIndexType := arrow.PrimitiveTypes.Float32
+	_, err := extensions.NewTimestampWithOffsetTypeDictionaryEncoded(testTimeUnit, invalidIndexType)
+	assert.True(t, err != nil, "Err should not be nil if index type is invalid dict key")
+
+	indexTypes := []arrow.DataType{
+		arrow.PrimitiveTypes.Uint8,
+		arrow.PrimitiveTypes.Uint16,
+		arrow.PrimitiveTypes.Uint32,
+		arrow.PrimitiveTypes.Uint64,
+		arrow.PrimitiveTypes.Int8,
+		arrow.PrimitiveTypes.Int16,
+		arrow.PrimitiveTypes.Int32,
+		arrow.PrimitiveTypes.Int64,
+	};
+
+	for _, indexType := range indexTypes {
+		typ, err := extensions.NewTimestampWithOffsetTypeDictionaryEncoded(testTimeUnit, indexType)
+		assert.True(t, err == nil, "Err should be nil")
+
+		assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
+		assert.True(t, typ.ExtensionEquals(typ))
+
+		assert.True(t, arrow.TypeEqual(typ, typ))
+		assert.True(t, arrow.TypeEqual(
+			arrow.StructOf(
+				arrow.Field{
+					Name: "timestamp",
+					Type: &arrow.TimestampType{
+						Unit:     testTimeUnit,
+						TimeZone: "UTC",
+					},
+					Nullable: false,
+				},
+				arrow.Field{
+					Name: "offset_minutes",
+					Type: dict(indexType),
+					Nullable: false,
+				},
+			),
+			typ.StorageType()))
+
+		assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
+	}
+}
+
 func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	builder := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit)
-	builder.Append(testDate1)
-	builder.AppendNull()
-	builder.Append(testDate2)
-	builder.Append(testDate3)
-
-	// it should build the array with the correct size
-	arr := builder.NewArray()
-	typedArr := arr.(*extensions.TimestampWithOffsetArray)
-	assert.Equal(t, 4, arr.Data().Len())
-	defer arr.Release()
-
-	// typedArr.Value(i) should return values adjusted for their original timezone
-	assert.Equal(t, testDate1, typedArr.Value(0))
-	assert.Equal(t, testDate2, typedArr.Value(2))
-	assert.Equal(t, testDate3, typedArr.Value(3))
-
-	// storage TimeUnit should be the same as we pass in to the builder, and storage timezone should be UTC
-	timestampStructField := typedArr.Storage().(*array.Struct).Field(0)
-	timestampStructDataType := timestampStructField.DataType().(*arrow.TimestampType)
-	assert.Equal(t, timestampStructDataType.Unit, testTimeUnit)
-	assert.Equal(t, timestampStructDataType.TimeZone, "UTC")
-
-	// stored values should be equivalent to the raw values in UTC
-	timestampsArr := timestampStructField.(*array.Timestamp)
-	assert.Equal(t, testDate1.In(time.UTC), timestampsArr.Value(0).ToTime(testTimeUnit))
-	assert.Equal(t, testDate2.In(time.UTC), timestampsArr.Value(2).ToTime(testTimeUnit))
-	assert.Equal(t, testDate3.In(time.UTC), timestampsArr.Value(3).ToTime(testTimeUnit))
-
-	// the array should encode itself as JSON and string
-	arrStr := arr.String()
-	assert.Equal(t, fmt.Sprintf(`["%[1]s" (null) "%[2]s" "%[3]s"]`, testDate1, testDate2, testDate3), arrStr)
-	jsonStr, err := json.Marshal(arr)
+	// NOTE: we need to compare the arrays parsed from JSON with a primitive-encoded array, since that will always
+	// use that encoding (there is no way to pass a flag to array.FromJSON to say explicitly what storage type you want)
+	primitiveBuilder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, arrow.PrimitiveTypes.Int16)
 	assert.NoError(t, err)
+	primitiveBuilder.Append(testDate1)
+	primitiveBuilder.AppendNull()
+	primitiveBuilder.Append(testDate2)
+	primitiveBuilder.Append(testDate3)
+	jsonComparisonArr := primitiveBuilder.NewArray()
+	defer jsonComparisonArr.Release()
 
-	// roundtripping from JSON with array.FromJSON should work
-	roundtripped, _, err := array.FromJSON(mem, extensions.NewTimestampWithOffsetType(testTimeUnit), bytes.NewReader(jsonStr))
-	defer roundtripped.Release()
-	assert.NoError(t, err)
-	assert.Truef(t, array.Equal(arr, roundtripped), "expected %s got %s", arr, roundtripped)
+	for _, offsetType := range allAllowedOffsetTypes {
+		builder, _ := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
+
+		builder.Append(testDate1)
+		builder.AppendNull()
+		builder.Append(testDate2)
+		builder.Append(testDate3)
+
+		// it should build the array with the correct size
+		arr := builder.NewArray()
+		typedArr := arr.(*extensions.TimestampWithOffsetArray)
+		assert.Equal(t, 4, arr.Data().Len())
+		defer arr.Release()
+
+		// typedArr.Value(i) should return values adjusted for their original timezone
+		assert.Equal(t, testDate1, typedArr.Value(0))
+		assert.Equal(t, testDate2, typedArr.Value(2))
+		assert.Equal(t, testDate3, typedArr.Value(3))
+
+		// storage TimeUnit should be the same as we pass in to the builder, and storage timezone should be UTC
+		timestampStructField := typedArr.Storage().(*array.Struct).Field(0)
+		timestampStructDataType := timestampStructField.DataType().(*arrow.TimestampType)
+		assert.Equal(t, timestampStructDataType.Unit, testTimeUnit)
+		assert.Equal(t, timestampStructDataType.TimeZone, "UTC")
+
+		// stored values should be equivalent to the raw values in UTC
+		timestampsArr := timestampStructField.(*array.Timestamp)
+		assert.Equal(t, testDate1.In(time.UTC), timestampsArr.Value(0).ToTime(testTimeUnit))
+		assert.Equal(t, testDate2.In(time.UTC), timestampsArr.Value(2).ToTime(testTimeUnit))
+		assert.Equal(t, testDate3.In(time.UTC), timestampsArr.Value(3).ToTime(testTimeUnit))
+
+		// the array should encode itself as JSON and string
+		arrStr := arr.String()
+		assert.Equal(t, fmt.Sprintf(`["%[1]s" (null) "%[2]s" "%[3]s"]`, testDate1, testDate2, testDate3), arrStr)
+		jsonStr, err := json.Marshal(arr)
+		assert.NoError(t, err)
+
+		// roundtripping from JSON with array.FromJSON should work
+		expectedDataType, _ := extensions.NewTimestampWithOffsetType(testTimeUnit, offsetType)
+		roundtripped, _, err := array.FromJSON(mem, expectedDataType, bytes.NewReader(jsonStr))
+		defer roundtripped.Release()
+		assert.NoError(t, err)
+		assert.Truef(t, array.Equal(jsonComparisonArr, roundtripped), "expected %s\n\ngot %s", jsonComparisonArr, roundtripped)
+	}
 }
 
 func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
-	schema := arrow.NewSchema([]arrow.Field{
-		{
-			Name:     "timestamp_with_offset",
-			Nullable: true,
-			Type:     extensions.NewTimestampWithOffsetType(testTimeUnit),
-		},
-	}, nil)
-	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
-	defer builder.Release()
+	for _, offsetType := range allAllowedOffsetTypes {
+		dataType, _ := extensions.NewTimestampWithOffsetType(testTimeUnit, offsetType)
+		schema := arrow.NewSchema([]arrow.Field{
+			{
+				Name:     "timestamp_with_offset",
+				Nullable: true,
+				Type:     dataType,
+			},
+		}, nil)
+		builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+		defer builder.Release()
 
-	fieldBuilder := builder.Field(0).(*extensions.TimestampWithOffsetBuilder)
+		fieldBuilder := builder.Field(0).(*extensions.TimestampWithOffsetBuilder)
 
-	// append a simple time.Time
-	fieldBuilder.Append(testDate1)
+		// append a simple time.Time
+		fieldBuilder.Append(testDate1)
 
-	// append a null and 2 time.Time all at once
-	values := []time.Time{
-		time.Unix(0, 0).In(time.UTC),
-		testDate2,
-		testDate3,
-	}
-	valids := []bool{false, true, true}
-	fieldBuilder.AppendValues(values, valids)
+		// append a null and 2 time.Time all at once
+		values := []time.Time{
+			time.Unix(0, 0).In(time.UTC),
+			testDate2,
+			testDate3,
+		}
+		valids := []bool{false, true, true}
+		fieldBuilder.AppendValues(values, valids)
 
-	// append a value from RFC3339 string
-	fieldBuilder.AppendValueFromString(testDate1.Format(time.RFC3339))
+		// append a value from RFC3339 string
+		fieldBuilder.AppendValueFromString(testDate1.Format(time.RFC3339))
 
-	// append value formatted in a different string layout
-	fieldBuilder.Layout = time.RFC3339Nano
-	fieldBuilder.AppendValueFromString(testDate2.Format(time.RFC3339Nano))
+		// append value formatted in a different string layout
+		fieldBuilder.Layout = time.RFC3339Nano
+		fieldBuilder.AppendValueFromString(testDate2.Format(time.RFC3339Nano))
 
-	record := builder.NewRecordBatch()
+		record := builder.NewRecordBatch()
 
-	// Record batch should JSON-encode values containing per-row timezone info
-	json, err := record.MarshalJSON()
-	require.NoError(t, err)
-	expect := `[{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
+		// Record batch should JSON-encode values containing per-row timezone info
+		json, err := record.MarshalJSON()
+		require.NoError(t, err)
+		expect := `[{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
 ,{"timestamp_with_offset":null}
 ,{"timestamp_with_offset":"2024-12-31T16:00:00-08:00"}
 ,{"timestamp_with_offset":"2025-01-01T06:00:00+06:00"}
 ,{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
 ,{"timestamp_with_offset":"2024-12-31T16:00:00-08:00"}
 ]`
-	require.Equal(t, expect, string(json))
+		require.Equal(t, expect, string(json))
 
-	// Record batch roundtrip to JSON should work
-	roundtripped, _, err := array.RecordFromJSON(memory.DefaultAllocator, schema, bytes.NewReader(json))
-	require.NoError(t, err)
-	defer roundtripped.Release()
-	require.Equal(t, schema, roundtripped.Schema())
-	assert.Truef(t, array.RecordEqual(record, roundtripped), "expected %s\n\ngot %s", record, roundtripped)
+		// Record batch roundtrip to JSON should work
+		roundtripped, _, err := array.RecordFromJSON(memory.DefaultAllocator, schema, bytes.NewReader(json))
+		require.NoError(t, err)
+		defer roundtripped.Release()
+		require.Equal(t, schema, roundtripped.Schema())
+		assert.Truef(t, array.RecordEqual(record, roundtripped), "expected %s\n\ngot %s", record, roundtripped)
+	}
 }
 
 func TestTimestampWithOffsetTypeBatchIPCRoundTrip(t *testing.T) {
-	raw := `["2025-01-01T00:00:00Z",null,"2024-12-31T16:00:00-08:00","2025-01-01T06:00:00+06:00","2025-01-01T00:00:00Z","2024-12-31T16:00:00-08:00"]`
-	typ := extensions.NewTimestampWithOffsetType(testTimeUnit)
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
 
-	arr, _, err := array.FromJSON(memory.DefaultAllocator, typ, strings.NewReader(raw))
-	require.NoError(t, err)
-	defer arr.Release()
+	for _, offsetType := range allAllowedOffsetTypes {
+		builder, _ := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
+		builder.Append(testDate1)
+		builder.AppendNull()
+		builder.Append(testDate2)
+		builder.Append(testDate3)
+		arr := builder.NewArray()
+		defer arr.Release()
 
-	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{Name: "timestamp_with_offset", Type: typ, Nullable: true}}, nil), []arrow.Array{arr}, -1)
-	defer batch.Release()
+		typ, _ := extensions.NewTimestampWithOffsetType(testTimeUnit, offsetType)
 
-	var written arrow.RecordBatch
-	{
-		var buf bytes.Buffer
-		wr := ipc.NewWriter(&buf, ipc.WithSchema(batch.Schema()))
-		require.NoError(t, wr.Write(batch))
-		require.NoError(t, wr.Close())
+		batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{Name: "timestamp_with_offset", Type: typ, Nullable: true}}, nil), []arrow.Array{arr}, -1)
+		defer batch.Release()
 
-		rdr, err := ipc.NewReader(&buf)
-		require.NoError(t, err)
-		written, err = rdr.Read()
-		require.NoError(t, err)
-		written.Retain()
-		defer written.Release()
-		rdr.Release()
+		var written arrow.RecordBatch
+		{
+			var buf bytes.Buffer
+			wr := ipc.NewWriter(&buf, ipc.WithSchema(batch.Schema()))
+			require.NoError(t, wr.Write(batch))
+			require.NoError(t, wr.Close())
+
+			rdr, err := ipc.NewReader(&buf)
+			require.NoError(t, err)
+			written, err = rdr.Read()
+			require.NoError(t, err)
+			written.Retain()
+			defer written.Release()
+			rdr.Release()
+		}
+
+		assert.Truef(t, batch.Schema().Equal(written.Schema()), "expected: %s\n\ngot: %s",
+			batch.Schema(), written.Schema())
+
+		assert.Truef(t, array.RecordEqual(batch, written), "expected: %s\n\ngot: %s",
+			batch, written)
 	}
-
-	assert.Truef(t, batch.Schema().Equal(written.Schema()), "expected: %s\n\ngot: %s",
-		batch.Schema(), written.Schema())
-
-	assert.Truef(t, array.RecordEqual(batch, written), "expected: %s\n\ngot: %s",
-		batch, written)
 }

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -79,7 +79,7 @@ var allAllowedOffsetTypes = []arrow.DataType{
 }
 
 func TestTimestampWithOffsetTypePrimitiveBasics(t *testing.T) {
-	typ := extensions.NewTimestampWithOffsetTypePrimitiveEncoded(testTimeUnit)
+	typ := extensions.NewTimestampWithOffsetType(testTimeUnit)
 
 	assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
 	assert.True(t, typ.ExtensionEquals(typ))
@@ -246,7 +246,7 @@ func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 		assert.NoError(t, err)
 
 		// roundtripping from JSON with array.FromJSON should work
-		expectedDataType, _ := extensions.NewTimestampWithOffsetType(testTimeUnit, offsetType)
+		expectedDataType, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
 		roundtripped, _, err := array.FromJSON(mem, expectedDataType, bytes.NewReader(jsonStr))
 		defer roundtripped.Release()
 		assert.NoError(t, err)
@@ -256,7 +256,7 @@ func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 
 func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 	for _, offsetType := range allAllowedOffsetTypes {
-		dataType, _ := extensions.NewTimestampWithOffsetType(testTimeUnit, offsetType)
+		dataType, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
 		schema := arrow.NewSchema([]arrow.Field{
 			{
 				Name:     "timestamp_with_offset",
@@ -324,7 +324,7 @@ func TestTimestampWithOffsetTypeBatchIPCRoundTrip(t *testing.T) {
 		arr := builder.NewArray()
 		defer arr.Release()
 
-		typ, _ := extensions.NewTimestampWithOffsetType(testTimeUnit, offsetType)
+		typ, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
 
 		batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{Name: "timestamp_with_offset", Type: typ, Nullable: true}}, nil), []arrow.Array{arr}, -1)
 		defer batch.Release()

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -179,20 +179,38 @@ func TestTimestampWithOffsetTypeRunEndEncodedBasics(t *testing.T) {
 	assertReeBasics(t, &arrow.Int64Type{})
 }
 
+func TestTimestampWithOffsetEquals(t *testing.T) {
+	// Completely different types are not equal
+	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewBool8Type()))
+
+	// Different time units are not equal
+	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Microsecond)))
+	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Second)))
+	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Second)))
+	//
+	// // Different underlying storage type is not equal
+	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	// assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	//
+	// // Dict-encoding key type is not equal
+	// assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+	//
+	// // REE index type is not equal
+	// assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+	//
+	// // Equals OK
+	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Nanosecond)))
+	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Microsecond)))
+	// assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	// assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+	// assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	// assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+}
+
 func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-
-	// NOTE: we need to compare the arrays parsed from JSON with a primitive-encoded array, since that will always
-	// use that encoding (there is no way to pass a flag to array.FromJSON to say explicitly what storage type you want)
-	primitiveBuilder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, arrow.PrimitiveTypes.Int16)
-	assert.NoError(t, err)
-	primitiveBuilder.Append(testDate0)
-	primitiveBuilder.AppendNull()
-	primitiveBuilder.Append(testDate1)
-	primitiveBuilder.Append(testDate2)
-	jsonComparisonArr := primitiveBuilder.NewArray()
-	defer jsonComparisonArr.Release()
 
 	for _, offsetType := range allAllowedOffsetTypes {
 		builder, _ := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
@@ -236,7 +254,7 @@ func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 		roundtripped, _, err := array.FromJSON(mem, expectedDataType, bytes.NewReader(jsonStr))
 		defer roundtripped.Release()
 		assert.NoError(t, err)
-		assert.Truef(t, array.Equal(jsonComparisonArr, roundtripped), "expected %s\n\ngot %s", jsonComparisonArr, roundtripped)
+		assert.Truef(t, array.Equal(arr, roundtripped), "expected %s\n\ngot %s", arr, roundtripped)
 	}
 }
 

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -106,91 +106,77 @@ func TestTimestampWithOffsetTypePrimitiveBasics(t *testing.T) {
 	assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
 }
 
+func assertDictBasics[I extensions.DictIndexType](t *testing.T, indexType I) {
+	typ := extensions.NewTimestampWithOffsetTypeDictionaryEncoded(testTimeUnit, indexType)
+
+	assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
+	assert.True(t, typ.ExtensionEquals(typ))
+
+	assert.True(t, arrow.TypeEqual(typ, typ))
+	assert.True(t, arrow.TypeEqual(
+		arrow.StructOf(
+			arrow.Field{
+				Name: "timestamp",
+				Type: &arrow.TimestampType{
+					Unit:     testTimeUnit,
+					TimeZone: "UTC",
+				},
+				Nullable: false,
+			},
+			arrow.Field{
+				Name: "offset_minutes",
+				Type: dict(arrow.DataType(indexType)),
+				Nullable: false,
+			},
+		),
+		typ.StorageType()))
+
+	assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
+}
+
 func TestTimestampWithOffsetTypeDictionaryEncodedBasics(t *testing.T) {
-	invalidIndexType := arrow.PrimitiveTypes.Float32
-	_, err := extensions.NewTimestampWithOffsetTypeDictionaryEncoded(testTimeUnit, invalidIndexType)
-	assert.True(t, err != nil, "Err should not be nil if index type is invalid dict key")
+	assertDictBasics(t, &arrow.Uint8Type{})
+	assertDictBasics(t, &arrow.Uint16Type{})
+	assertDictBasics(t, &arrow.Uint32Type{})
+	assertDictBasics(t, &arrow.Uint64Type{})
+	assertDictBasics(t, &arrow.Int8Type{})
+	assertDictBasics(t, &arrow.Int16Type{})
+	assertDictBasics(t, &arrow.Int32Type{})
+	assertDictBasics(t, &arrow.Int64Type{})
+}
 
-	indexTypes := []arrow.DataType{
-		arrow.PrimitiveTypes.Uint8,
-		arrow.PrimitiveTypes.Uint16,
-		arrow.PrimitiveTypes.Uint32,
-		arrow.PrimitiveTypes.Uint64,
-		arrow.PrimitiveTypes.Int8,
-		arrow.PrimitiveTypes.Int16,
-		arrow.PrimitiveTypes.Int32,
-		arrow.PrimitiveTypes.Int64,
-	};
+func assertReeBasics[E extensions.TimestampWithOffsetRunEndsType](t *testing.T, runEndsType E) {
+	typ := extensions.NewTimestampWithOffsetTypeRunEndEncoded(testTimeUnit, runEndsType)
 
-	for _, indexType := range indexTypes {
-		typ, err := extensions.NewTimestampWithOffsetTypeDictionaryEncoded(testTimeUnit, indexType)
-		assert.True(t, err == nil, "Err should be nil")
+	assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
+	assert.True(t, typ.ExtensionEquals(typ))
 
-		assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
-		assert.True(t, typ.ExtensionEquals(typ))
-
-		assert.True(t, arrow.TypeEqual(typ, typ))
-		assert.True(t, arrow.TypeEqual(
-			arrow.StructOf(
-				arrow.Field{
-					Name: "timestamp",
-					Type: &arrow.TimestampType{
-						Unit:     testTimeUnit,
-						TimeZone: "UTC",
-					},
-					Nullable: false,
+	assert.True(t, arrow.TypeEqual(typ, typ))
+	assert.True(t, arrow.TypeEqual(
+		arrow.StructOf(
+			arrow.Field{
+				Name: "timestamp",
+				Type: &arrow.TimestampType{
+					Unit:     testTimeUnit,
+					TimeZone: "UTC",
 				},
-				arrow.Field{
-					Name: "offset_minutes",
-					Type: dict(indexType),
-					Nullable: false,
-				},
-			),
-			typ.StorageType()))
+				Nullable: false,
+			},
+			arrow.Field{
+				Name: "offset_minutes",
+				Type: ree(arrow.DataType(runEndsType)),
+				Nullable: false,
+			},
+		),
+		typ.StorageType()))
 
-		assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
-	}
+	assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
 }
 
 func TestTimestampWithOffsetTypeRunEndEncodedBasics(t *testing.T) {
-	invalidRunEndsType := arrow.PrimitiveTypes.Float32
-	_, err := extensions.NewTimestampWithOffsetTypeRunEndEncoded(testTimeUnit, invalidRunEndsType)
-	assert.True(t, err != nil, "Err should not be nil if run ends type is invalid")
-
-	runEndsTypes := []arrow.DataType{
-		arrow.PrimitiveTypes.Int16,
-		arrow.PrimitiveTypes.Int32,
-		arrow.PrimitiveTypes.Int64,
-	};
-
-	for _, indexType := range runEndsTypes {
-		typ, err := extensions.NewTimestampWithOffsetTypeRunEndEncoded(testTimeUnit, indexType)
-		assert.True(t, err == nil, "Err should be nil")
-
-		assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
-		assert.True(t, typ.ExtensionEquals(typ))
-
-		assert.True(t, arrow.TypeEqual(typ, typ))
-		assert.True(t, arrow.TypeEqual(
-			arrow.StructOf(
-				arrow.Field{
-					Name: "timestamp",
-					Type: &arrow.TimestampType{
-						Unit:     testTimeUnit,
-						TimeZone: "UTC",
-					},
-					Nullable: false,
-				},
-				arrow.Field{
-					Name: "offset_minutes",
-					Type: ree(indexType),
-					Nullable: false,
-				},
-			),
-			typ.StorageType()))
-
-		assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
-	}
+	assertReeBasics(t, &arrow.Int16Type{})
+	assertReeBasics(t, &arrow.Int32Type{})
+	assertReeBasics(t, &arrow.Int64Type{})
 }
 
 func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -1,0 +1,209 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions_test
+
+import (
+	"bytes"
+	_ "bytes"
+	"fmt"
+	"strings"
+	_ "strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
+	"github.com/apache/arrow-go/v18/arrow/ipc"
+	_ "github.com/apache/arrow-go/v18/arrow/ipc"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/internal/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testTimeUnit = arrow.Microsecond
+
+var testDate1 = time.Date(2025, 01, 01, 00, 00, 00, 00, time.FixedZone("UTC+00:00", 0))
+
+var testZone1 = time.FixedZone("UTC-08:00", -8*60*60)
+var testDate2 = testDate1.In(testZone1)
+
+var testZone2 = time.FixedZone("UTC+06:00", +6*60*60)
+var testDate3 = testDate1.In(testZone2)
+
+func TestTimestampWithOffsetTypeBasics(t *testing.T) {
+	typ := extensions.NewTimestampWithOffsetType(testTimeUnit)
+
+	assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
+	assert.True(t, typ.ExtensionEquals(typ))
+
+	assert.True(t, arrow.TypeEqual(typ, typ))
+	assert.True(t, arrow.TypeEqual(
+		arrow.StructOf(
+			arrow.Field{
+				Name: "timestamp",
+				Type: &arrow.TimestampType{
+					Unit:     testTimeUnit,
+					TimeZone: "UTC",
+				},
+				Nullable: false,
+			},
+			arrow.Field{
+				Name:     "offset_minutes",
+				Type:     arrow.PrimitiveTypes.Int16,
+				Nullable: false,
+			},
+		),
+		typ.StorageType()))
+
+	assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
+}
+
+func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	builder := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit)
+	builder.Append(testDate1)
+	builder.AppendNull()
+	builder.Append(testDate2)
+	builder.Append(testDate3)
+
+	// it should build the array with the correct size
+	arr := builder.NewArray()
+	typedArr := arr.(*extensions.TimestampWithOffsetArray)
+	assert.Equal(t, 4, arr.Data().Len())
+	defer arr.Release()
+
+	// typedArr.Value(i) should return values adjusted for their original timezone
+	assert.Equal(t, testDate1, typedArr.Value(0))
+	assert.Equal(t, testDate2, typedArr.Value(2))
+	assert.Equal(t, testDate3, typedArr.Value(3))
+
+	// storage TimeUnit should be the same as we pass in to the builder, and storage timezone should be UTC
+	timestampStructField := typedArr.Storage().(*array.Struct).Field(0)
+	timestampStructDataType := timestampStructField.DataType().(*arrow.TimestampType)
+	assert.Equal(t, timestampStructDataType.Unit, testTimeUnit)
+	assert.Equal(t, timestampStructDataType.TimeZone, "UTC")
+
+	// stored values should be equivalent to the raw values in UTC
+	timestampsArr := timestampStructField.(*array.Timestamp)
+	assert.Equal(t, testDate1.In(time.UTC), timestampsArr.Value(0).ToTime(testTimeUnit))
+	assert.Equal(t, testDate2.In(time.UTC), timestampsArr.Value(2).ToTime(testTimeUnit))
+	assert.Equal(t, testDate3.In(time.UTC), timestampsArr.Value(3).ToTime(testTimeUnit))
+
+	// the array should encode itself as JSON and string
+	arrStr := arr.String()
+	assert.Equal(t, fmt.Sprintf(`["%[1]s" (null) "%[2]s" "%[3]s"]`, testDate1, testDate2, testDate3), arrStr)
+	jsonStr, err := json.Marshal(arr)
+	assert.NoError(t, err)
+
+	// roundtripping from JSON with array.FromJSON should work
+	roundtripped, _, err := array.FromJSON(mem, extensions.NewTimestampWithOffsetType(testTimeUnit), bytes.NewReader(jsonStr))
+	defer roundtripped.Release()
+	assert.NoError(t, err)
+	assert.Truef(t, array.Equal(arr, roundtripped), "expected %s got %s", arr, roundtripped)
+}
+
+func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "timestamp_with_offset",
+			Nullable: true,
+			Type:     extensions.NewTimestampWithOffsetType(testTimeUnit),
+		},
+	}, nil)
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer builder.Release()
+
+	fieldBuilder := builder.Field(0).(*extensions.TimestampWithOffsetBuilder)
+
+	// append a simple time.Time
+	fieldBuilder.Append(testDate1)
+
+	// append a null and 2 time.Time all at once
+	values := []time.Time{
+		time.Unix(0, 0).In(time.UTC),
+		testDate2,
+		testDate3,
+	}
+	valids := []bool{false, true, true}
+	fieldBuilder.AppendValues(values, valids)
+
+	// append a value from RFC3339 string
+	fieldBuilder.AppendValueFromString(testDate1.Format(time.RFC3339))
+
+	// append value formatted in a different string layout
+	fieldBuilder.Layout = time.RFC3339Nano
+	fieldBuilder.AppendValueFromString(testDate2.Format(time.RFC3339Nano))
+
+	record := builder.NewRecordBatch()
+
+	// Record batch should JSON-encode values containing per-row timezone info
+	json, err := record.MarshalJSON()
+	require.NoError(t, err)
+	expect := `[{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
+,{"timestamp_with_offset":null}
+,{"timestamp_with_offset":"2024-12-31T16:00:00-08:00"}
+,{"timestamp_with_offset":"2025-01-01T06:00:00+06:00"}
+,{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
+,{"timestamp_with_offset":"2024-12-31T16:00:00-08:00"}
+]`
+	require.Equal(t, expect, string(json))
+
+	// Record batch roundtrip to JSON should work
+	roundtripped, _, err := array.RecordFromJSON(memory.DefaultAllocator, schema, bytes.NewReader(json))
+	require.NoError(t, err)
+	defer roundtripped.Release()
+	require.Equal(t, schema, roundtripped.Schema())
+	assert.Truef(t, array.RecordEqual(record, roundtripped), "expected %s\n\ngot %s", record, roundtripped)
+}
+
+func TestTimestampWithOffsetTypeBatchIPCRoundTrip(t *testing.T) {
+	raw := `["2025-01-01T00:00:00Z",null,"2024-12-31T16:00:00-08:00","2025-01-01T06:00:00+06:00","2025-01-01T00:00:00Z","2024-12-31T16:00:00-08:00"]`
+	typ := extensions.NewTimestampWithOffsetType(testTimeUnit)
+
+	arr, _, err := array.FromJSON(memory.DefaultAllocator, typ, strings.NewReader(raw))
+	require.NoError(t, err)
+	defer arr.Release()
+
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{Name: "timestamp_with_offset", Type: typ, Nullable: true}}, nil), []arrow.Array{arr}, -1)
+	defer batch.Release()
+
+	var written arrow.RecordBatch
+	{
+		var buf bytes.Buffer
+		wr := ipc.NewWriter(&buf, ipc.WithSchema(batch.Schema()))
+		require.NoError(t, wr.Write(batch))
+		require.NoError(t, wr.Close())
+
+		rdr, err := ipc.NewReader(&buf)
+		require.NoError(t, err)
+		written, err = rdr.Read()
+		require.NoError(t, err)
+		written.Retain()
+		defer written.Release()
+		rdr.Release()
+	}
+
+	assert.Truef(t, batch.Schema().Equal(written.Schema()), "expected: %s\n\ngot: %s",
+		batch.Schema(), written.Schema())
+
+	assert.Truef(t, array.RecordEqual(batch, written), "expected: %s\n\ngot: %s",
+		batch, written)
+}

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -145,7 +145,7 @@ func TestTimestampWithOffsetTypeDictionaryEncodedBasics(t *testing.T) {
 	assertDictBasics(t, &arrow.Int64Type{})
 }
 
-func assertReeBasics[E extensions.TimestampWithOffsetRunEndsType](t *testing.T, runEndsType E) {
+func assertReeBasics[E extensions.DictIndexType](t *testing.T, runEndsType E) {
 	typ := extensions.NewTimestampWithOffsetTypeRunEndEncoded(testTimeUnit, runEndsType)
 
 	assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
@@ -184,28 +184,28 @@ func TestTimestampWithOffsetEquals(t *testing.T) {
 	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewBool8Type()))
 
 	// Different time units are not equal
-	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Microsecond)))
-	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Second)))
-	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Second)))
-	//
-	// // Different underlying storage type is not equal
-	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{})))
-	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
-	// assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
-	//
-	// // Dict-encoding key type is not equal
-	// assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
-	//
-	// // REE index type is not equal
-	// assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
-	//
-	// // Equals OK
-	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Nanosecond)))
-	// assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Microsecond)))
-	// assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{})))
-	// assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
-	// assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
-	// assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Microsecond)))
+	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Second)))
+	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Second)))
+
+	// Different underlying storage type is not equal
+	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+
+	// Dict-encoding key type is not equal
+	assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+
+	// REE index type is not equal
+	assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+
+	// Equals OK
+	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Nanosecond)))
+	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Microsecond)))
+	assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+	assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
 }
 
 func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -34,9 +34,11 @@ import (
 
 var testTimeUnit = arrow.Microsecond
 
+var epoch = time.Unix(0, 0).In(time.FixedZone("UTC+00:00", 0))
+
 var testDate0 = time.Date(2025, 01, 01, 00, 00, 00, 00, time.FixedZone("UTC+00:00", 0))
 
-var testZone1 = time.FixedZone("UTC-08:30", -8*60*60 -30*60)
+var testZone1 = time.FixedZone("UTC-08:30", -8*60*60-30*60)
 var testDate1 = testDate0.In(testZone1)
 
 var testZone2 = time.FixedZone("UTC+11:00", +11*60*60)
@@ -219,17 +221,19 @@ func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 		builder.AppendNull()
 		builder.Append(testDate1)
 		builder.Append(testDate2)
+		builder.Append(epoch)
 
 		// it should build the array with the correct size
 		arr := builder.NewArray()
 		typedArr := arr.(*extensions.TimestampWithOffsetArray)
-		assert.Equal(t, 4, arr.Data().Len())
+		assert.Equal(t, 5, arr.Data().Len())
 		defer arr.Release()
 
 		// typedArr.Value(i) should return values adjusted for their original timezone
 		assert.Equal(t, testDate0, typedArr.Value(0))
 		assert.Equal(t, testDate1, typedArr.Value(2))
 		assert.Equal(t, testDate2, typedArr.Value(3))
+		assert.Equal(t, epoch, typedArr.Value(4))
 
 		// storage TimeUnit should be the same as we pass in to the builder, and storage timezone should be UTC
 		timestampStructField := typedArr.Storage().(*array.Struct).Field(0)
@@ -242,10 +246,11 @@ func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 		assert.Equal(t, testDate0.In(time.UTC), timestampsArr.Value(0).ToTime(testTimeUnit))
 		assert.Equal(t, testDate1.In(time.UTC), timestampsArr.Value(2).ToTime(testTimeUnit))
 		assert.Equal(t, testDate2.In(time.UTC), timestampsArr.Value(3).ToTime(testTimeUnit))
+		assert.Equal(t, epoch.In(time.UTC), timestampsArr.Value(4).ToTime(testTimeUnit))
 
 		// the array should encode itself as JSON and string
 		arrStr := arr.String()
-		assert.Equal(t, fmt.Sprintf(`["%[1]s" (null) "%[2]s" "%[3]s"]`, testDate0, testDate1, testDate2), arrStr)
+		assert.Equal(t, fmt.Sprintf(`["%[1]s" (null) "%[2]s" "%[3]s" "%[4]s"]`, testDate0, testDate1, testDate2, epoch), arrStr)
 		jsonStr, err := json.Marshal(arr)
 		assert.NoError(t, err)
 
@@ -276,6 +281,9 @@ func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 		// append a simple time.Time
 		fieldBuilder.Append(testDate0)
 
+		// append the epoch
+		fieldBuilder.Append(epoch)
+
 		// append a null and 2 time.Time all at once
 		values := []time.Time{
 			time.Unix(0, 0).In(time.UTC),
@@ -298,6 +306,7 @@ func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 		json, err := record.MarshalJSON()
 		require.NoError(t, err)
 		expect := `[{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
+,{"timestamp_with_offset":"1970-01-01T00:00:00Z"}
 ,{"timestamp_with_offset":null}
 ,{"timestamp_with_offset":"2024-12-31T15:30:00-08:30"}
 ,{"timestamp_with_offset":"2025-01-01T11:00:00+11:00"}
@@ -325,6 +334,7 @@ func TestTimestampWithOffsetTypeBatchIPCRoundTrip(t *testing.T) {
 		builder.AppendNull()
 		builder.Append(testDate1)
 		builder.Append(testDate2)
+		builder.Append(epoch)
 		arr := builder.NewArray()
 		defer arr.Release()
 

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -46,7 +46,7 @@ func dict(index arrow.DataType) arrow.DataType {
 	return &arrow.DictionaryType{
 		IndexType: index,
 		ValueType: arrow.PrimitiveTypes.Int16,
-		Ordered: false,
+		Ordered:   false,
 	}
 }
 
@@ -124,8 +124,8 @@ func assertDictBasics[I extensions.DictIndexType](t *testing.T, indexType I) {
 				Nullable: false,
 			},
 			arrow.Field{
-				Name: "offset_minutes",
-				Type: dict(arrow.DataType(indexType)),
+				Name:     "offset_minutes",
+				Type:     dict(arrow.DataType(indexType)),
 				Nullable: false,
 			},
 		),
@@ -145,7 +145,7 @@ func TestTimestampWithOffsetTypeDictionaryEncodedBasics(t *testing.T) {
 	assertDictBasics(t, &arrow.Int64Type{})
 }
 
-func assertReeBasics[E extensions.DictIndexType](t *testing.T, runEndsType E) {
+func assertReeBasics[E extensions.RunEndsType](t *testing.T, runEndsType E) {
 	typ := extensions.NewTimestampWithOffsetTypeRunEndEncoded(testTimeUnit, runEndsType)
 
 	assert.Equal(t, "arrow.timestamp_with_offset", typ.ExtensionName())
@@ -163,8 +163,8 @@ func assertReeBasics[E extensions.DictIndexType](t *testing.T, runEndsType E) {
 				Nullable: false,
 			},
 			arrow.Field{
-				Name: "offset_minutes",
-				Type: ree(arrow.DataType(runEndsType)),
+				Name:     "offset_minutes",
+				Type:     ree(arrow.DataType(runEndsType)),
 				Nullable: false,
 			},
 		),
@@ -197,15 +197,15 @@ func TestTimestampWithOffsetEquals(t *testing.T) {
 	assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
 
 	// REE index type is not equal
-	assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+	assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int32Type{})))
 
 	// Equals OK
-	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Nanosecond)))
-	assert.False(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Microsecond)))
-	assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{})))
-	assert.False(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
-	assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
-	assert.False(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+	assert.True(t, extensions.NewTimestampWithOffsetType(arrow.Nanosecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Nanosecond)))
+	assert.True(t, extensions.NewTimestampWithOffsetType(arrow.Microsecond).ExtensionEquals(extensions.NewTimestampWithOffsetType(arrow.Microsecond)))
+	assert.True(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	assert.True(t, extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeDictionaryEncoded(arrow.Microsecond, &arrow.Uint16Type{})))
+	assert.True(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int16Type{})))
+	assert.True(t, extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int32Type{}).ExtensionEquals(extensions.NewTimestampWithOffsetTypeRunEndEncoded(arrow.Microsecond, &arrow.Int32Type{})))
 }
 
 func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -60,24 +60,26 @@ func ree(runEnds arrow.DataType) arrow.DataType {
 
 // All tests use this in a for loop to make sure everything works for every possible
 // encoding of offsets (primitive, dictionary, run-end)
-var allAllowedOffsetTypes = []arrow.DataType{
+var allAllowedOffsetTypes = make(map[string]arrow.DataType)
+
+func init() {
 	// primitive offsetType
-	arrow.PrimitiveTypes.Int16,
+	allAllowedOffsetTypes["primitive-int16"] = arrow.PrimitiveTypes.Int16
 
 	// dict-encoded offsetType
-	dict(arrow.PrimitiveTypes.Uint8),
-	dict(arrow.PrimitiveTypes.Uint16),
-	dict(arrow.PrimitiveTypes.Uint32),
-	dict(arrow.PrimitiveTypes.Uint64),
-	dict(arrow.PrimitiveTypes.Int8),
-	dict(arrow.PrimitiveTypes.Int16),
-	dict(arrow.PrimitiveTypes.Int32),
-	dict(arrow.PrimitiveTypes.Int64),
+	allAllowedOffsetTypes["dict-Uint8"] = dict(arrow.PrimitiveTypes.Uint8)
+	allAllowedOffsetTypes["dict-Uint16"] = dict(arrow.PrimitiveTypes.Uint16)
+	allAllowedOffsetTypes["dict-Uint32"] = dict(arrow.PrimitiveTypes.Uint32)
+	allAllowedOffsetTypes["dict-Uint64"] = dict(arrow.PrimitiveTypes.Uint64)
+	allAllowedOffsetTypes["dict-Int8"] = dict(arrow.PrimitiveTypes.Int8)
+	allAllowedOffsetTypes["dict-Int16"] = dict(arrow.PrimitiveTypes.Int16)
+	allAllowedOffsetTypes["dict-Int32"] = dict(arrow.PrimitiveTypes.Int32)
+	allAllowedOffsetTypes["dict-Int64"] = dict(arrow.PrimitiveTypes.Int64)
 
 	// run-end encoded offsetType
-	ree(arrow.PrimitiveTypes.Int16),
-	ree(arrow.PrimitiveTypes.Int32),
-	ree(arrow.PrimitiveTypes.Int64),
+	allAllowedOffsetTypes["ree-Int16"] = ree(arrow.PrimitiveTypes.Int16)
+	allAllowedOffsetTypes["ree-Int32"] = ree(arrow.PrimitiveTypes.Int32)
+	allAllowedOffsetTypes["ree-Int64"] = ree(arrow.PrimitiveTypes.Int64)
 }
 
 func TestTimestampWithOffsetTypePrimitiveBasics(t *testing.T) {
@@ -214,98 +216,101 @@ func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	for _, offsetType := range allAllowedOffsetTypes {
-		builder, _ := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
+	for name, offsetType := range allAllowedOffsetTypes {
+		t.Run(name, func(t *testing.T) {
+			builder, _ := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
 
-		builder.Append(testDate0)
-		builder.AppendNull()
-		builder.Append(testDate1)
-		builder.Append(testDate2)
-		builder.Append(epoch)
+			builder.Append(testDate0)
+			builder.AppendNull()
+			builder.Append(testDate1)
+			builder.Append(testDate2)
+			builder.Append(epoch)
 
-		// it should build the array with the correct size
-		arr := builder.NewArray()
-		typedArr := arr.(*extensions.TimestampWithOffsetArray)
-		assert.Equal(t, 5, arr.Data().Len())
-		defer arr.Release()
+			// it should build the array with the correct size
+			arr := builder.NewArray()
+			typedArr := arr.(*extensions.TimestampWithOffsetArray)
+			assert.Equal(t, 5, arr.Data().Len())
+			defer arr.Release()
 
-		// typedArr.Value(i) should return values adjusted for their original timezone
-		assert.Equal(t, testDate0, typedArr.Value(0))
-		assert.Equal(t, testDate1, typedArr.Value(2))
-		assert.Equal(t, testDate2, typedArr.Value(3))
-		assert.Equal(t, epoch, typedArr.Value(4))
+			// typedArr.Value(i) should return values adjusted for their original timezone
+			assert.Equal(t, testDate0, typedArr.Value(0))
+			assert.Equal(t, testDate1, typedArr.Value(2))
+			assert.Equal(t, testDate2, typedArr.Value(3))
+			assert.Equal(t, epoch, typedArr.Value(4))
 
-		// storage TimeUnit should be the same as we pass in to the builder, and storage timezone should be UTC
-		timestampStructField := typedArr.Storage().(*array.Struct).Field(0)
-		timestampStructDataType := timestampStructField.DataType().(*arrow.TimestampType)
-		assert.Equal(t, timestampStructDataType.Unit, testTimeUnit)
-		assert.Equal(t, timestampStructDataType.TimeZone, "UTC")
+			// storage TimeUnit should be the same as we pass in to the builder, and storage timezone should be UTC
+			timestampStructField := typedArr.Storage().(*array.Struct).Field(0)
+			timestampStructDataType := timestampStructField.DataType().(*arrow.TimestampType)
+			assert.Equal(t, timestampStructDataType.Unit, testTimeUnit)
+			assert.Equal(t, timestampStructDataType.TimeZone, "UTC")
 
-		// stored values should be equivalent to the raw values in UTC
-		timestampsArr := timestampStructField.(*array.Timestamp)
-		assert.Equal(t, testDate0.In(time.UTC), timestampsArr.Value(0).ToTime(testTimeUnit))
-		assert.Equal(t, testDate1.In(time.UTC), timestampsArr.Value(2).ToTime(testTimeUnit))
-		assert.Equal(t, testDate2.In(time.UTC), timestampsArr.Value(3).ToTime(testTimeUnit))
-		assert.Equal(t, epoch.In(time.UTC), timestampsArr.Value(4).ToTime(testTimeUnit))
+			// stored values should be equivalent to the raw values in UTC
+			timestampsArr := timestampStructField.(*array.Timestamp)
+			assert.Equal(t, testDate0.In(time.UTC), timestampsArr.Value(0).ToTime(testTimeUnit))
+			assert.Equal(t, testDate1.In(time.UTC), timestampsArr.Value(2).ToTime(testTimeUnit))
+			assert.Equal(t, testDate2.In(time.UTC), timestampsArr.Value(3).ToTime(testTimeUnit))
+			assert.Equal(t, epoch.In(time.UTC), timestampsArr.Value(4).ToTime(testTimeUnit))
 
-		// the array should encode itself as JSON and string
-		arrStr := arr.String()
-		assert.Equal(t, fmt.Sprintf(`["%[1]s" (null) "%[2]s" "%[3]s" "%[4]s"]`, testDate0, testDate1, testDate2, epoch), arrStr)
-		jsonStr, err := json.Marshal(arr)
-		assert.NoError(t, err)
+			// the array should encode itself as JSON and string
+			arrStr := arr.String()
+			assert.Equal(t, fmt.Sprintf(`["%[1]s" (null) "%[2]s" "%[3]s" "%[4]s"]`, testDate0, testDate1, testDate2, epoch), arrStr)
+			jsonStr, err := json.Marshal(arr)
+			assert.NoError(t, err)
 
-		// roundtripping from JSON with array.FromJSON should work
-		expectedDataType, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
-		roundtripped, _, err := array.FromJSON(mem, expectedDataType, bytes.NewReader(jsonStr))
-		defer roundtripped.Release()
-		assert.NoError(t, err)
-		assert.Truef(t, array.Equal(arr, roundtripped), "expected %s\n\ngot %s", arr, roundtripped)
+			// roundtripping from JSON with array.FromJSON should work
+			expectedDataType, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
+			roundtripped, _, err := array.FromJSON(mem, expectedDataType, bytes.NewReader(jsonStr))
+			defer roundtripped.Release()
+			assert.NoError(t, err)
+			assert.Truef(t, array.Equal(arr, roundtripped), "expected %s\n\ngot %s", arr, roundtripped)
+		})
 	}
 }
 
 func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
-	for _, offsetType := range allAllowedOffsetTypes {
-		dataType, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
-		schema := arrow.NewSchema([]arrow.Field{
-			{
-				Name:     "timestamp_with_offset",
-				Nullable: true,
-				Type:     dataType,
-			},
-		}, nil)
-		builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
-		defer builder.Release()
+	for name, offsetType := range allAllowedOffsetTypes {
+		t.Run(name, func(t *testing.T) {
+			dataType, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
+			schema := arrow.NewSchema([]arrow.Field{
+				{
+					Name:     "timestamp_with_offset",
+					Nullable: true,
+					Type:     dataType,
+				},
+			}, nil)
+			builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+			defer builder.Release()
 
-		fieldBuilder := builder.Field(0).(*extensions.TimestampWithOffsetBuilder)
+			fieldBuilder := builder.Field(0).(*extensions.TimestampWithOffsetBuilder)
 
-		// append a simple time.Time
-		fieldBuilder.Append(testDate0)
+			// append a simple time.Time
+			fieldBuilder.Append(testDate0)
 
-		// append the epoch
-		fieldBuilder.Append(epoch)
+			// append the epoch
+			fieldBuilder.Append(epoch)
 
-		// append a null and 2 time.Time all at once
-		values := []time.Time{
-			time.Unix(0, 0).In(time.UTC),
-			testDate1,
-			testDate2,
-		}
-		valids := []bool{false, true, true}
-		fieldBuilder.AppendValues(values, valids)
+			// append a null and 2 time.Time all at once
+			values := []time.Time{
+				time.Unix(0, 0).In(time.UTC),
+				testDate1,
+				testDate2,
+			}
+			valids := []bool{false, true, true}
+			fieldBuilder.AppendValues(values, valids)
 
-		// append a value from RFC3339 string
-		fieldBuilder.AppendValueFromString(testDate0.Format(time.RFC3339))
+			// append a value from RFC3339 string
+			fieldBuilder.AppendValueFromString(testDate0.Format(time.RFC3339))
 
-		// append value formatted in a different string layout
-		fieldBuilder.Layout = time.RFC3339Nano
-		fieldBuilder.AppendValueFromString(testDate1.Format(time.RFC3339Nano))
+			// append value formatted in a different string layout
+			fieldBuilder.Layout = time.RFC3339Nano
+			fieldBuilder.AppendValueFromString(testDate1.Format(time.RFC3339Nano))
 
-		record := builder.NewRecordBatch()
+			record := builder.NewRecordBatch()
 
-		// Record batch should JSON-encode values containing per-row timezone info
-		json, err := record.MarshalJSON()
-		require.NoError(t, err)
-		expect := `[{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
+			// Record batch should JSON-encode values containing per-row timezone info
+			json, err := record.MarshalJSON()
+			require.NoError(t, err)
+			expect := `[{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
 ,{"timestamp_with_offset":"1970-01-01T00:00:00Z"}
 ,{"timestamp_with_offset":null}
 ,{"timestamp_with_offset":"2024-12-31T15:30:00-08:30"}
@@ -313,14 +318,15 @@ func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 ,{"timestamp_with_offset":"2025-01-01T00:00:00Z"}
 ,{"timestamp_with_offset":"2024-12-31T15:30:00-08:30"}
 ]`
-		require.Equal(t, expect, string(json))
+			require.Equal(t, expect, string(json))
 
-		// Record batch roundtrip to JSON should work
-		roundtripped, _, err := array.RecordFromJSON(memory.DefaultAllocator, schema, bytes.NewReader(json))
-		require.NoError(t, err)
-		defer roundtripped.Release()
-		require.Equal(t, schema, roundtripped.Schema())
-		assert.Truef(t, array.RecordEqual(record, roundtripped), "expected %s\n\ngot %s", record, roundtripped)
+			// Record batch roundtrip to JSON should work
+			roundtripped, _, err := array.RecordFromJSON(memory.DefaultAllocator, schema, bytes.NewReader(json))
+			require.NoError(t, err)
+			defer roundtripped.Release()
+			require.Equal(t, schema, roundtripped.Schema())
+			assert.Truef(t, array.RecordEqual(record, roundtripped), "expected %s\n\ngot %s", record, roundtripped)
+		})
 	}
 }
 
@@ -328,41 +334,43 @@ func TestTimestampWithOffsetTypeBatchIPCRoundTrip(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	for _, offsetType := range allAllowedOffsetTypes {
-		builder, _ := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
-		builder.Append(testDate0)
-		builder.AppendNull()
-		builder.Append(testDate1)
-		builder.Append(testDate2)
-		builder.Append(epoch)
-		arr := builder.NewArray()
-		defer arr.Release()
+	for name, offsetType := range allAllowedOffsetTypes {
+		t.Run(name, func(t *testing.T) {
+			builder, _ := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
+			builder.Append(testDate0)
+			builder.AppendNull()
+			builder.Append(testDate1)
+			builder.Append(testDate2)
+			builder.Append(epoch)
+			arr := builder.NewArray()
+			defer arr.Release()
 
-		typ, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
+			typ, _ := extensions.NewTimestampWithOffsetTypeCustomOffset(testTimeUnit, offsetType)
 
-		batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{Name: "timestamp_with_offset", Type: typ, Nullable: true}}, nil), []arrow.Array{arr}, -1)
-		defer batch.Release()
+			batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{{Name: "timestamp_with_offset", Type: typ, Nullable: true}}, nil), []arrow.Array{arr}, -1)
+			defer batch.Release()
 
-		var written arrow.RecordBatch
-		{
-			var buf bytes.Buffer
-			wr := ipc.NewWriter(&buf, ipc.WithSchema(batch.Schema()))
-			require.NoError(t, wr.Write(batch))
-			require.NoError(t, wr.Close())
+			var written arrow.RecordBatch
+			{
+				var buf bytes.Buffer
+				wr := ipc.NewWriter(&buf, ipc.WithSchema(batch.Schema()))
+				require.NoError(t, wr.Write(batch))
+				require.NoError(t, wr.Close())
 
-			rdr, err := ipc.NewReader(&buf)
-			require.NoError(t, err)
-			written, err = rdr.Read()
-			require.NoError(t, err)
-			written.Retain()
-			defer written.Release()
-			rdr.Release()
-		}
+				rdr, err := ipc.NewReader(&buf)
+				require.NoError(t, err)
+				written, err = rdr.Read()
+				require.NoError(t, err)
+				written.Retain()
+				defer written.Release()
+				rdr.Release()
+			}
 
-		assert.Truef(t, batch.Schema().Equal(written.Schema()), "expected: %s\n\ngot: %s",
-			batch.Schema(), written.Schema())
+			assert.Truef(t, batch.Schema().Equal(written.Schema()), "expected: %s\n\ngot: %s",
+				batch.Schema(), written.Schema())
 
-		assert.Truef(t, array.RecordEqual(batch, written), "expected: %s\n\ngot: %s",
-			batch, written)
+			assert.Truef(t, array.RecordEqual(batch, written), "expected: %s\n\ngot: %s",
+				batch, written)
+		})
 	}
 }

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -267,6 +267,57 @@ func TestTimestampWithOffsetExtensionBuilder(t *testing.T) {
 	}
 }
 
+func TestTimestampWithOffsetBuilderAppendValuesLeadingNull(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	for name, offsetType := range allAllowedOffsetTypes {
+		t.Run(name, func(t *testing.T) {
+			builder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
+			require.NoError(t, err)
+
+			// A leading null as the very first operation on a fresh builder must not
+			// corrupt the offsets. Reading every value below would panic on a
+			// run-end encoded array whose run-ends and values children fell out of
+			// sync (which happened when a run was continued before one existed).
+			builder.AppendValues([]time.Time{epoch, testDate1, testDate2}, []bool{false, true, true})
+
+			arr := builder.NewArray()
+			defer arr.Release()
+			typedArr := arr.(*extensions.TimestampWithOffsetArray)
+
+			require.Equal(t, 3, arr.Data().Len())
+			assert.True(t, typedArr.IsNull(0))
+			assert.Equal(t, testDate1, typedArr.Value(1))
+			assert.Equal(t, testDate2, typedArr.Value(2))
+		})
+	}
+}
+
+func TestTimestampWithOffsetBuilderRunEndEncodedNullContinuesRun(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	builder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, ree(arrow.PrimitiveTypes.Int16))
+	require.NoError(t, err)
+
+	// The same offset surrounds a null. The null must continue the current run
+	// rather than reset the tracked offset, otherwise one logical run is split
+	// into two adjacent runs that share the same value.
+	builder.AppendValues([]time.Time{testDate1, epoch, testDate1}, []bool{true, false, true})
+
+	arr := builder.NewArray()
+	defer arr.Release()
+	typedArr := arr.(*extensions.TimestampWithOffsetArray)
+
+	offsets := typedArr.Storage().(*array.Struct).Field(1).(*array.RunEndEncoded)
+	assert.Equal(t, 1, offsets.Values().Len())
+
+	assert.Equal(t, testDate1, typedArr.Value(0))
+	assert.True(t, typedArr.IsNull(1))
+	assert.Equal(t, testDate1, typedArr.Value(2))
+}
+
 func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 	for name, offsetType := range allAllowedOffsetTypes {
 		t.Run(name, func(t *testing.T) {

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -449,6 +449,23 @@ func TestTimestampWithOffsetRunEndEncodedSliced(t *testing.T) {
 	}
 }
 
+func TestTimestampWithOffsetSubHourNegativeZone(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	// A negative offset smaller than one hour must keep its sign in the zone
+	// name (regression: -30 minutes formatted as "UTC+00:30" instead of "UTC-00:30").
+	b, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, arrow.PrimitiveTypes.Int16)
+	require.NoError(t, err)
+	b.Append(testDate0.In(time.FixedZone("UTC-00:30", -30*60)))
+	arr := b.NewArray().(*extensions.TimestampWithOffsetArray)
+	defer arr.Release()
+
+	name, off := arr.Value(0).Zone()
+	require.Equal(t, -30*60, off)
+	require.Equal(t, "UTC-00:30", name)
+}
+
 func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 	for name, offsetType := range allAllowedOffsetTypes {
 		t.Run(name, func(t *testing.T) {

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -386,6 +386,30 @@ func TestTimestampWithOffsetBuilderReuseAfterNewArray(t *testing.T) {
 	}
 }
 
+func TestTimestampWithOffsetBuilderAppendNullBetweenEqualOffsets(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	builder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, ree(arrow.PrimitiveTypes.Int16))
+	require.NoError(t, err)
+
+	// AppendNull appends a null offset run; the following value repeats the
+	// pre-null offset and must start its own run instead of being folded into
+	// the null run (which would decode the trailing value's offset as null).
+	builder.Append(testDate1)
+	builder.AppendNull()
+	builder.Append(testDate1)
+
+	arr := builder.NewArray()
+	defer arr.Release()
+	typedArr := arr.(*extensions.TimestampWithOffsetArray)
+
+	require.Equal(t, 3, arr.Data().Len())
+	assert.Equal(t, testDate1, typedArr.Value(0))
+	assert.True(t, typedArr.IsNull(1))
+	assert.Equal(t, testDate1, typedArr.Value(2))
+}
+
 func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 	for name, offsetType := range allAllowedOffsetTypes {
 		t.Run(name, func(t *testing.T) {

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -410,6 +410,45 @@ func TestTimestampWithOffsetBuilderAppendNullBetweenEqualOffsets(t *testing.T) {
 	assert.Equal(t, testDate1, typedArr.Value(2))
 }
 
+func TestTimestampWithOffsetRunEndEncodedSliced(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	for _, runEnds := range []arrow.DataType{
+		arrow.PrimitiveTypes.Int16, arrow.PrimitiveTypes.Int32, arrow.PrimitiveTypes.Int64,
+	} {
+		t.Run(runEnds.String(), func(t *testing.T) {
+			builder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, ree(runEnds))
+			require.NoError(t, err)
+
+			// Offsets [0,0,-510,-510,-510,660,0] give run-ends [2,5,6,7], so a
+			// slice starting at index 3 begins inside a later run: the case where
+			// an offset-unaware physical index decodes the wrong run.
+			values := []time.Time{testDate0, testDate0, testDate1, testDate1, testDate1, testDate2, epoch}
+			builder.AppendValues(values, nil)
+			arr := builder.NewArray().(*extensions.TimestampWithOffsetArray)
+			defer arr.Release()
+
+			want := arr.Values()
+
+			for start := 0; start < arr.Len(); start++ {
+				for end := start; end <= arr.Len(); end++ {
+					sliced := array.NewSlice(arr, int64(start), int64(end)).(*extensions.TimestampWithOffsetArray)
+					got := sliced.Values()
+					require.Equalf(t, end-start, len(got), "slice [%d:%d]", start, end)
+					for k := 0; k < end-start; k++ {
+						require.Truef(t, want[start+k].Equal(got[k]), "slice [%d:%d] row %d instant: want %s got %s", start, end, k, want[start+k], got[k])
+						_, wantOff := want[start+k].Zone()
+						_, gotOff := got[k].Zone()
+						require.Equalf(t, wantOff, gotOff, "slice [%d:%d] row %d offset", start, end, k)
+					}
+					sliced.Release()
+				}
+			}
+		})
+	}
+}
+
 func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 	for name, offsetType := range allAllowedOffsetTypes {
 		t.Run(name, func(t *testing.T) {

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -124,6 +124,45 @@ func TestTimestampWithOffsetTypeDeserializeMetadata(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestTimestampWithOffsetTypeDeserializeInvalidStorage(t *testing.T) {
+	base := extensions.NewTimestampWithOffsetType(testTimeUnit)
+
+	utcTS := &arrow.TimestampType{Unit: testTimeUnit, TimeZone: "UTC"}
+	tsField := arrow.Field{Name: "timestamp", Type: utcTS}
+	offField := arrow.Field{Name: "offset_minutes", Type: arrow.PrimitiveTypes.Int16}
+
+	badDict := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.PrimitiveTypes.Int32}
+	badREE := arrow.RunEndEncodedOf(arrow.PrimitiveTypes.Int32, arrow.PrimitiveTypes.Int32)
+
+	valid, err := base.Deserialize(base.StorageType(), "")
+	require.NoError(t, err)
+	require.NotNil(t, valid)
+
+	invalid := map[string]arrow.DataType{
+		"not a struct":                 arrow.PrimitiveTypes.Int16,
+		"too few fields":               arrow.StructOf(tsField),
+		"too many fields":              arrow.StructOf(tsField, offField, offField),
+		"timestamp wrong name":         arrow.StructOf(arrow.Field{Name: "ts", Type: utcTS}, offField),
+		"timestamp not a timestamp":    arrow.StructOf(arrow.Field{Name: "timestamp", Type: arrow.PrimitiveTypes.Int64}, offField),
+		"timestamp non-UTC zone":       arrow.StructOf(arrow.Field{Name: "timestamp", Type: &arrow.TimestampType{Unit: testTimeUnit, TimeZone: "America/New_York"}}, offField),
+		"timestamp empty zone":         arrow.StructOf(arrow.Field{Name: "timestamp", Type: &arrow.TimestampType{Unit: testTimeUnit}}, offField),
+		"timestamp nullable":           arrow.StructOf(arrow.Field{Name: "timestamp", Type: utcTS, Nullable: true}, offField),
+		"offset wrong name":            arrow.StructOf(tsField, arrow.Field{Name: "offset", Type: arrow.PrimitiveTypes.Int16}),
+		"offset wrong primitive type":  arrow.StructOf(tsField, arrow.Field{Name: "offset_minutes", Type: arrow.PrimitiveTypes.Int32}),
+		"offset nullable":              arrow.StructOf(tsField, arrow.Field{Name: "offset_minutes", Type: arrow.PrimitiveTypes.Int16, Nullable: true}),
+		"offset dict value not int16":  arrow.StructOf(tsField, arrow.Field{Name: "offset_minutes", Type: badDict}),
+		"offset ree encoded not int16": arrow.StructOf(tsField, arrow.Field{Name: "offset_minutes", Type: badREE}),
+		"fields swapped":               arrow.StructOf(offField, tsField),
+	}
+
+	for name, storage := range invalid {
+		t.Run(name, func(t *testing.T) {
+			_, err := base.Deserialize(storage, "")
+			assert.Error(t, err)
+		})
+	}
+}
+
 func assertDictBasics[I extensions.DictIndexType](t *testing.T, indexType I) {
 	typ := extensions.NewTimestampWithOffsetTypeDictionaryEncoded(testTimeUnit, indexType)
 

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -468,7 +468,23 @@ func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 			require.NoError(t, err)
 			defer roundtripped.Release()
 			require.Equal(t, schema, roundtripped.Schema())
-			assert.Truef(t, array.RecordEqual(record, roundtripped), "expected %s\n\ngot %s", record, roundtripped)
+			// Avoid array.RecordEqual here: it compares the inner non-nullable
+			// struct child validity bitmaps, which differ between builder output and
+			// JSON reader output. That inner-nullability parity is decoupled from this
+			// type, so assert only what it guarantees: per-row instant, offset, validity.
+			origArr := record.Column(0).(*extensions.TimestampWithOffsetArray)
+			gotArr := roundtripped.Column(0).(*extensions.TimestampWithOffsetArray)
+			require.Equal(t, origArr.Len(), gotArr.Len())
+			for i := 0; i < origArr.Len(); i++ {
+				require.Equalf(t, origArr.IsNull(i), gotArr.IsNull(i), "validity mismatch at row %d", i)
+				if origArr.IsValid(i) {
+					want, got := origArr.Value(i), gotArr.Value(i)
+					require.Truef(t, want.Equal(got), "instant mismatch at row %d: %s vs %s", i, want, got)
+					_, wantOff := want.Zone()
+					_, gotOff := got.Zone()
+					require.Equalf(t, wantOff, gotOff, "offset mismatch at row %d", i)
+				}
+			}
 		})
 	}
 }

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -318,6 +318,60 @@ func TestTimestampWithOffsetBuilderRunEndEncodedNullContinuesRun(t *testing.T) {
 	assert.Equal(t, testDate1, typedArr.Value(2))
 }
 
+func TestTimestampWithOffsetBuilderAppendValuesNilValids(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	for name, offsetType := range allAllowedOffsetTypes {
+		t.Run(name, func(t *testing.T) {
+			builder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
+			require.NoError(t, err)
+
+			// nil validity must be treated as all-valid so the parent struct and
+			// its child builders stay the same length.
+			builder.AppendValues([]time.Time{testDate0, testDate1, testDate2}, nil)
+
+			arr := builder.NewArray()
+			defer arr.Release()
+			typedArr := arr.(*extensions.TimestampWithOffsetArray)
+
+			require.Equal(t, 3, arr.Data().Len())
+			assert.Equal(t, testDate0, typedArr.Value(0))
+			assert.Equal(t, testDate1, typedArr.Value(1))
+			assert.Equal(t, testDate2, typedArr.Value(2))
+		})
+	}
+}
+
+func TestTimestampWithOffsetBuilderReuseAfterNewArray(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	for name, offsetType := range allAllowedOffsetTypes {
+		t.Run(name, func(t *testing.T) {
+			builder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
+			require.NoError(t, err)
+
+			builder.Append(testDate1)
+			arr1 := builder.NewArray()
+			defer arr1.Release()
+
+			// Reusing the builder must start a fresh run even when the first value
+			// repeats the previous array's offset; otherwise a run-end-encoded
+			// offset is continued on a freshly reset (empty) builder.
+			builder.Append(testDate1)
+			builder.Append(testDate2)
+			arr2 := builder.NewArray()
+			defer arr2.Release()
+
+			typedArr := arr2.(*extensions.TimestampWithOffsetArray)
+			require.Equal(t, 2, arr2.Data().Len())
+			assert.Equal(t, testDate1, typedArr.Value(0))
+			assert.Equal(t, testDate2, typedArr.Value(1))
+		})
+	}
+}
+
 func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 	for name, offsetType := range allAllowedOffsetTypes {
 		t.Run(name, func(t *testing.T) {

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -110,6 +110,20 @@ func TestTimestampWithOffsetTypePrimitiveBasics(t *testing.T) {
 	assert.Equal(t, "extension<arrow.timestamp_with_offset>", typ.String())
 }
 
+func TestTimestampWithOffsetTypeDeserializeMetadata(t *testing.T) {
+	typ := extensions.NewTimestampWithOffsetType(testTimeUnit)
+	storage := typ.StorageType()
+
+	for _, data := range []string{"", "{}"} {
+		got, err := typ.Deserialize(storage, data)
+		assert.NoError(t, err)
+		assert.True(t, typ.ExtensionEquals(got))
+	}
+
+	_, err := typ.Deserialize(storage, "not-empty")
+	assert.Error(t, err)
+}
+
 func assertDictBasics[I extensions.DictIndexType](t *testing.T, indexType I) {
 	typ := extensions.NewTimestampWithOffsetTypeDictionaryEncoded(testTimeUnit, indexType)
 

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -577,10 +577,12 @@ func TestTimestampWithOffsetExtensionRecordBuilder(t *testing.T) {
 			require.NoError(t, err)
 			defer roundtripped.Release()
 			require.Equal(t, schema, roundtripped.Schema())
-			// Avoid array.RecordEqual here: it compares the inner non-nullable
-			// struct child validity bitmaps, which differ between builder output and
-			// JSON reader output. That inner-nullability parity is decoupled from this
-			// type, so assert only what it guarantees: per-row instant, offset, validity.
+			// FIXME: ideally array.RecordEqual would succeed after roundtripping.
+			// It currently doesn't because it compares the inner non-nullable struct
+			// child validity bitmaps, which differ between builder output and JSON
+			// reader output. That inner-nullability parity is decoupled from this
+			// type (tracked in apache/arrow-go#918), so for now avoid RecordEqual and
+			// assert only what this type guarantees: per-row instant, offset, validity.
 			origArr := record.Column(0).(*extensions.TimestampWithOffsetArray)
 			gotArr := roundtripped.Column(0).(*extensions.TimestampWithOffsetArray)
 			require.Equal(t, origArr.Len(), gotArr.Len())

--- a/arrow/extensions/timestamp_with_offset_test.go
+++ b/arrow/extensions/timestamp_with_offset_test.go
@@ -322,25 +322,39 @@ func TestTimestampWithOffsetBuilderAppendValuesNilValids(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
+	// nil and empty validity slices must both be treated as all-valid so the
+	// parent struct and its child builders stay the same length.
+	validsVariants := map[string][]bool{"nil": nil, "empty": {}}
+
 	for name, offsetType := range allAllowedOffsetTypes {
-		t.Run(name, func(t *testing.T) {
-			builder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
-			require.NoError(t, err)
+		for validsName, valids := range validsVariants {
+			t.Run(name+"/"+validsName, func(t *testing.T) {
+				builder, err := extensions.NewTimestampWithOffsetBuilder(mem, testTimeUnit, offsetType)
+				require.NoError(t, err)
 
-			// nil validity must be treated as all-valid so the parent struct and
-			// its child builders stay the same length.
-			builder.AppendValues([]time.Time{testDate0, testDate1, testDate2}, nil)
+				builder.AppendValues([]time.Time{testDate0, testDate1, testDate2}, valids)
 
-			arr := builder.NewArray()
-			defer arr.Release()
-			typedArr := arr.(*extensions.TimestampWithOffsetArray)
+				arr := builder.NewArray()
+				defer arr.Release()
+				typedArr := arr.(*extensions.TimestampWithOffsetArray)
 
-			require.Equal(t, 3, arr.Data().Len())
-			assert.Equal(t, testDate0, typedArr.Value(0))
-			assert.Equal(t, testDate1, typedArr.Value(1))
-			assert.Equal(t, testDate2, typedArr.Value(2))
-		})
+				require.Equal(t, 3, arr.Data().Len())
+				assert.Equal(t, testDate0, typedArr.Value(0))
+				assert.Equal(t, testDate1, typedArr.Value(1))
+				assert.Equal(t, testDate2, typedArr.Value(2))
+			})
+		}
 	}
+}
+
+func TestTimestampWithOffsetBuilderAppendValuesMismatchedValidsPanics(t *testing.T) {
+	builder, err := extensions.NewTimestampWithOffsetBuilder(memory.DefaultAllocator, testTimeUnit, arrow.PrimitiveTypes.Int16)
+	require.NoError(t, err)
+	defer builder.Release()
+
+	assert.Panics(t, func() {
+		builder.AppendValues([]time.Time{testDate0, testDate1}, []bool{true})
+	})
 }
 
 func TestTimestampWithOffsetBuilderReuseAfterNewArray(t *testing.T) {


### PR DESCRIPTION
# Which issue does this PR close?

Implements the new `arrow.timestamp_with_offset` canonical extension type for arrow-go.

# Rationale for this change

Be compatible with the Arrow columnar spec's `arrow.timestamp_with_offset` canonical extension type.

# What changes are included in this PR?

Adds a `TimestampWithOffset` extension type. This type represents a timestamp column that stores a potentially different timezone offset per value: the timestamp is stored in UTC alongside the original timezone offset in minutes. The offset-in-minutes field can be primitive-, dictionary-, or run-end-encoded.

**This PR has been decoupled from the inner-nullability parity work it was previously based on.** Those comparison / JSON-marshaling changes now live in #918 and can be reviewed and merged independently. This PR is now scoped to just the extension type and touches only:

- `arrow/extensions/timestamp_with_offset.go` (new)
- `arrow/extensions/timestamp_with_offset_test.go` (new)
- `arrow/extensions/extensions.go` (register the canonical type)

To keep this PR self-contained, the JSON round-trip test asserts the values the type guarantees (per-row instant, timezone offset, and validity) rather than `array.RecordEqual`, which would compare inner non-nullable struct child validity bitmaps — the parity concern tracked separately in #918.

# Are these changes tested?

Yes — primitive/dictionary/run-end offset encodings, JSON marshal + round-trip, and IPC round-trip.

# Are there any user-facing changes?

Yes, this is a new canonical extension type.
