### PR TITLE
doc(parquet): document arrow parquet mappings

### DIFF
--- a/parquet/doc.go
+++ b/parquet/doc.go
@@ -79,7 +79,12 @@
 // # Arrow to Parquet Type Mappings
 //
 // When reading and writing Parquet, the parquet package converts between Arrow
-// and Parquet types in the following manner:
+// and Parquet types in the manner described in the table below.
+//
+// When converting a Parquet type where a large and non-large offset Arrow type
+// would work, the non-large variant is chosen. If the Parquet file is written
+// with `WithStoreSchema`, types will be preserved and dictionaries will be
+// restored when round-tripping.
 //
 //	Arrow Type              Parquet Physical Type     Parquet Logical Type
 //	----------              ---------------------     --------------------


### PR DESCRIPTION
### Rationale for this change

Documents the Arrow to Parquet type conversions and documents which types have no conversion. Closes #403

### What changes are included in this PR?

I'm sneaking this into the doc.go file for the parquet package so this PR just adds text tehre.

### Are these changes tested?

Visually and partially with some unit tests (not included).

### Are there any user-facing changes?

No

