### PR TITLE
optimization: compare: avoid initializing config when it's not needed

### DIFF
--- a/arrow/compare.go
+++ b/arrow/compare.go
@@ -40,11 +40,6 @@ func CheckMetadata() TypeEqualOption {
 // TypeEqual checks if two DataType are the same, optionally checking metadata
 // equality for STRUCT types.
 func TypeEqual(left, right DataType, opts ...TypeEqualOption) bool {
-	var cfg typeEqualsConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-
 	switch {
 	case left == right:
 		return true
@@ -52,6 +47,11 @@ func TypeEqual(left, right DataType, opts ...TypeEqualOption) bool {
 		return false
 	case left.ID() != right.ID():
 		return false
+	}
+
+	var cfg typeEqualsConfig
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	switch l := left.(type) {


### PR DESCRIPTION
This makes Schema.Equal ~20% faster in my use case (where the hot path is almost always taken, left == right).

cfg escapes to the heap; this change avoids making cfg exist until after the hot path, making it even faster.

### Rationale for this change


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?

