### PR TITLE
optimization: schema: use slices.Sort instead of sort.Slice

### DIFF
--- a/arrow/schema.go
+++ b/arrow/schema.go
@@ -19,7 +19,6 @@ package arrow
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow/endian"
@@ -57,7 +56,7 @@ func MetadataFrom(kv map[string]string) Metadata {
 	for k := range kv {
 		md.keys = append(md.keys, k)
 	}
-	sort.Strings(md.keys)
+	slices.Sort(md.keys)
 	for _, k := range md.keys {
 		md.values = append(md.values, kv[k])
 	}


### PR DESCRIPTION
Shaves off nearly half of the time of Metadata.Equal for me; sort.Slice takes in `any` as the type of the slice, which requires converting the slice to an interface - which itself requires allocating and converting the pointer to the slice header to use as the interface value.

### Rationale for this change


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?

