### PR TITLE
String optimize

### DIFF
--- a/arrow/ipc/metadata.go
+++ b/arrow/ipc/metadata.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/endian"
@@ -183,7 +184,8 @@ func fieldFromFB(field *flatbuf.Field, pos dictutils.FieldPos, memo *dictutils.M
 		o   arrow.Field
 	)
 
-	o.Name = string(field.Name())
+	name := field.Name()
+	o.Name = unsafe.String(&name[0], len(name))
 	o.Nullable = field.Nullable()
 	o.Metadata, err = metadataFromFB(field)
 	if err != nil {

--- a/arrow/ipc/metadata.go
+++ b/arrow/ipc/metadata.go
@@ -35,6 +35,7 @@ import (
 // Magic string identifying an Apache Arrow file.
 var Magic = []byte("ARROW1")
 
+
 const (
 	currentMetadataVersion = MetadataV5
 	minMetadataVersion     = MetadataV4
@@ -462,7 +463,7 @@ func (fv *fieldVisitor) visit(field arrow.Field) {
 		field.Type = dt.StorageType()
 		fv.visit(field)
 		fv.meta[ExtensionTypeKeyName] = dt.ExtensionName()
-		fv.meta[ExtensionMetadataKeyName] = string(dt.Serialize())
+		fv.meta[ExtensionMetadataKeyName] = dt.Serialize()
 
 	case *arrow.DictionaryType:
 		field.Type = dt.ValueType
@@ -988,8 +989,9 @@ func timeFromFB(data flatbuf.Time) (arrow.DataType, error) {
 
 func timestampFromFB(data flatbuf.Timestamp) (arrow.DataType, error) {
 	unit := unitFromFB(data.Unit())
-	tz := string(data.Timezone())
-	return &arrow.TimestampType{Unit: unit, TimeZone: tz}, nil
+	tz := data.Timezone()
+	tzs := unsafe.String(&tz[0], len(tz))
+	return &arrow.TimestampType{Unit: unit, TimeZone: tzs}, nil
 }
 
 func dateFromFB(data flatbuf.Date) (arrow.DataType, error) {


### PR DESCRIPTION
Slight speed-up for a few string conversions.

Strings are immutable. As such, `string([]byte(foo))`, given a mutable buffer, must copy the string, so that changes to the underlying slice do not break the language's requirements.

`unsafe.String(foo, length)`, instead, crafts a string header pointing to the existing buffer. _So long as that buffer is never modified_ for the lifetime of the string, this can be totally safe, and is faster.

Since the flatbufs will never be modified, it's totally safe to craft strings that point directly into its innards. The string pointer is sufficient to prevent GC, and we never modify that flatbuf data on read paths.

Tests pass and there's a small but measurable performance improvement in profiles I was looking at.

<!-- pr-triage-fold: triaged=2026-08-27T20:05:47.992843Z head=73eb8a1 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @pixelherodev** · by `@zeroshade` · 2026-08-27 20:05 UTC
>
> Helpful heads-up from the maintainers — please address these [Pull Request quality criteria](https://github.com/apache/arrow-go/blob/main/CONTRIBUTING.md#did-you-write-a-patch-that-fixes-a-bug-or-brings-an-improvement) items before this PR can be reviewed:
>
> - :x: **Static checks** — failing: Lint. See [docs](https://github.com/apache/arrow-go/blob/main/CONTRIBUTING.md#did-you-write-a-patch-that-fixes-a-bug-or-brings-an-improvement).
> - :x: **Failing CI checks** — failing: AMD64 Debian 12 Go 1.24, ARM64 Debian 12 Go 1.24, Verify (macos-latest), AMD64 Debian 12 Go 1.24 - CGO, Verify (ubuntu-latest) (+5 more). See [docs](https://github.com/apache/arrow-go/blob/main/CONTRIBUTING.md#did-you-write-a-patch-that-fixes-a-bug-or-brings-an-improvement).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
