### PR TITLE
fix: Metadata.Equal comparison with keys in different order

### DIFF
--- a/arrow/schema.go
+++ b/arrow/schema.go
@@ -130,7 +130,7 @@ func (md Metadata) sortedIndices() []int {
 	}
 
 	slices.SortFunc(idxes, func(i, j int) int {
-		return strings.Compare(md.keys[idxes[i]], md.keys[idxes[j]])
+		return strings.Compare(md.keys[i], md.keys[j])
 	})
 	return idxes
 }

--- a/arrow/schema_test.go
+++ b/arrow/schema_test.go
@@ -149,6 +149,18 @@ func TestMetadata(t *testing.T) {
 	})
 }
 
+func TestMetadataSortedIndices(t *testing.T) {
+	md1 := NewMetadata(
+		[]string{"..", "a", "b", "c", "A", "B", "C"},
+		[]string{"1", "2", "3", "4", "5", "6", "7"})
+
+	md2 := NewMetadata(
+		[]string{"A", "B", "C", "..", "a", "b", "c"},
+		[]string{"5", "6", "7", "1", "2", "3", "4"})
+
+	assert.True(t, md1.Equal(md2))
+}
+
 func TestSchema(t *testing.T) {
 	for _, tc := range []struct {
 		fields    []Field


### PR DESCRIPTION
### Rationale for this change
fixes #565

### What changes are included in this PR?
Fixing `Metadata.sortedIndices` to properly sort the key indices

### Are these changes tested?
Yes, a unit test is added for this situation

### Are there any user-facing changes?
No
