### PR TITLE
proof of concept: unify refcounting logic

### DIFF
--- a/arrow/ipc/message.go
+++ b/arrow/ipc/message.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"sync/atomic"
 
+	"github.com/apache/arrow-go/v18/arrow/internal/debug"
 	"github.com/apache/arrow-go/v18/arrow/internal/flatbuf"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 )
@@ -157,7 +158,7 @@ func (r *messageReader) Retain() {
 // When the reference count goes to zero, the memory is freed.
 // Release may be called simultaneously from multiple goroutines.
 func (r *messageReader) Release() {
-	r.refCount.Load()
+	debug.Assert(r.refCount.Load() > 0, "too many releases")
 
 	if r.refCount.Add(-1) == 0 {
 		if r.msg != nil {

--- a/arrow/ipc/message.go
+++ b/arrow/ipc/message.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/internal/debug"
 	"github.com/apache/arrow-go/v18/arrow/internal/flatbuf"
@@ -86,7 +87,7 @@ func NewMessage(meta, body *memory.Buffer) *Message {
 		body: body,
 	}
 	m.Refcount.Buffers = []**memory.Buffer{&m.meta, &m.body}
-	m.Additional = func() { m.msg = nil }
+	m.Derived = []unsafe.Pointer{unsafe.Pointer(&m.msg)}
 	m.Retain()
 	return m
 }
@@ -102,7 +103,7 @@ func newMessageFromFB(meta *flatbuf.Message, body *memory.Buffer) *Message {
 		body: body,
 	}
 	m.Refcount.Buffers = []**memory.Buffer{&m.meta, &m.body}
-	m.Additional = func() { m.msg = nil }
+	m.Derived = []unsafe.Pointer{unsafe.Pointer(&m.msg)}
 	m.Retain()
 	return m
 }

--- a/arrow/ipc/message.go
+++ b/arrow/ipc/message.go
@@ -86,8 +86,8 @@ func NewMessage(meta, body *memory.Buffer) *Message {
 		meta: meta,
 		body: body,
 	}
-	m.Refcount.Buffers = []**memory.Buffer{&m.meta, &m.body}
-	m.Derived = []unsafe.Pointer{unsafe.Pointer(&m.msg)}
+	m.ReferenceBuffer(&m.meta, &m.body)
+	m.ReferenceDerived(unsafe.Pointer(&m.msg))
 	m.Retain()
 	return m
 }
@@ -102,8 +102,8 @@ func newMessageFromFB(meta *flatbuf.Message, body *memory.Buffer) *Message {
 		meta: memory.NewBufferBytes(meta.Table().Bytes),
 		body: body,
 	}
-	m.Refcount.Buffers = []**memory.Buffer{&m.meta, &m.body}
-	m.Derived = []unsafe.Pointer{unsafe.Pointer(&m.msg)}
+	m.ReferenceBuffer(&m.meta, &m.body)
+	m.ReferenceDerived(unsafe.Pointer(&m.msg))
 	m.Retain()
 	return m
 }

--- a/arrow/ipc/message.go
+++ b/arrow/ipc/message.go
@@ -129,7 +129,7 @@ type messageReader struct {
 	memory.Refcount
 	r io.Reader
 
-	msg      *Message
+	msg *Message
 
 	mem    memory.Allocator
 	header [4]byte

--- a/arrow/ipc/reader.go
+++ b/arrow/ipc/reader.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -97,7 +98,8 @@ func NewReader(r io.Reader, opts ...Option) (rr *Reader, err error) {
 	}()
 	cfg := newConfig(opts...)
 	mr := &messageReader{r: r, mem: cfg.alloc}
-	mr.refCount.Add(1)
+	mr.Retain()
+	mr.ReferenceDependency(unsafe.Pointer(&mr.msg))
 	rr = &Reader{
 		r:        mr,
 		refCount: atomic.Int64{},

--- a/arrow/memory/refcount.go
+++ b/arrow/memory/refcount.go
@@ -1,0 +1,41 @@
+package memory
+
+import (
+	"sync/atomic"
+
+	"github.com/apache/arrow-go/v18/arrow/internal/debug"
+)
+
+type Refcount struct {
+	count        atomic.Int64
+	Dependencies []**Refcount
+	Buffers []**Buffer
+	Additional func()
+}
+
+func (r *Refcount) Retain() {
+	r.count.Add(1)
+}
+
+func (r *Refcount) Release() {
+	new := r.count.Add(-1)
+	if new == 0 {
+		for _, buffer := range r.Buffers {
+			(*buffer).Release()
+			*buffer = nil
+		}
+		for _, dependency := range r.Dependencies {
+			(*dependency).Release()
+			*dependency = nil
+		}
+		r.Buffers = nil
+		r.Dependencies = nil
+		if r.Additional != nil {
+			r.Additional()
+		}
+	} else if new < 0 {
+		// This branch can be optimized out when !debug
+		// This avoids an unnecessary extra Load
+		debug.Assert(false, "too many releases")
+	}
+}

--- a/arrow/memory/refcount.go
+++ b/arrow/memory/refcount.go
@@ -1,3 +1,5 @@
+//go:build refcounting
+
 package memory
 
 import (
@@ -12,6 +14,37 @@ type Refcount struct {
 	Dependencies []**Refcount
 	Buffers []**Buffer
 	Derived []unsafe.Pointer
+}
+
+func (r *Refcount) ReferenceDependency(d ...**Refcount) {
+	if r.Dependencies == nil {
+		r.Dependencies = d
+	} else {
+		for _, d := range d {
+			r.Dependencies = append(r.Dependencies, d)
+		}
+	}
+}
+
+func (r *Refcount) ReferenceBuffer(b...**Buffer) {
+	if r.Buffers == nil {
+		r.Buffers = b
+	} else {
+		for _, b := range b {
+			r.Buffers = append(r.Buffers, b)
+		}
+	}
+}
+
+
+func (r *Refcount) ReferenceDerived(p ...unsafe.Pointer) {
+	if r.Derived == nil {
+		r.Derived = p
+	} else {
+		for _, p := range p {
+			r.Derived = append(r.Derived, p)
+		}
+	}
 }
 
 func (r *Refcount) Retain() {

--- a/arrow/memory/refcount.go
+++ b/arrow/memory/refcount.go
@@ -1,4 +1,4 @@
-//go:build refcounting
+//go:build !norc
 
 package memory
 

--- a/arrow/memory/refcount_disabled.go
+++ b/arrow/memory/refcount_disabled.go
@@ -1,0 +1,11 @@
+//go:build !refcounting
+
+package memory
+
+type Refcount struct{}
+
+func (r *Refcount) ReferenceDependency(d ...any) {}
+func (r *Refcount) ReferenceBuffer(b ...any) {}
+func (r *Refcount) ReferenceDerived(p ...any) {}
+func (r *Refcount) Retain() {}
+func (r *Refcount) Release() {}

--- a/arrow/memory/refcount_disabled.go
+++ b/arrow/memory/refcount_disabled.go
@@ -1,4 +1,4 @@
-//go:build !refcounting
+//go:build norc
 
 package memory
 

--- a/arrow/memory/refcount_disabled.go
+++ b/arrow/memory/refcount_disabled.go
@@ -5,7 +5,7 @@ package memory
 type Refcount struct{}
 
 func (r *Refcount) ReferenceDependency(d ...any) {}
-func (r *Refcount) ReferenceBuffer(b ...any) {}
-func (r *Refcount) ReferenceDerived(p ...any) {}
-func (r *Refcount) Retain() {}
-func (r *Refcount) Release() {}
+func (r *Refcount) ReferenceBuffer(b ...any)     {}
+func (r *Refcount) ReferenceDerived(p ...any)    {}
+func (r *Refcount) Retain()                      {}
+func (r *Refcount) Release()                     {}


### PR DESCRIPTION
A step towards the addcleanup work: we want to be able to turn refcounting off entirely. Rather than move all ~200 release+retain functions into files with build tags, IMO it makes sense to unify all refcounting logic into memory.Refcount, embed that everywhere else, and then we can just turn _that_ off with switching to AddCleanup.

This is a proof of concept using that with just ipc/Message to obtain feedback before finishing the work.

<!-- pr-triage-fold: triaged=2026-08-27T20:05:47.992843Z head=5889b53 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @pixelherodev** · by `@zeroshade` · 2026-08-27 20:05 UTC
>
> Helpful heads-up from the maintainers — please address these [Pull Request quality criteria](https://github.com/apache/arrow-go/blob/main/CONTRIBUTING.md#did-you-write-a-patch-that-fixes-a-bug-or-brings-an-improvement) items before this PR can be reviewed:
>
> - :x: **Merge conflicts** — the branch conflicts with `main`. See [docs](https://github.com/apache/arrow-go/blob/main/CONTRIBUTING.md#did-you-write-a-patch-that-fixes-a-bug-or-brings-an-improvement).
> - :x: **Static checks** — failing: Lint. See [docs](https://github.com/apache/arrow-go/blob/main/CONTRIBUTING.md#did-you-write-a-patch-that-fixes-a-bug-or-brings-an-improvement).
> - :x: **Failing CI checks** — failing: Archive. See [docs](https://github.com/apache/arrow-go/blob/main/CONTRIBUTING.md#did-you-write-a-patch-that-fixes-a-bug-or-brings-an-improvement).
> - :x: **Unresolved review comments** — 3 thread(s) remain open ([1](https://github.com/apache/arrow-go/pull/578#discussion_r2558104886), [2](https://github.com/apache/arrow-go/pull/578#discussion_r2558106891), [3](https://github.com/apache/arrow-go/pull/578#discussion_r2558108594)). See [docs](https://github.com/apache/arrow-go/blob/main/CONTRIBUTING.md#did-you-write-a-patch-that-fixes-a-bug-or-brings-an-improvement).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
