### PR TITLE
[Go][Parquet] Fix FixedSizeList nullable elements read as NULL

### DIFF
--- a/parquet/pqarrow/path_builder.go
+++ b/parquet/pqarrow/path_builder.go
@@ -412,6 +412,7 @@ func (p *pathBuilder) Visit(arr arrow.Array) error {
 			defLevelIfEmpty: p.info.maxDefLevel,
 		})
 		// if arr.data.offset > 0, slice?
+		p.nullableInParent = arr.DataType().(*arrow.FixedSizeListType).ElemField().Nullable
 		return p.Visit(larr.ListValues())
 	case arrow.DICTIONARY:
 		// only currently handle dictionaryarray where the dictionary


### PR DESCRIPTION
Fixes #584

The `FIXED_SIZE_LIST` case in `pathBuilder.Visit` was missing the `nullableInParent` assignment that the `LIST` case has, causing non-null values to be read back as NULL.

**Fix:** Add one line to set `nullableInParent` before visiting child values.

**Test:** Added `TestFixedSizeListNullableElements` roundtrip test.