### PR TITLE
ci(benchmark): switch to new conbench instance

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload results
         if: github.event_name == 'push' && github.repository == 'apache/arrow-go' && github.ref_name == 'main'
         env:
-          CONBENCH_URL: https://conbench.ursa.dev
+          CONBENCH_URL: https://conbench.arrow-dev.org
           CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
           CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASS }}
           CONBENCH_REF: ${{ github.ref_name }}


### PR DESCRIPTION
### Rationale for this change

conbench.ursa.dev is no longer online.

### What changes are included in this PR?

Switch posting benchmarking result to conbench.arrow-dev.org in corresponiding workflow.

### Are these changes tested?

No.

### Are there any user-facing changes?

Conbench view is on a new url.

Closes #592 