### PR TITLE
fix(internal): fix assertion on undefined behavior

### DIFF
--- a/internal/utils/math_64bit_test.go
+++ b/internal/utils/math_64bit_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestMul_64bit(t *testing.T) {
 	// These constants are smaller in magnitude than the exact square root.
-	assert.Greater(t, sqrtMinInt, int(math.Sqrt(math.MinInt64)))
+	assert.Greater(t, sqrtMinInt, -int(math.Sqrt(math.MaxInt64)))
 	assert.Less(t, sqrtMaxInt, int(math.Sqrt(math.MaxInt64)))
 
 	for _, tt := range []struct {


### PR DESCRIPTION
### Rationale for this change

Prior to this PR, `TestMul_64bit`  in `internal/utils/math_64bit_test.go` fails on macOS aarch64. This wasn't caught on CI because there's no CI job for macOS aarch64. The behavior under test is technically undefined behavior (`int(NaN)` is UB).

### What changes are included in this PR?

Just to keep the change small, I did the minimum necessary to make the assertion pass on all platforms.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

Closes https://github.com/apache/arrow-go/issues/413
