### PR TITLE
chore: update conbench URL to conbench.arrow-dev.org

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload results
         if: github.event_name == 'push' && github.repository == 'apache/arrow-go' && github.ref_name == 'main'
         env:
-          CONBENCH_URL: https://conbench.ursa.dev
+          CONBENCH_URL: https://conbench.arrow-dev.org
           CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
           CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASS }}
           CONBENCH_REF: ${{ github.ref_name }}


### PR DESCRIPTION
### Rationale for this change

conbench was migrated from conbench.ursa.dev to conbench.arrow-dev.org and the ursa.dev instance was shut down. This should get benchmarks reporting again.

### What changes are included in this PR?

- Updated `CONBENCH_URL` env var in benchmark.yml

### Are these changes tested?

No.

### Are there any user-facing changes?

No.

Closes #592
