### PR TITLE
fix(parquet/variant): fix basic stringify

### DIFF
--- a/parquet/variant/variant.go
+++ b/parquet/variant/variant.go
@@ -685,7 +685,7 @@ func (v Value) Value() any {
 	case BasicArray:
 		valueHdr := (v.value[0] >> basicTypeBits)
 		fieldOffsetSz := (valueHdr & 0b11) + 1
-		isLarge := (valueHdr & 0b1) == 1
+		isLarge := ((valueHdr >> 2) & 0b1) == 1
 
 		var (
 			sz                     int

--- a/parquet/variant/variant_test.go
+++ b/parquet/variant/variant_test.go
@@ -783,3 +783,28 @@ func TestValueCloneConsistency(t *testing.T) {
 	assert.Equal(t, variant.String, cloned.Type())
 	assert.Equal(t, "test", cloned.Value())
 }
+
+// test fix from github.com/apache/arrow-go/issues/623
+func TestVariantJSONRoundTrip(t *testing.T) {
+	jsonBytes := []byte(`{
+  "object_array": [
+    {
+      "a_field_name_1": "some value AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "a_field_name_2": "some value AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "a_field_name_3": "some value",
+      "a_field_name_4": "some value",
+      "a_field_name_5": "some value",
+      "a_field_name_6": "some value",
+      "a_field_name_7": "some value",
+      "a_field_name_8": "some value",
+      "a_field_name_9": "some value",
+      "a_field_name_10": "some value"
+    }
+  ]
+}`)
+	variantFromJSON, err := variant.ParseJSONBytes(jsonBytes, false)
+	if err != nil {
+		panic(err)
+	}
+	assert.JSONEq(t, string(jsonBytes), variantFromJSON.String())
+}


### PR DESCRIPTION
### Rationale for this change
fixes #623

### What changes are included in this PR?
checking for the `isLarge` bit upon calling `Value()` for a BasicArray was incorrect, forgetting to shift appropriately.

### Are these changes tested?
Yes, a unit test is added to check for this

### Are there any user-facing changes?
only fixing the assert.
