### PR TITLE
fix(parquet/pqarrow): fix partial struct panic

### DIFF
--- a/parquet/pqarrow/file_reader.go
+++ b/parquet/pqarrow/file_reader.go
@@ -594,6 +594,8 @@ func (fr *FileReader) getReader(ctx context.Context, field *SchemaField, arrowFi
 		// because we performed getReader concurrently, we need to prune out any empty readers
 		childReaders = slices.DeleteFunc(childReaders,
 			func(r *ColumnReader) bool { return r == nil })
+		childFields = slices.DeleteFunc(childFields,
+			func(f arrow.Field) bool { return f.Type == nil })
 		if len(childFields) == 0 {
 			return nil, nil
 		}


### PR DESCRIPTION
### Rationale for this change
fixes #628

### What changes are included in this PR?
Maintain the consistency of the childFields which we lost during the migration to use DeleteFunc (we were only pruning childReaders, not childFields).

### Are these changes tested?
Test case is added

### Are there any user-facing changes?
Just fixing this panic
