### PR TITLE
ipc: clear variadicCounts in recordEncoder.reset()

### DIFF
--- a/arrow/ipc/writer.go
+++ b/arrow/ipc/writer.go
@@ -366,6 +366,7 @@ func (w *recordEncoder) shouldCompress(uncompressed, compressed int) bool {
 func (w *recordEncoder) reset() {
 	w.start = 0
 	w.fields = make([]fieldMetadata, 0)
+	w.variadicCounts = nil
 }
 
 func (w *recordEncoder) getCompressor(id int) compressor {


### PR DESCRIPTION
The reset() function did not clear variadicCounts, causing it to accumulate across batch encodings. This produces malformed IPC where each DictionaryBatch contains variadic counts from all previous batches, which other IPC reader implementations do not expect (e.g. arrow-rs)

### Rationale for this change
arrow-rs was returning errors when reading IPC files written by arrow-go

### What changes are included in this PR?
Clearing state on reset

### Are these changes tested?
Yes

### Are there any user-facing changes?
No
