### PR TITLE
chore: bump version to 18.5.1

### DIFF
--- a/arrow/doc.go
+++ b/arrow/doc.go
@@ -34,7 +34,7 @@ To build with tinygo include the noasm build tag.
 */
 package arrow
 
-const PkgVersion = "18.5.0"
+const PkgVersion = "18.5.1"
 
 //go:generate go run _tools/tmpl/main.go -i -data=numeric.tmpldata type_traits_numeric.gen.go.tmpl type_traits_numeric.gen_test.go.tmpl array/numeric.gen.go.tmpl array/numericbuilder.gen.go.tmpl array/bufferbuilder_numeric.gen.go.tmpl
 //go:generate go run _tools/tmpl/main.go -i -data=datatype_numeric.gen.go.tmpldata datatype_numeric.gen.go.tmpl tensor/numeric.gen.go.tmpl tensor/numeric.gen_test.go.tmpl


### PR DESCRIPTION
### Rationale for this change
Bumping the version to v18.5.1 in preparation for a patch release

