### PR TITLE
fix(arrow/compute): take on record/array with nested struct

### DIFF
--- a/arrow/compute/cast.go
+++ b/arrow/compute/cast.go
@@ -301,7 +301,7 @@ func CastStruct(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult)
 			out.Buffers[0].Buf, 0)
 	}
 
-	out.Children = make([]exec.ArraySpan, outFieldCount)
+	out.ResizeChildren(outFieldCount)
 	for outFieldIndex, idx := range fieldsToSelect {
 		values := input.Children[idx].MakeArray()
 		defer values.Release()

--- a/arrow/compute/selection.go
+++ b/arrow/compute/selection.go
@@ -514,7 +514,7 @@ func structTake(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult)
 	defer values.Release()
 
 	// select from children without bounds checking
-	out.Children = make([]exec.ArraySpan, values.NumField())
+	out.ResizeChildren(values.NumField())
 	eg, cctx := errgroup.WithContext(ctx.Ctx)
 	eg.SetLimit(GetExecCtx(ctx.Ctx).NumParallel)
 


### PR DESCRIPTION
### Rationale for this change
fixes #644

### What changes are included in this PR?
Fixes handling of children during spans in the Selection code for children. 

### Are these changes tested?
Tests are added to cover the issue

