### PR TITLE
fix(flight/flightsql/driver): fix `time.Time` params

### DIFF
--- a/arrow/flight/flightsql/driver/utils.go
+++ b/arrow/flight/flightsql/driver/utils.go
@@ -276,7 +276,7 @@ func setFieldValue(builder array.Builder, arg interface{}) error {
 				b.Append(arrow.Time64(x))
 			}
 		case time.Time:
-			b.Append(arrow.Time64(v.Nanosecond()))
+			b.Append(arrow.Time64(v.UnixNano()))
 		default:
 			return fmt.Errorf("invalid value type %T for builder %T", arg, builder)
 		}


### PR DESCRIPTION
### Rationale for this change

Parameters passed as `time.Time` were being interpreted incorrectly. `Nanosecond()` returns the nanosecond portion of the timestamp within a one-second interval, not the number of nanoseconds since the Unix epoch.

### What changes are included in this PR?

Just a one-liner!

### Are these changes tested?

Yes, tested locally with a real FlightSQL server.

### Are there any user-facing changes?

`time.Time` parameters should work now!