### PR TITLE
feat: Support setting IPC options in FlightSQL call options

### DIFF
--- a/arrow/flight/flightsql/client_test.go
+++ b/arrow/flight/flightsql/client_test.go
@@ -684,14 +684,12 @@ func (s *FlightSqlClientSuite) TestExecuteIngestWithIPCOptions() {
 
 	s.mockClient.On("DoPut", s.callOpts).Return(mockedPut, nil)
 
-	count, err := s.sqlClient.ExecuteIngest(
+	count, err := s.sqlClient.ExecuteIngestWithIPC(
 		context.Background(),
 		rdr,
 		request,
-		flightsql.BuildCallOptions(
-			flightsql.WithGRPCCallOptions(s.callOpts...),
-			flightsql.WithIPCCallOptions(ipc.WithLZ4()),
-		)...,
+		[]ipc.Option{ipc.WithLZ4()},
+		s.callOpts...,
 	)
 	s.Require().NoError(err)
 	s.EqualValues(1, count)
@@ -746,14 +744,12 @@ func (s *FlightSqlClientSuite) TestExecuteIngestWithSchemaOverrideOption() {
 
 	s.mockClient.On("DoPut", s.callOpts).Return(mockedPut, nil)
 
-	_, err = s.sqlClient.ExecuteIngest(
+	_, err = s.sqlClient.ExecuteIngestWithIPC(
 		context.Background(),
 		rdr,
 		request,
-		flightsql.BuildCallOptions(
-			flightsql.WithGRPCCallOptions(s.callOpts...),
-			flightsql.WithIPCCallOptions(ipc.WithSchema(overrideSchema)),
-		)...,
+		[]ipc.Option{ipc.WithSchema(overrideSchema)},
+		s.callOpts...,
 	)
 	s.Error(err)
 	s.ErrorContains(err, "different schema")
@@ -787,14 +783,12 @@ func (s *FlightSqlClientSuite) TestExecuteIngestWithSliceOptions() {
 	s.mockClient.On("DoPut", s.callOpts).Return(mockedPut, nil)
 
 	ipcOpts := []ipc.Option{ipc.WithLZ4()}
-	count, err := s.sqlClient.ExecuteIngest(
+	count, err := s.sqlClient.ExecuteIngestWithIPC(
 		context.Background(),
 		rdr,
 		request,
-		flightsql.BuildCallOptions(
-			flightsql.WithGRPCCallOptions(s.callOpts...),
-			flightsql.WithIPCCallOptions(ipcOpts...),
-		)...,
+		ipcOpts,
+		s.callOpts...,
 	)
 	s.Require().NoError(err)
 	s.EqualValues(1, count)

--- a/arrow/flight/flightsql/types.go
+++ b/arrow/flight/flightsql/types.go
@@ -18,8 +18,6 @@ package flightsql
 
 import (
 	pb "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
-	"github.com/apache/arrow-go/v18/arrow/ipc"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -150,88 +148,7 @@ type (
 	// - TransactionId: Ingest as part of this transaction
 	// - Options: Additional, backend-specific options
 	ExecuteIngestOpts pb.CommandStatementIngest
-
-	CallOptionInput interface {
-		appendClientCallOptions(grpcOpts *[]grpc.CallOption, ipcOpts *[]ipc.Option)
-	}
-
-	grpcCallOptionsInput struct {
-		opts []grpc.CallOption
-	}
-
-	ipcCallOptionsInput struct {
-		opts []ipc.Option
-	}
-
-	// Wrap IPC options as an empty grpc CallOption so they can be passed through
-	// existing methods that accept grpc call options.
-	ipcCallOptions struct {
-		grpc.EmptyCallOption
-		opts []ipc.Option
-	}
 )
-
-func (o grpcCallOptionsInput) appendClientCallOptions(grpcOpts *[]grpc.CallOption, _ *[]ipc.Option) {
-	*grpcOpts = append(*grpcOpts, o.opts...)
-}
-
-func (o ipcCallOptionsInput) appendClientCallOptions(_ *[]grpc.CallOption, ipcOpts *[]ipc.Option) {
-	*ipcOpts = append(*ipcOpts, o.opts...)
-}
-
-// WithGRPCCallOptions creates typed grpc call-option input for BuildCallOptions.
-func WithGRPCCallOptions(opts ...grpc.CallOption) CallOptionInput {
-	copied := make([]grpc.CallOption, len(opts))
-	copy(copied, opts)
-	return grpcCallOptionsInput{opts: copied}
-}
-
-// WithIPCCallOptions creates typed IPC writer-option input for BuildCallOptions.
-func WithIPCCallOptions(opts ...ipc.Option) CallOptionInput {
-	copied := make([]ipc.Option, len(opts))
-	copy(copied, opts)
-	return ipcCallOptionsInput{opts: copied}
-}
-
-// BuildCallOptions combines typed grpc and IPC option inputs into grpc call
-// options for client APIs.
-//
-// The resulting options can be expanded directly into methods like ExecuteIngest.
-func BuildCallOptions(opts ...CallOptionInput) []grpc.CallOption {
-	grpcOpts := make([]grpc.CallOption, 0)
-	ipcOpts := make([]ipc.Option, 0)
-
-	for _, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		opt.appendClientCallOptions(&grpcOpts, &ipcOpts)
-	}
-
-	if len(ipcOpts) == 0 {
-		return grpcOpts
-	}
-
-	out := make([]grpc.CallOption, 0, len(grpcOpts)+1)
-	out = append(out, grpcOpts...)
-	out = append(out, &ipcCallOptions{opts: ipcOpts})
-	return out
-}
-
-func splitCallOptions(opts []grpc.CallOption) ([]grpc.CallOption, []ipc.Option) {
-	grpcOpts := make([]grpc.CallOption, 0, len(opts))
-	ipcOpts := make([]ipc.Option, 0)
-
-	for _, opt := range opts {
-		if ipcCallOpt, ok := opt.(*ipcCallOptions); ok {
-			ipcOpts = append(ipcOpts, ipcCallOpt.opts...)
-			continue
-		}
-		grpcOpts = append(grpcOpts, opt)
-	}
-
-	return grpcOpts, ipcOpts
-}
 
 // SqlInfo enum values
 const (


### PR DESCRIPTION
### Rationale for this change

I would like to specify the IPC stream compression settings for the FlightSQL `ExecuteIngest` command. Currently, there is no way to apply IPC options to the writer stream from the `ExecuteIngest` method.

### What changes are included in this PR?

* Introduces a `ExecuteIngestWithIPC` which allows passing IPC options
* Retains the existing behaviour of `ExecuteIngest`
* Consolidates the shared execute ingest behaviour into a private `executeIngest`

### Are these changes tested?

* Tested with new unit tests to validate the record batch frames are sent with LZ4 compression when the `ipc.WithLZ4()` option is passed in the call options

### Are there any user-facing changes?

* Yes - introduces a new public method `ExecuteIngestWithIPC`
