### PR TITLE
chore(dev/release): embed hash of source tarball into email

### DIFF
--- a/dev/release/release_rc.sh
+++ b/dev/release/release_rc.sh
@@ -115,7 +115,8 @@ gh release download "${rc_tag}" \
   --repo "${repository}" \
   --clobber
 
-SOURCE_TARBALL_HASH=$(cat "${tar_gz}.sha512" | awk '{print $1}')
+SOURCE_TARBALL_HASH=$(awk '{print $1}' "${tar_gz}.sha512")
+rm -f "${tar_gz}.sha512"
 
 echo "Draft email for dev@arrow.apache.org mailing list"
 echo ""


### PR DESCRIPTION
Following the discussion on https://lists.apache.org/thread/o2mpsf5okhzfz2k4mbg5d4s9ror69587 and https://github.com/apache/arrow-adbc/pull/3965, I figured we should do the same for arrow-go.