### PR TITLE
perf(parquet): remove string concatenation in hot debug assert

### DIFF
--- a/arrow/array/diff.go
+++ b/arrow/array/diff.go
@@ -62,14 +62,14 @@ func (e Edits) UnifiedDiff(base, target arrow.Array) string {
 	for i := 0; i < len(e); i++ {
 		if i > 0 {
 			if !wrotePosition {
-				s.WriteString(fmt.Sprintf("@@ -%d, +%d @@\n", baseIndex, targetIndex))
+				fmt.Fprintf(&s, "@@ -%d, +%d @@\n", baseIndex, targetIndex)
 				wrotePosition = true
 			}
 			if e[i].Insert {
-				s.WriteString(fmt.Sprintf("+%v\n", stringAt(target, targetIndex)))
+				fmt.Fprintf(&s, "+%v\n", stringAt(target, targetIndex))
 				targetIndex++
 			} else {
-				s.WriteString(fmt.Sprintf("-%v\n", stringAt(base, baseIndex)))
+				fmt.Fprintf(&s, "-%v\n", stringAt(base, baseIndex))
 				baseIndex++
 			}
 		}

--- a/arrow/datatype_nested.go
+++ b/arrow/datatype_nested.go
@@ -443,7 +443,7 @@ func (t *StructType) String() string {
 		if i > 0 {
 			o.WriteString(", ")
 		}
-		o.WriteString(fmt.Sprintf("%s: %v", f.Name, f.Type))
+		fmt.Fprintf(&o, "%s: %v", f.Name, f.Type)
 		if f.Nullable {
 			o.WriteString(" nullable")
 		}
@@ -578,9 +578,9 @@ func (*MapType) Name() string { return "map" }
 
 func (t *MapType) String() string {
 	var o strings.Builder
-	o.WriteString(fmt.Sprintf("map<%s, %s",
+	fmt.Fprintf(&o, "map<%s, %s",
 		t.value.Elem().(*StructType).Field(0).Type,
-		t.value.Elem().(*StructType).Field(1).Type))
+		t.value.Elem().(*StructType).Field(1).Type)
 	if t.KeysSorted {
 		o.WriteString(", keys_sorted")
 	}

--- a/arrow/flight/flightsql/driver/driver_test.go
+++ b/arrow/flight/flightsql/driver/driver_test.go
@@ -430,7 +430,7 @@ func (s *SqlTestSuite) TestRowsManualPrematureClose() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -515,7 +515,7 @@ func (s *SqlTestSuite) TestRowsNormalExhaustion() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -607,7 +607,7 @@ func (s *SqlTestSuite) TestRowsPrematureCloseDuringNextLoop() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -701,7 +701,7 @@ func (s *SqlTestSuite) TestRowsInterruptionByContextManualCancellation() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -789,7 +789,7 @@ func (s *SqlTestSuite) TestRowsInterruptionByContextTimeout() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -881,7 +881,7 @@ func (s *SqlTestSuite) TestRowsManualPrematureCloseStmt() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -972,7 +972,7 @@ func (s *SqlTestSuite) TestRowsNormalExhaustionStmt() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -1067,7 +1067,7 @@ func (s *SqlTestSuite) TestRowsPrematureCloseDuringNextLoopStmt() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -1167,7 +1167,7 @@ func (s *SqlTestSuite) TestRowsInterruptionByContextManualCancellationStmt() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")
@@ -1258,7 +1258,7 @@ func (s *SqlTestSuite) TestRowsInterruptionByContextTimeoutStmt() {
 	sb.WriteString(sqlInsert)
 
 	for i := 0; i < rowCount; i++ {
-		sb.WriteString(fmt.Sprintf(`('%s', %d),`, getRandomString(gen, randStringLen), gen.Int()))
+		fmt.Fprintf(&sb, `('%s', %d),`, getRandomString(gen, randStringLen), gen.Int())
 	}
 
 	insertQuery := strings.TrimSuffix(sb.String(), ",")

--- a/arrow/memory/checked_allocator.go
+++ b/arrow/memory/checked_allocator.go
@@ -167,10 +167,10 @@ func (a *CheckedAllocator) AssertSize(t TestingT, sz int) {
 			// It may be nil for non-Go code or fully inlined functions.
 			if fn := frame.Func; fn != nil {
 				// format as func name + the offset in bytes from func entrypoint
-				callersMsg.WriteString(fmt.Sprintf("%s+%x", fn.Name(), frame.PC-fn.Entry()))
+				fmt.Fprintf(&callersMsg, "%s+%x", fn.Name(), frame.PC-fn.Entry())
 			} else {
 				// fallback to outer func name + file line
-				callersMsg.WriteString(fmt.Sprintf("%s, line %d", frame.Function, frame.Line))
+				fmt.Fprintf(&callersMsg, "%s, line %d", frame.Function, frame.Line)
 			}
 
 			// Write a proper file name + line, so it's really easy to find the leak

--- a/arrow/scalar/nested.go
+++ b/arrow/scalar/nested.go
@@ -227,7 +227,7 @@ func (s *Struct) CastTo(to arrow.DataType) (Scalar, error) {
 		if i > 0 {
 			bld.WriteString(", ")
 		}
-		bld.WriteString(fmt.Sprintf("%s:%s = %s", st.Field(i).Name, st.Field(i).Type, v.String()))
+		fmt.Fprintf(&bld, "%s:%s = %s", st.Field(i).Name, st.Field(i).Type, v.String())
 	}
 	bld.WriteByte('}')
 	buf := memory.NewBufferBytes(bld.Bytes())

--- a/parquet/file/column_writer.go
+++ b/parquet/file/column_writer.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"strconv"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -449,8 +448,7 @@ func (w *columnWriter) writeLevels(numValues int64, defLevels, repLevels []int16
 	// if the field is required and non-repeated, no definition levels
 	if defLevels != nil && maxDefLevel > 0 {
 		for _, v := range defLevels[:numValues] {
-			debug.Assert(v <= maxDefLevel, "columnwriter: invalid definition level "+
-				strconv.Itoa(int(v))+" for column "+w.descr.Path())
+			debug.Assert(v <= maxDefLevel, "columnwriter: invalid definition level")
 			if v == maxDefLevel {
 				toWrite++
 			}


### PR DESCRIPTION
### Rationale for this change
https://github.com/apache/arrow-go/issues/706

### What changes are included in this PR?
Remove string concatenation in hot debug assert.

There are a few changes caused by `golangci-lint run` because fix is enabled in .golangci.yaml. I include these harmless changes as keeping them may cause unnecessary frictions for future contributors(who automate golangci-lint), but I can revert them if needed :)

### Are these changes tested?
yes


### Are there any user-facing changes?
no

