### PR TITLE
feat: filter and take for dictionary arrays

### DIFF
--- a/arrow/compute/selection.go
+++ b/arrow/compute/selection.go
@@ -485,6 +485,40 @@ func structFilter(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResul
 	return nil
 }
 
+
+// dictionaryFilter is a special case for filtering a dictionary array
+//
+// The implementation uses the 'dictionaryTake' implementation.
+func dictionaryFilter(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult) error {
+	// convert the filter (boolean array) to indices to take from the dictionary array.
+	indices, err := kernels.GetTakeIndices(exec.GetAllocator(ctx.Ctx),
+		&batch.Values[1].Array, ctx.State.(kernels.FilterState).NullSelection)
+	if err != nil {
+		return err
+	}
+	defer indices.Release()
+
+	filter := NewDatum(indices)
+	defer filter.Release()
+
+	valData := batch.Values[0].Array.MakeData()
+	defer valData.Release()
+
+	vals := NewDatum(valData)
+	defer vals.Release()
+
+	// run 'take' on the dictionary array, which will call dictionaryTake.
+	// we know the bounds are good because the indices were just created by GetTakeIndices
+	result, err := Take(ctx.Ctx, kernels.TakeOptions{BoundsCheck: false}, vals, filter)
+	if err != nil {
+		return err
+	}
+	defer result.Release()
+
+	out.TakeOwnership(result.(*ArrayDatum).Value)
+	return nil
+}
+
 func structTake(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult) error {
 	// generate top level validity bitmap
 	if err := kernels.TakeExec(kernels.StructImpl)(ctx, batch, out); err != nil {
@@ -519,6 +553,33 @@ func structTake(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult)
 	return eg.Wait()
 }
 
+
+// dictionaryTake is a special case for taking from a dictionary array.
+//
+// We can run 'take' only on the indices, without updating the mapping from indices to values.
+func dictionaryTake(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult) error {
+	dictArr := batch.Values[0].Array.MakeArray().(*array.Dictionary)
+	defer dictArr.Release()
+
+	selection := batch.Values[1].Array.MakeArray()
+	defer selection.Release()
+
+	// run 'take' on the indices array of the dictionary array.
+	takenIndices, err := TakeArrayOpts(ctx.Ctx, dictArr.Indices(), selection, kernels.TakeOptions{BoundsCheck: ctx.State.(kernels.TakeState).BoundsCheck})
+	if err != nil {
+		return err
+	}
+	defer takenIndices.Release()
+
+	// create a new dictionary array - the indices are the 'taken' indices,
+	// and the dictionary is a pointer to the original dictionary.
+	result := array.NewDictionaryArray(dictArr.DataType(), takenIndices, dictArr.Dictionary())
+	defer result.Release()
+
+	out.TakeOwnership(result.Data())
+	return nil
+}
+
 // RegisterVectorSelection registers functions that select specific
 // values from arrays such as Take and Filter
 func RegisterVectorSelection(reg FunctionRegistry) {
@@ -533,6 +594,7 @@ func RegisterVectorSelection(reg FunctionRegistry) {
 		{In: exec.NewIDInput(arrow.LARGE_LIST), Exec: selectListImpl(kernels.FilterExec(kernels.ListImpl[int64]))},
 		{In: exec.NewIDInput(arrow.FIXED_SIZE_LIST), Exec: selectListImpl(kernels.FilterExec(kernels.FSLImpl))},
 		{In: exec.NewIDInput(arrow.DENSE_UNION), Exec: denseUnionImpl(kernels.FilterExec(kernels.DenseUnionImpl))},
+		{In: exec.NewIDInput(arrow.DICTIONARY), Exec: dictionaryFilter},
 		{In: exec.NewIDInput(arrow.EXTENSION), Exec: extensionFilterImpl},
 		{In: exec.NewIDInput(arrow.STRUCT), Exec: structFilter},
 	}...)
@@ -543,6 +605,7 @@ func RegisterVectorSelection(reg FunctionRegistry) {
 		{In: exec.NewIDInput(arrow.FIXED_SIZE_LIST), Exec: selectListImpl(kernels.TakeExec(kernels.FSLImpl))},
 		{In: exec.NewIDInput(arrow.MAP), Exec: selectMapImpl(kernels.TakeExec(kernels.MapImpl))},
 		{In: exec.NewIDInput(arrow.DENSE_UNION), Exec: denseUnionImpl(kernels.TakeExec(kernels.DenseUnionImpl))},
+		{In: exec.NewIDInput(arrow.DICTIONARY), Exec: dictionaryTake},
 		{In: exec.NewIDInput(arrow.EXTENSION), Exec: extensionTakeImpl},
 		{In: exec.NewIDInput(arrow.STRUCT), Exec: structTake},
 	}...)

--- a/arrow/compute/selection.go
+++ b/arrow/compute/selection.go
@@ -485,7 +485,6 @@ func structFilter(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResul
 	return nil
 }
 
-
 // dictionaryFilter is a special case for filtering a dictionary array
 //
 // The implementation uses the 'dictionaryTake' implementation.
@@ -552,7 +551,6 @@ func structTake(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult)
 
 	return eg.Wait()
 }
-
 
 // dictionaryTake is a special case for taking from a dictionary array.
 //

--- a/arrow/compute/selection.go
+++ b/arrow/compute/selection.go
@@ -487,7 +487,8 @@ func structFilter(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResul
 
 // dictionaryFilter is a special case for filtering a dictionary array
 //
-// The implementation uses the 'dictionaryTake' implementation.
+// The shared dictionary is reused as-is and never compacted, so the result may retain values
+// that are no longer referenced by any index.
 func dictionaryFilter(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult) error {
 	// convert the filter (boolean array) to indices to take from the dictionary array.
 	indices, err := kernels.GetTakeIndices(exec.GetAllocator(ctx.Ctx),
@@ -554,7 +555,8 @@ func structTake(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult)
 
 // dictionaryTake is a special case for taking from a dictionary array.
 //
-// We can run 'take' only on the indices, without updating the mapping from indices to values.
+// The shared dictionary is reused as-is and never compacted, so the result may retain values
+// that are no longer referenced by any index.
 func dictionaryTake(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult) error {
 	dictArr := batch.Values[0].Array.MakeArray().(*array.Dictionary)
 	defer dictArr.Release()

--- a/arrow/compute/vector_selection_test.go
+++ b/arrow/compute/vector_selection_test.go
@@ -66,6 +66,21 @@ func (f *FilterKernelTestSuite) getArr(dt arrow.DataType, str string) arrow.Arra
 	return arr
 }
 
+// assertDictionaryLogicalEqual compares two dictionary arrays by decoding both to the
+// value type and comparing. Use when logical equality is desired (same decoded values)
+// rather than physical (same indices and dictionary).
+func assertDictionaryLogicalEqual(t *testing.T, ctx context.Context, expected, actual arrow.Array) bool {
+	valueType := expected.DataType().(*arrow.DictionaryType).ValueType
+	castOpts := compute.NewCastOptions(valueType, true)
+	decodedExpected, err := compute.CastArray(ctx, expected, castOpts)
+	require.NoError(t, err)
+	defer decodedExpected.Release()
+	decodedActual, err := compute.CastArray(ctx, actual, castOpts)
+	require.NoError(t, err)
+	defer decodedActual.Release()
+	return assertArraysEqual(t, decodedExpected, decodedActual)
+}
+
 func (f *FilterKernelTestSuite) doAssertFilter(values, filter, expected arrow.Array) {
 	ctx := compute.WithAllocator(context.TODO(), f.mem)
 	valDatum := compute.NewDatum(values)
@@ -79,7 +94,11 @@ func (f *FilterKernelTestSuite) doAssertFilter(values, filter, expected arrow.Ar
 		defer out.Release()
 		actual := out.(*compute.ArrayDatum).MakeArray()
 		defer actual.Release()
-		f.Truef(array.Equal(expected, actual), "expected: %s\ngot: %s", expected, actual)
+		if expected.DataType().ID() == arrow.DICTIONARY {
+			assertDictionaryLogicalEqual(f.T(), ctx, expected, actual)
+		} else {
+			f.Truef(array.Equal(expected, actual), "expected: %s\ngot: %s", expected, actual)
+		}
 	})
 
 	// f.Run("drop", func() {
@@ -174,7 +193,12 @@ func (tk *TakeKernelTestSuite) assertTakeArrays(values, indices, expected arrow.
 	actual, err := compute.TakeArray(tk.ctx, values, indices)
 	tk.Require().NoError(err)
 	defer actual.Release()
-	assertArraysEqual(tk.T(), expected, actual)
+
+	if expected.DataType().ID() == arrow.DICTIONARY {
+		assertDictionaryLogicalEqual(tk.T(), tk.ctx, expected, actual)
+	} else {
+		assertArraysEqual(tk.T(), expected, actual)
+	}
 }
 
 func (tk *TakeKernelTestSuite) takeJSON(dt arrow.DataType, values string, idxType arrow.DataType, indices string) (arrow.Array, error) {
@@ -1805,6 +1829,7 @@ func TestTakeKernels(t *testing.T) {
 	for _, dt := range baseBinaryTypes {
 		suite.Run(t, &TakeKernelTestString{TakeKernelTestTyped: TakeKernelTestTyped{dt: dt}})
 	}
+	suite.Run(t, &TakeKernelTestString{TakeKernelTestTyped: TakeKernelTestTyped{dt: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.BinaryTypes.String}}})
 	suite.Run(t, new(TakeKernelLists))
 	suite.Run(t, new(TakeKernelDenseUnion))
 	suite.Run(t, new(TakeKernelTestExtension))
@@ -1826,6 +1851,7 @@ func TestFilterKernels(t *testing.T) {
 	for _, dt := range baseBinaryTypes {
 		suite.Run(t, &FilterKernelWithString{dt: dt})
 	}
+	suite.Run(t, &FilterKernelWithString{dt: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.BinaryTypes.String}})
 	suite.Run(t, new(FilterKernelWithList))
 	suite.Run(t, new(FilterKernelWithUnion))
 	suite.Run(t, new(FilterKernelExtension))

--- a/arrow/compute/vector_selection_test.go
+++ b/arrow/compute/vector_selection_test.go
@@ -1820,6 +1820,182 @@ func TestMapPreservesValueNullable(t *testing.T) {
 		"Map struct child type not preserved:\nwant: %s\n got: %s", wantChildType, gotChildType)
 }
 
+// TestDictionarySelectionTypeCoverage exercises Take and Filter on dictionary
+// arrays across several index types and value types (utf8, int64, float64,
+// struct, list). Inputs are built with array.DictArrayFromJSON (separate indices
+// and dictionary JSON) rather than array.FromJSON, which has no dictionary builder
+// for nested value types. Take and Filter only reorder/select the indices and keep
+// the dictionary unchanged, so results are verified by deconstructing the resulting
+// dictionary into its indices and shared dictionary and comparing each part. The
+// uint16_index_float64_value case carries a null index that must be preserved.
+func TestDictionarySelectionTypeCoverage(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	ctx := compute.WithAllocator(context.TODO(), mem)
+
+	type tc struct {
+		name         string
+		dt           *arrow.DictionaryType
+		lookupValues string // distinct dictionary lookup values
+		inputIdx     string // indices of the input array
+		takeSel      string // selection indices for Take
+		wantTakeIdx  string // expected indices after Take
+		filter       string // boolean mask for Filter
+		wantFiltIdx  string // expected indices after Filter
+	}
+	cases := []tc{
+		{
+			name:         "int32_index_utf8_value",
+			dt:           &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String},
+			lookupValues: `["a", "b", "c"]`,
+			inputIdx:     `[2, 0, 1, 2, 1, 0]`,
+			takeSel:      `[5, 0, 3, 1]`, wantTakeIdx: `[0, 2, 2, 0]`,
+			filter: `[true, false, true, false, true, true]`, wantFiltIdx: `[2, 1, 1, 0]`,
+		},
+		{
+			name:         "int8_index_int64_value",
+			dt:           &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.PrimitiveTypes.Int64},
+			lookupValues: `[10, 20, 30, 40]`,
+			inputIdx:     `[3, 0, 2]`,
+			takeSel:      `[2, 0]`, wantTakeIdx: `[2, 3]`,
+			filter: `[false, true, true]`, wantFiltIdx: `[0, 2]`,
+		},
+		{
+			// null index in the input that must survive both Take and Filter.
+			name:         "uint16_index_float64_value",
+			dt:           &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint16, ValueType: arrow.PrimitiveTypes.Float64},
+			lookupValues: `[1.5, 2.5, 4.0]`,
+			inputIdx:     `[2, null, 0]`,
+			takeSel:      `[1, 2, 0]`, wantTakeIdx: `[null, 0, 2]`,
+			filter: `[true, true, false]`, wantFiltIdx: `[2, null]`,
+		},
+		{
+			name: "int8_index_struct_value",
+			dt: &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.StructOf(
+				arrow.Field{Name: "a", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+				arrow.Field{Name: "b", Type: arrow.BinaryTypes.String, Nullable: true},
+			)},
+			lookupValues: `[{"a": 1, "b": "x"}, {"a": null, "b": null}, {"a": 3, "b": "z"}]`,
+			inputIdx:     `[2, 0, 1]`,
+			takeSel:      `[2, 0]`, wantTakeIdx: `[1, 2]`,
+			filter: `[true, false, true]`, wantFiltIdx: `[2, 1]`,
+		},
+		{
+			name:         "uint16_index_list_int32_value",
+			dt:           &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Uint16, ValueType: arrow.ListOf(arrow.PrimitiveTypes.Int32)},
+			lookupValues: `[[], [1, 2], [3]]`,
+			inputIdx:     `[1, 0, 2]`,
+			takeSel:      `[2, 0]`, wantTakeIdx: `[2, 1]`,
+			filter: `[true, false, true]`, wantFiltIdx: `[1, 2]`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			input, err := array.DictArrayFromJSON(mem, c.dt, c.inputIdx, c.lookupValues)
+			require.NoError(t, err)
+			defer input.Release()
+
+			// assertDict asserts that the dictionary indices equal wantIdxJSON and
+			// that the dictionary lookup values are left unchanged.
+			assertDict := func(wantIdxJSON string, got arrow.Array) {
+				gotDict, ok := got.(*array.Dictionary)
+				require.Truef(t, ok, "expected *array.Dictionary, got %T", got)
+
+				wantIdx, _, err := array.FromJSON(mem, c.dt.IndexType, strings.NewReader(wantIdxJSON))
+				require.NoError(t, err)
+				defer wantIdx.Release()
+
+				// Build a fresh, independent copy of the expected lookup values from
+				// the source JSON.
+				originalLookupValues, _, err := array.FromJSON(mem, c.dt.ValueType, strings.NewReader(c.lookupValues))
+				require.NoError(t, err)
+				defer originalLookupValues.Release()
+
+				assert.Truef(t, array.Equal(wantIdx, gotDict.Indices()),
+					"indices mismatch\nwant: %s\n got: %s", wantIdx, gotDict.Indices())
+				assert.Truef(t, array.Equal(originalLookupValues, gotDict.Dictionary()),
+					"lookup values mismatch\nwant: %s\n got: %s", originalLookupValues, gotDict.Dictionary())
+			}
+
+			takeSel, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(c.takeSel))
+			require.NoError(t, err)
+			defer takeSel.Release()
+
+			gotTake, err := compute.TakeArray(ctx, input, takeSel)
+			require.NoError(t, err)
+			defer gotTake.Release()
+			assertDict(c.wantTakeIdx, gotTake)
+
+			filter, _, err := array.FromJSON(mem, arrow.FixedWidthTypes.Boolean, strings.NewReader(c.filter))
+			require.NoError(t, err)
+			defer filter.Release()
+
+			gotFilter, err := compute.FilterArray(ctx, input, filter, *compute.DefaultFilterOptions())
+			require.NoError(t, err)
+			defer gotFilter.Release()
+			assertDict(c.wantFiltIdx, gotFilter)
+		})
+	}
+}
+
+// TestDictionarySelectionLengthAndBounds checks the error paths of Filter and
+// Take on a dictionary array (int8 index -> utf8 value):
+//   - Filter requires the boolean mask to be the same length as the values;
+//     both a too-short and a too-long mask must fail with arrow.ErrInvalid.
+//   - Take must reject out-of-range selection indices with arrow.ErrIndex,
+//     both an index past the end and a negative index.
+func TestDictionarySelectionLengthAndBounds(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	ctx := compute.WithAllocator(context.TODO(), mem)
+
+	dt := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.BinaryTypes.String}
+
+	// values has 4 elements; valid indices are 0..3.
+	values, err := array.DictArrayFromJSON(mem, dt, `[2, 0, 1, 0]`, `["a", "b", "c"]`)
+	require.NoError(t, err)
+	defer values.Release()
+
+	t.Run("filter_length_mismatch", func(t *testing.T) {
+		for _, c := range []struct {
+			name string
+			mask string
+		}{
+			{"too_short", `[true, false]`},
+			{"too_long", `[true, false, true, false, true]`},
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				filter, _, err := array.FromJSON(mem, arrow.FixedWidthTypes.Boolean, strings.NewReader(c.mask))
+				require.NoError(t, err)
+				defer filter.Release()
+
+				_, err = compute.FilterArray(ctx, values, filter, *compute.DefaultFilterOptions())
+				assert.ErrorIs(t, err, arrow.ErrInvalid)
+			})
+		}
+	})
+
+	t.Run("take_out_of_bounds", func(t *testing.T) {
+		for _, c := range []struct {
+			name string
+			sel  string
+		}{
+			{"too_big", `[0, 4]`},   // 4 is past the last valid index (3)
+			{"too_small", `[0, -1]`}, // negative index
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				sel, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(c.sel))
+				require.NoError(t, err)
+				defer sel.Release()
+
+				_, err = compute.TakeArray(ctx, values, sel)
+				assert.ErrorIs(t, err, arrow.ErrIndex)
+			})
+		}
+	})
+}
+
 func TestTakeKernels(t *testing.T) {
 	suite.Run(t, new(TakeKernelTest))
 	for _, dt := range numericTypes {

--- a/arrow/compute/vector_selection_test.go
+++ b/arrow/compute/vector_selection_test.go
@@ -1820,14 +1820,9 @@ func TestMapPreservesValueNullable(t *testing.T) {
 		"Map struct child type not preserved:\nwant: %s\n got: %s", wantChildType, gotChildType)
 }
 
-// TestDictionarySelectionTypeCoverage exercises Take and Filter on dictionary
-// arrays across several index types and value types (utf8, int64, float64,
-// struct, list). Inputs are built with array.DictArrayFromJSON (separate indices
-// and dictionary JSON) rather than array.FromJSON, which has no dictionary builder
-// for nested value types. Take and Filter only reorder/select the indices and keep
-// the dictionary unchanged, so results are verified by deconstructing the resulting
-// dictionary into its indices and shared dictionary and comparing each part. The
-// uint16_index_float64_value case carries a null index that must be preserved.
+// TestDictionarySelectionTypeCoverage exercises Take and Filter on dictionary arrays
+//
+// It uses varied index types and value types.
 func TestDictionarySelectionTypeCoverage(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
@@ -1981,7 +1976,7 @@ func TestDictionarySelectionLengthAndBounds(t *testing.T) {
 			name string
 			sel  string
 		}{
-			{"too_big", `[0, 4]`},   // 4 is past the last valid index (3)
+			{"too_big", `[0, 4]`},    // 4 is past the last valid index (3)
 			{"too_small", `[0, -1]`}, // negative index
 		} {
 			t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
Add 'take' and 'filter' implementations for dictionary arrays. These implementations simply filter/take on the index column and shallow-copy the dictionary.

https://github.com/apache/arrow-go/issues/714

### Rationale for this change

It would be nice for 'take' and 'filter' to work for all array encodings, including dictionary

### What changes are included in this PR?

Just 'take' and 'filter' implementations and an addition to the tests

### Are these changes tested?

Unit tests added

### Are there any user-facing changes?

These will now work instead of failing with an error like:

```
not implemented: function 'array_filter' has no kernel matching input types (dictionary<values=utf8, indices=int8, ordered=false>, bool)
```