### PR TITLE
chore: Update CI with Go 1.25/1.26

### DIFF
--- a/.env
+++ b/.env
@@ -28,4 +28,4 @@ REPO=ghcr.io/apache/arrow-go
 DEBIAN=12
 
 # Default versions for various dependencies
-GO=1.24.6
+GO=1.25.8

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.24.3']
+        go: ['1.26.1']
         arch: ['amd64']
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@def8c394e3ad351a79bc93815e4a585520fe993b # v6.2.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
           cache-dependency-path: go.sum
       - name: Install pre-commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,7 +329,7 @@ jobs:
     name: TinyGo
     runs-on: ubuntu-latest
     env:
-      TINYGO_VERSION: 0.38.0
+      TINYGO_VERSION: 0.40.1
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,19 +40,19 @@ jobs:
         include:
           - arch-label: AMD64
             arch: amd64
-            go: 1.24
+            go: 1.25
             runs-on: ubuntu-latest
           - arch-label: ARM64
             arch: arm64v8
-            go: 1.24
+            go: 1.25
             runs-on: ubuntu-24.04-arm
           - arch-label: AMD64
             arch: amd64
-            go: 1.25
+            go: 1.26
             runs-on: ubuntu-latest
           - arch-label: ARM64
             arch: arm64v8
-            go: 1.25
+            go: 1.26
             runs-on: ubuntu-24.04-arm
     env:
       ARCH: ${{ matrix.arch }}
@@ -88,8 +88,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.24'
           - '1.25'
+          - '1.26'
     env:
       GO: ${{ matrix.go }}
     steps:
@@ -128,8 +128,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.24'
           - '1.25'
+          - '1.26'
     env:
       GO: ${{ matrix.go }}
     steps:
@@ -168,8 +168,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.24'
           - '1.25'
+          - '1.26'
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1
@@ -195,8 +195,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.24'
           - '1.25'
+          - '1.26'
     env:
       ARROW_GO_TESTCGO: "1"
     steps:
@@ -229,8 +229,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - '1.24'
           - '1.25'
+          - '1.26'
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v5.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,7 +329,7 @@ jobs:
     name: TinyGo
     runs-on: ubuntu-latest
     env:
-      TINYGO_VERSION: 0.40.1
+      TINYGO_VERSION: 0.38.0
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@
 
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.4.0
+    rev: v2.11.3
     hooks:
       # no built-in support for multiple go.mod
       # https://github.com/golangci/golangci-lint/issues/828

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@
 
 module github.com/apache/arrow-go/v18
 
-go 1.25.0
+go 1.24.0
 
 require (
 	github.com/andybalholm/brotli v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@
 
 module github.com/apache/arrow-go/v18
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/andybalholm/brotli v1.2.0


### PR DESCRIPTION
### Rationale for this change
We follow the standard go policy of supporting N - 1 where N is the latest version of Go. Several dependencies have already updated to a minimum of go1.25 so we need to do the same.

### What changes are included in this PR?
- Update .env default Go version to 1.25.8
- Update CI workflows to test Go 1.25 and 1.26, removing 1.24:
  - test.yml: Update all test matrices (docker, macos, windows)
  - benchmark.yml: Update to Go 1.26.1
  - lint.yml: Update to Go 1.25

### Are these changes tested?
Yes

### Are there any user-facing changes?
Starting with our next version, our go.mod will list go1.25 as our minimum
