### PR TITLE
chore: pin docker/login-action for ASF allowlist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           submodules: recursive
       - name: Login to GitHub Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -138,7 +138,7 @@ jobs:
         with:
           submodules: recursive
       - name: Login to GitHub Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
### Rationale for this change

CI is failing
Example: https://github.com/apache/arrow-go/actions/runs/23573127399

### What changes are included in this PR?

Pin the actions so they match the ASF allowlist (https://github.com/apache/infrastructure-actions)

### Are these changes tested?

N/A

### Are there any user-facing changes?

No
