### PR TITLE
ci: fix mingw GO_VERSION

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,6 +283,7 @@ jobs:
         run: |
           ci/scripts/msys2_setup.sh
       - name: Get required Go version
+        shell: msys2 {0}
         run: "(. .env && echo \"GO_VERSION=${GO}\") >> $GITHUB_ENV"
       - name: Update CGO Env vars
         shell: msys2 {0}


### PR DESCRIPTION
### Rationale for this change
MingW WIndows build is failing

### What changes are included in this PR?
fix CI steps that sets the GO_VERSION from `.env` into the environment


### Are there any user-facing changes?
CI only
