### PR TITLE
chore: remove mentions of compatibility with go toolchain < go1.18

### DIFF
--- a/arrow/compute/doc.go
+++ b/arrow/compute/doc.go
@@ -15,18 +15,13 @@
 // limitations under the License.
 
 // Package compute is a native-go implementation of an Acero-like
-// arrow compute engine. It requires go1.18+
+// arrow compute engine.
 //
 // While consumers of Arrow that are able to use CGO could utilize the
 // C Data API (using the cdata package) and could link against the
 // acero library directly, there are consumers who cannot use CGO. This
 // is an attempt to provide for those users, and in general create a
 // native-go arrow compute engine.
-//
-// The overwhelming majority of things in this package require go1.18 as
-// it utilizes generics. The files in this package and its sub-packages
-// are all excluded from being built by go versions lower than 1.18 so
-// that the larger Arrow module itself is still compatible with go1.17.
 //
 // Everything in this package should be considered Experimental for now.
 package compute

--- a/arrow/compute/internal/kernels/doc.go
+++ b/arrow/compute/internal/kernels/doc.go
@@ -15,5 +15,5 @@
 // limitations under the License.
 
 // Package kernels defines all of the computation kernels for the compute
-// library. This requires >= go1.18 since it utilizes Go generics.
+// library.
 package kernels

--- a/parquet/doc.go
+++ b/parquet/doc.go
@@ -20,9 +20,6 @@
 // shredding and assembly algorithm to accommodate complex data structures which
 // can then be used to efficiently store the data.
 //
-// While the go.mod states go1.18, everything here should be compatible
-// with go versions 1.17 and 1.16.
-//
 // This implementation is a native go implementation for reading and writing the
 // parquet file format.
 //


### PR DESCRIPTION
The github.com/apache/arrow/go/v11/arrow/compute module was removed in commit f6e34421658726a6e5c98327a7e6b619ae798d34, making it part of the main module. The go version in go.mod was updated to go1.18, but older versions of the go toolchain could still be used;

> Requirements
>
> Despite the go.mod stating go1.18, everything except for the compute package
> is able to be built with go1.17 (and most is also compatible with go1.16).

Before Go 1.21, the go line in go.mod was effectively advisory: older toolchains might still try to build the module, and only complain if they hit something unsupported. Starting with Go 1.21 (backported to go1.19.3 and go1.20.8), the go line became a strict minimum requirement. https://go.dev/doc/go1.21

Commit ddfa8159f9cace619b0da2898c7aea0906393655 updated the go version in go.mod to go1.21.0, no longer allowing older toolchains to be used.

This patch removes the mentions of older toolchains.

### Rationale for this change


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?

