### PR TITLE
fix(parquet): clarify docstring on Close method of FileWriter, proper err output

### DIFF
--- a/parquet/file/file_writer.go
+++ b/parquet/file/file_writer.go
@@ -228,7 +228,8 @@ func (fw *Writer) AppendKeyValueMetadata(key string, value string) error {
 }
 
 // Close closes any open row group writer and writes the file footer. Subsequent
-// calls to close will have no effect.
+// calls to close will have no effect. If the underlying writer implements [io.Closer],
+// then this will also call Close on the underlying writer.
 func (fw *Writer) Close() (err error) {
 	if fw.open {
 		// if any functions here panic, we set open to be false so
@@ -250,7 +251,7 @@ func (fw *Writer) Close() (err error) {
 
 		err = fw.FlushWithFooter()
 	}
-	return nil
+	return
 }
 
 // FileMetadata returns the current state of the FileMetadata that would be written

--- a/parquet/pqarrow/file_writer.go
+++ b/parquet/pqarrow/file_writer.go
@@ -404,7 +404,8 @@ func (fw *FileWriter) AppendKeyValueMetadata(key string, value string) error {
 }
 
 // Close flushes out the data and closes the file. It can be called multiple times,
-// subsequent calls after the first will have no effect.
+// subsequent calls after the first will have no effect. If the underlying writer implements
+// [io.Closer], then this will also call Close on the underlying writer.
 func (fw *FileWriter) Close() error {
 	if !fw.closed {
 		fw.closed = true


### PR DESCRIPTION
### Rationale for this change
Fixes #703

### What changes are included in this PR?
Clarifying the docstrings on the Close methods of the FileWriter and pqarrow.FileWriter

### Are these changes tested?
Documentation changes, no need to test

### Are there any user-facing changes?
No
