### PR TITLE
release: fix syntax error in verify_rc.sh

### DIFF
--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -66,7 +66,7 @@ setup_tmpdir() {
 download() {
   curl \
     --fail \
-    --location \    
+    --location \
     --show-error \
     --silent \
     --output "$2" \


### PR DESCRIPTION
The previous commit didn't fix the issue because \ needs to be the final
character, or at least it does on my system.

Ref: https://github.com/apache/arrow-go/pull/781#issuecomment-4314898385
