### PR TITLE
docs(parquet): correct DefaultDataPageSize comment from 1K to 1M

### DIFF
--- a/parquet/writer_properties.go
+++ b/parquet/writer_properties.go
@@ -27,7 +27,7 @@ import (
 const (
 	// Default Buffer size used for the Reader
 	DefaultBufSize int64 = 4096 * 4
-	// Default data page size limit is 1K it's not guaranteed, but we will try to
+	// Default data page size limit is 1M, it's not guaranteed, but we will try to
 	// cut data pages off at this size where possible.
 	DefaultDataPageSize int64 = 1024 * 1024
 	// Default is for dictionary encoding to be turned on, use WithDictionaryDefault


### PR DESCRIPTION
### Rationale for this change

The doc comment for `DefaultDataPageSize` in `parquet/writer_properties.go` described the value as "1K" when the actual value is `1024 * 1024` = 1M (1 MiB).

### What changes are included in this PR?

Updates the comment so the annotation matches the value.

### Are these changes tested?

This is a comment-only change; no behavior is altered. `go build ./parquet/...` passes.

### Are there any user-facing changes?

No code-behavior changes; only the godoc text for the `DefaultDataPageSize` constant.

Closes #812