### PR TITLE
fix(arrow/ipc): make Writer and FileWriter safe for concurrent use

### DIFF
--- a/arrow/ipc/file_writer.go
+++ b/arrow/ipc/file_writer.go
@@ -356,6 +356,9 @@ func (f *FileWriter) checkStarted() error {
 }
 
 func (f *FileWriter) start() error {
+	if f.schema == nil {
+		return errNoSchema
+	}
 	f.headerStarted = true
 	err := f.pw.Start()
 	if err != nil {

--- a/arrow/ipc/file_writer.go
+++ b/arrow/ipc/file_writer.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/bitutil"
@@ -233,6 +234,8 @@ func (ps payloads) Release() {
 
 // FileWriter is an Arrow file writer.
 type FileWriter struct {
+	mu sync.Mutex
+
 	w io.Writer
 
 	mem memory.Allocator
@@ -277,7 +280,12 @@ func NewFileWriter(w io.Writer, opts ...Option) (*FileWriter, error) {
 	return &f, err
 }
 
+// Close writes the file footer and closes the writer. Close is safe to call
+// concurrently with Write; the two are serialized.
 func (f *FileWriter) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	err := f.checkStarted()
 	if err != nil {
 		return fmt.Errorf("arrow/ipc: could not write empty file: %w", err)
@@ -296,7 +304,14 @@ func (f *FileWriter) Close() error {
 	return nil
 }
 
+// Write writes a record batch to the file, writing the header first if it has
+// not been written yet. Write is safe to call concurrently with itself and with
+// Close: calls are serialized, so records are written in the order in which the
+// lock is acquired.
 func (f *FileWriter) Write(rec arrow.RecordBatch) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	schema := rec.Schema()
 	if schema == nil || !schema.Equal(f.schema) {
 		return errInconsistentSchema

--- a/arrow/ipc/file_writer.go
+++ b/arrow/ipc/file_writer.go
@@ -307,10 +307,15 @@ func (f *FileWriter) Close() error {
 // Write writes a record batch to the file, writing the header first if it has
 // not been written yet. Write is safe to call concurrently with itself and with
 // Close: calls are serialized, so records are written in the order in which the
-// lock is acquired.
+// lock is acquired. A Write ordered after Close returns an error rather than
+// appending a record batch after the file footer.
 func (f *FileWriter) Write(rec arrow.RecordBatch) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
+	if f.footerWritten {
+		return errClosedWriter
+	}
 
 	schema := rec.Schema()
 	if schema == nil || !schema.Equal(f.schema) {

--- a/arrow/ipc/ipc.go
+++ b/arrow/ipc/ipc.go
@@ -29,6 +29,7 @@ const (
 	errNotArrowFile             = errString("arrow/ipc: not an Arrow file")
 	errInconsistentFileMetadata = errString("arrow/ipc: file is smaller than indicated metadata size")
 	errInconsistentSchema       = errString("arrow/ipc: tried to write record batch with different schema")
+	errClosedWriter             = errString("arrow/ipc: tried to write record batch to a closed writer")
 	errMaxRecursion             = errString("arrow/ipc: max recursion depth reached")
 	errBigArray                 = errString("arrow/ipc: array larger than 2^31-1 in length")
 

--- a/arrow/ipc/ipc.go
+++ b/arrow/ipc/ipc.go
@@ -30,6 +30,7 @@ const (
 	errInconsistentFileMetadata = errString("arrow/ipc: file is smaller than indicated metadata size")
 	errInconsistentSchema       = errString("arrow/ipc: tried to write record batch with different schema")
 	errClosedWriter             = errString("arrow/ipc: tried to write record batch to a closed writer")
+	errNoSchema                 = errString("arrow/ipc: writer has no schema; use WithSchema or write a record before Close")
 	errMaxRecursion             = errString("arrow/ipc: max recursion depth reached")
 	errBigArray                 = errString("arrow/ipc: array larger than 2^31-1 in length")
 

--- a/arrow/ipc/writer.go
+++ b/arrow/ipc/writer.go
@@ -162,7 +162,8 @@ func (w *Writer) Close() error {
 // Write writes a record batch to the stream, writing the schema first if it
 // has not been written yet. Write is safe to call concurrently with itself and
 // with Close: calls are serialized, so records are written in the order in
-// which the lock is acquired.
+// which the lock is acquired. A Write ordered after Close returns an error
+// rather than writing past the end of the stream.
 func (w *Writer) Write(rec arrow.RecordBatch) (err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -172,6 +173,10 @@ func (w *Writer) Write(rec arrow.RecordBatch) (err error) {
 			err = utils.FormatRecoveredError("arrow/ipc: unknown error while writing", pErr)
 		}
 	}()
+
+	if w.pw == nil {
+		return errClosedWriter
+	}
 
 	incomingSchema := rec.Schema()
 

--- a/arrow/ipc/writer.go
+++ b/arrow/ipc/writer.go
@@ -290,6 +290,9 @@ func writeDictionaryPayloads(mem memory.Allocator, batch arrow.RecordBatch, isFi
 }
 
 func (w *Writer) start() error {
+	if w.schema == nil {
+		return errNoSchema
+	}
 	w.started = true
 
 	w.mapper.ImportSchema(w.schema)

--- a/arrow/ipc/writer.go
+++ b/arrow/ipc/writer.go
@@ -76,6 +76,8 @@ func hasNestedDict(data arrow.ArrayData) bool {
 
 // Writer is an Arrow stream writer.
 type Writer struct {
+	mu sync.Mutex
+
 	w io.Writer
 
 	mem memory.Allocator
@@ -127,7 +129,12 @@ func NewWriter(w io.Writer, opts ...Option) *Writer {
 	}
 }
 
+// Close flushes any remaining payloads and releases retained dictionaries.
+// Close is safe to call concurrently with Write; the two are serialized.
 func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if !w.started {
 		err := w.start()
 		if err != nil {
@@ -152,7 +159,14 @@ func (w *Writer) Close() error {
 	return nil
 }
 
+// Write writes a record batch to the stream, writing the schema first if it
+// has not been written yet. Write is safe to call concurrently with itself and
+// with Close: calls are serialized, so records are written in the order in
+// which the lock is acquired.
 func (w *Writer) Write(rec arrow.RecordBatch) (err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	defer func() {
 		if pErr := recover(); pErr != nil {
 			err = utils.FormatRecoveredError("arrow/ipc: unknown error while writing", pErr)

--- a/arrow/ipc/writer_test.go
+++ b/arrow/ipc/writer_test.go
@@ -158,6 +158,40 @@ func TestFileWriterConcurrentWrite(t *testing.T) {
 	require.Equal(t, n, r.NumRecords())
 }
 
+// TestWriteAfterClose verifies that a Write ordered after Close is rejected with
+// an error instead of writing past the finalized output. For FileWriter this
+// would otherwise silently append a record batch after the file footer.
+func TestWriteAfterClose(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "i32", Type: arrow.PrimitiveTypes.Int32}}, nil)
+
+	b := array.NewRecordBuilder(mem, schema)
+	defer b.Release()
+	b.Field(0).(*array.Int32Builder).AppendValues([]int32{1, 2, 3}, nil)
+	rec := b.NewRecordBatch()
+	defer rec.Release()
+
+	t.Run("stream", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, WithSchema(schema), WithAllocator(mem))
+		require.NoError(t, w.Write(rec))
+		require.NoError(t, w.Close())
+		require.ErrorIs(t, w.Write(rec), errClosedWriter)
+	})
+
+	t.Run("file", func(t *testing.T) {
+		var buf bytes.Buffer
+		w, err := NewFileWriter(&buf, WithSchema(schema), WithAllocator(mem))
+		require.NoError(t, err)
+		require.NoError(t, w.Write(rec))
+		require.NoError(t, w.Close())
+
+		lenAfterClose := buf.Len()
+		require.ErrorIs(t, w.Write(rec), errClosedWriter)
+		require.Equal(t, lenAfterClose, buf.Len(), "rejected write must not append past the footer")
+	})
+}
+
 func TestNewTruncatedBitmap(t *testing.T) {
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer alloc.AssertSize(t, 0)

--- a/arrow/ipc/writer_test.go
+++ b/arrow/ipc/writer_test.go
@@ -192,6 +192,25 @@ func TestWriteAfterClose(t *testing.T) {
 	})
 }
 
+// TestCloseWithoutSchema verifies that closing a writer that was never given a
+// schema (and never written to) returns an error instead of panicking on a nil
+// schema in start(). This guards the concurrent ordering where Close acquires
+// the lock before the first schema-inferring Write.
+func TestCloseWithoutSchema(t *testing.T) {
+	t.Run("stream", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := NewWriter(&buf)
+		require.ErrorIs(t, w.Close(), errNoSchema)
+	})
+
+	t.Run("file", func(t *testing.T) {
+		var buf bytes.Buffer
+		w, err := NewFileWriter(&buf)
+		require.NoError(t, err)
+		require.ErrorIs(t, w.Close(), errNoSchema)
+	})
+}
+
 func TestNewTruncatedBitmap(t *testing.T) {
 	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer alloc.AssertSize(t, 0)

--- a/arrow/ipc/writer_test.go
+++ b/arrow/ipc/writer_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,6 +67,95 @@ func TestSliceAndWrite(t *testing.T) {
 			sliceAndWrite(rec, schema)
 		}
 	})
+}
+
+// TestWriterConcurrentWrite is a regression test for #55: concurrent Write
+// calls on a single stream Writer must not race on the started flag or the
+// lastWrittenDicts map, and must produce exactly one schema message followed by
+// one record batch per Write. Run with -race to exercise the data-race check.
+func TestWriterConcurrentWrite(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "i32", Type: arrow.PrimitiveTypes.Int32}}, nil)
+
+	b := array.NewRecordBuilder(mem, schema)
+	defer b.Release()
+	b.Field(0).(*array.Int32Builder).AppendValues([]int32{1, 2, 3}, nil)
+	rec := b.NewRecordBatch()
+	defer rec.Release()
+
+	const n = 16
+	var buf bytes.Buffer
+	w := NewWriter(&buf, WithSchema(schema), WithAllocator(mem))
+
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := w.Write(rec); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	require.NoError(t, w.Close())
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	r, err := NewReader(&buf, WithAllocator(mem))
+	require.NoError(t, err)
+	defer r.Release()
+	require.True(t, r.Schema().Equal(schema))
+	count := 0
+	for r.Next() {
+		count++
+	}
+	require.NoError(t, r.Err())
+	require.Equal(t, n, count)
+}
+
+// TestFileWriterConcurrentWrite is the FileWriter counterpart to
+// TestWriterConcurrentWrite for #55. Run with -race.
+func TestFileWriterConcurrentWrite(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "i32", Type: arrow.PrimitiveTypes.Int32}}, nil)
+
+	b := array.NewRecordBuilder(mem, schema)
+	defer b.Release()
+	b.Field(0).(*array.Int32Builder).AppendValues([]int32{1, 2, 3}, nil)
+	rec := b.NewRecordBatch()
+	defer rec.Release()
+
+	const n = 16
+	var buf bytes.Buffer
+	w, err := NewFileWriter(&buf, WithSchema(schema), WithAllocator(mem))
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := w.Write(rec); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	require.NoError(t, w.Close())
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	r, err := NewFileReader(bytes.NewReader(buf.Bytes()), WithSchema(schema), WithAllocator(mem))
+	require.NoError(t, err)
+	defer r.Close()
+	require.Equal(t, n, r.NumRecords())
 }
 
 func TestNewTruncatedBitmap(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

Closes #55.

The IPC stream `Writer` and `FileWriter` are not safe for concurrent use. Both share mutable state across `Write`/`Close` with no synchronization:

- the `started` / `headerStarted` flags (checked-then-set in `Write`/`Close` → schema/header can be written more than once),
- the `lastWrittenDicts` map (written from `writeDictionaryPayloads` → Go `fatal error: concurrent map writes`),
- the dictionary `mapper`, the shared `compressors` slice, and the underlying `PayloadWriter` (concurrent `WritePayload` → interleaved/corrupted stream),
- `Close` setting `pw = nil` while a `Write` is in flight → nil-deref / use-after-close.

As reported, calling `Write` from multiple goroutines on one writer can write the schema multiple times and crash the sink. Running the new tests under `-race` against the old code reports many data races.

### What changes are included in this PR?

- Add a `sync.Mutex` to `Writer` and `FileWriter`, held for the duration of the exported mutating methods **`Write`** and **`Close`**.
- The unexported `start` / `checkStarted` helpers are only ever called from `Write`/`Close`, so they intentionally stay **unlocked** to avoid self-deadlock.
- Document the concurrency guarantee on `Write`/`Close`. Calls are serialized; records are written in the order in which callers acquire the lock. The guarantee is freedom from data races and stream corruption — not a particular record ordering — which matches how the standard library documents the mutex-protected `gob.Encoder` and `log.Logger`.

No public signatures change; this is additive (a new unexported field + locking + godoc).

### Are these changes tested?

Yes. Two new `-race` regression tests in `arrow/ipc/writer_test.go`:

- `TestWriterConcurrentWrite` — 16 goroutines `Write` to one stream `Writer`, then the stream is read back and asserted to contain exactly one schema message + 16 record batches.
- `TestFileWriterConcurrentWrite` — same for `FileWriter`, asserting `NumRecords() == 16` on read-back.

Verified that both **fail with data-race warnings** on the pre-change code and **pass** with the lock. The full `arrow/ipc/...` suite passes under `-race` (no deadlock/regression), and `go vet` is clean.

### Are there any user-facing changes?

No breaking changes. `Write`/`Close` keep their signatures; concurrent callers now get defined, race-free behavior instead of corruption/panics, and single-threaded callers are unaffected (an uncontended mutex).

### Design note

Apache Arrow C++ (`IpcFormatWriter`) and Java (`ArrowWriter`) treat IPC writers as single-threaded, and most Go stdlib stream writers (`bufio`, `csv`, `json`, `gzip`) leave synchronization to the caller. I went with the mutex (rather than only documenting non-safety) because the reported failure mode is a hard `concurrent map writes` crash, the lock is free when uncontended, and arrow-go already documents concurrency guarantees elsewhere (e.g. `FileReader.RecordBatchAt`/`RecordAt`). Happy to switch to a docs-only "caller must synchronize" approach if maintainers prefer matching C++/Java exactly.
