### PR TITLE
feat(parquet): add experimental VECTOR repetition for Arrow FixedSizeList

### DIFF
--- a/parquet/file/column_reader.go
+++ b/parquet/file/column_reader.go
@@ -118,6 +118,11 @@ type ColumnChunkReader interface {
 	Err() error
 
 	SeekToRow(rowIdx int64) error
+	// seekToRowWithValueStride seeks to rowIdx using row-group row ordinals but
+	// positions the value decoder at rowIdx*valueStride physical values. This is
+	// used by leaf-only VECTOR columns where one logical row contributes a fixed
+	// number of primitive leaf values.
+	seekToRowWithValueStride(rowIdx, valueStride int64) error
 
 	// Skip buffered values
 	consumeBufferedValues(int64)
@@ -579,7 +584,7 @@ func (c *columnChunkReader) determineNumToRead(batchLen int64, defLvls, repLvls 
 // finds the page that contains the desired row index, and the Column Chunk
 // reader will discard values until it reaches the desired row index according
 // to the definition and repetition levels.
-func (c *columnChunkReader) SeekToRow(rowIdx int64) error {
+func (c *columnChunkReader) seekToPageForRow(rowIdx int64) error {
 	if err := c.pager().SeekToPageWithRow(rowIdx); err != nil {
 		return err
 	}
@@ -591,17 +596,131 @@ func (c *columnChunkReader) SeekToRow(rowIdx int64) error {
 		return c.err
 	}
 
-	gotDataPage, err := c.processPage()
-	if err != nil {
-		c.err = err
-		return err
+	// A seek rewinds to the start of the column chunk (SeekToPageWithRow), which
+	// re-streams the dictionary page. The dictionary is configured once per
+	// chunk, so an already-configured dictionary page is skipped here rather than
+	// re-read (configureDict would reject it as a second dictionary); readNewPage
+	// then advances to the first data page. The "more than one dictionary" guard
+	// still applies on the normal forward-read path through readNewPage.
+	gotDataPage := false
+	if _, isDict := c.curPage.(*DictionaryPage); !isDict || c.dictState == dictNotRead {
+		var err error
+		if gotDataPage, err = c.processPage(); err != nil {
+			c.err = err
+			return err
+		}
 	}
 
 	if !gotDataPage {
 		c.readNewPage()
 	}
+	return c.err
+}
 
+func (c *columnChunkReader) SeekToRow(rowIdx int64) error {
+	if c.descr.InVectorColumn() {
+		// VECTOR columns (Option B) contribute EffectiveVectorLength leaf values
+		// per row and carry no per-element levels, so a row ordinal maps to a
+		// fixed value stride. skipRows would otherwise treat one leaf slot as one
+		// row and undershoot the seek by a factor of the vector length.
+		return c.seekToRowWithValueStride(rowIdx, int64(c.descr.EffectiveVectorLength()))
+	}
+	if err := c.seekToPageForRow(rowIdx); err != nil {
+		return err
+	}
 	return c.skipRows(rowIdx - c.curPage.(DataPage).FirstRowIndex())
+}
+
+func (c *columnChunkReader) hasOffsetIndex() bool {
+	spr, ok := c.rdr.(*serializedPageReader)
+	if !ok || spr.pgIndexReader == nil {
+		return false
+	}
+	oidx, err := spr.pgIndexReader.GetOffsetIndex(spr.colIdx)
+	return err == nil && oidx != nil
+}
+
+func (c *columnChunkReader) seekToRowWithValueStride(rowIdx, valueStride int64) error {
+	if rowIdx < 0 {
+		return fmt.Errorf("parquet: cannot seek column reader to row index %d", rowIdx)
+	}
+	if valueStride <= 0 {
+		return fmt.Errorf("parquet: invalid value stride %d", valueStride)
+	}
+	valuesToSkip, ok := utils.Mul64(rowIdx, valueStride)
+	if !ok {
+		return errors.New("parquet: seek value offset overflow")
+	}
+	if spr, ok := c.rdr.(*serializedPageReader); ok {
+		if spr.nrows%valueStride != 0 {
+			return fmt.Errorf("parquet: VECTOR column chunk has %d values, not a multiple of vector length %d", spr.nrows, valueStride)
+		}
+		if spr.parentRows > 0 {
+			if rowIdx >= spr.parentRows {
+				return fmt.Errorf("parquet: cannot seek column reader to row index %d", rowIdx)
+			}
+		} else if valuesToSkip < 0 || valuesToSkip >= spr.nrows {
+			return fmt.Errorf("parquet: cannot seek column reader to row index %d", rowIdx)
+		}
+	}
+
+	// Use page-level seeking when page row ordinals are known to be parent rows:
+	// DataPageV2 stores num_rows, and V1 is reliable when an offset index supplies
+	// first_row_index. V1 pages without an offset index only expose num_values
+	// (leaf slots), so fall back to row-group-local value skipping below.
+	if err := c.seekToPageForRow(rowIdx); err != nil {
+		return err
+	}
+	page := c.curPage.(DataPage)
+	pageFirstRow := page.FirstRowIndex()
+	if _, ok := page.(*DataPageV2); ok || c.hasOffsetIndex() {
+		if pageFirstRow <= rowIdx {
+			pageValuesToSkip, ok := utils.Mul64(rowIdx-pageFirstRow, valueStride)
+			if !ok {
+				return errors.New("parquet: seek page value offset overflow")
+			}
+			return c.skipValues(pageValuesToSkip)
+		}
+	}
+
+	// The caller has already selected the row group by parent row. Reset to the
+	// start of that row group before skipping leaf values. This is the universally
+	// correct path for V1 pages without an offset index.
+	if err := c.seekToPageForRow(0); err != nil {
+		return err
+	}
+	return c.skipValues(valuesToSkip)
+}
+
+func (c *columnChunkReader) skipValues(nvalues int64) error {
+	toSkip := nvalues
+	for c.HasNext() && toSkip > 0 {
+		available := c.numBuffered - c.numDecoded
+		if available <= 0 {
+			continue
+		}
+		if toSkip >= available {
+			toSkip -= available
+			c.consumeBufferedValues(available)
+			continue
+		}
+
+		skipped, err := c.curDecoder.Discard(int(toSkip))
+		if err != nil {
+			c.err = err
+			return err
+		}
+		if skipped <= 0 {
+			c.err = errors.New("parquet: decoder did not discard any values")
+			return c.err
+		}
+		toSkip -= int64(skipped)
+		c.consumeBufferedValues(int64(skipped))
+	}
+	if toSkip > 0 {
+		return fmt.Errorf("parquet: cannot seek past end of column chunk, %d values remaining", toSkip)
+	}
+	return c.err
 }
 
 func (c *columnChunkReader) skipRows(nrows int64) error {

--- a/parquet/file/column_reader.go
+++ b/parquet/file/column_reader.go
@@ -576,14 +576,9 @@ func (c *columnChunkReader) determineNumToRead(batchLen int64, defLvls, repLvls 
 	return
 }
 
-// SeekToRow will seek to the row index provided in the column chunk. If
-// the metadata contains an OffsetIndex for skipping pages based on row indexes
-// then the pager will use that to skip to the correct page.
-//
-// If there is no OffsetIndex, then the pager will read each page until it
-// finds the page that contains the desired row index, and the Column Chunk
-// reader will discard values until it reaches the desired row index according
-// to the definition and repetition levels.
+// seekToPageForRow seeks the page reader to the page containing rowIdx and
+// initializes the current data page. If seeking replays an already-read
+// dictionary page, it skips reconfiguration and advances to the next data page.
 func (c *columnChunkReader) seekToPageForRow(rowIdx int64) error {
 	if err := c.pager().SeekToPageWithRow(rowIdx); err != nil {
 		return err
@@ -596,12 +591,6 @@ func (c *columnChunkReader) seekToPageForRow(rowIdx int64) error {
 		return c.err
 	}
 
-	// A seek rewinds to the start of the column chunk (SeekToPageWithRow), which
-	// re-streams the dictionary page. The dictionary is configured once per
-	// chunk, so an already-configured dictionary page is skipped here rather than
-	// re-read (configureDict would reject it as a second dictionary); readNewPage
-	// then advances to the first data page. The "more than one dictionary" guard
-	// still applies on the normal forward-read path through readNewPage.
 	gotDataPage := false
 	if _, isDict := c.curPage.(*DictionaryPage); !isDict || c.dictState == dictNotRead {
 		var err error
@@ -617,9 +606,17 @@ func (c *columnChunkReader) seekToPageForRow(rowIdx int64) error {
 	return c.err
 }
 
+// SeekToRow will seek to the row index provided in the column chunk. If
+// the metadata contains an OffsetIndex for skipping pages based on row indexes
+// then the pager will use that to skip to the correct page.
+//
+// If there is no OffsetIndex, then the pager will read each page until it
+// finds the page that contains the desired row index, and the Column Chunk
+// reader will discard values until it reaches the desired row index according
+// to the definition and repetition levels.
 func (c *columnChunkReader) SeekToRow(rowIdx int64) error {
 	if c.descr.InVectorColumn() {
-		// VECTOR columns (Option B) contribute EffectiveVectorLength leaf values
+		// VECTOR columns contribute EffectiveVectorLength leaf values
 		// per row and carry no per-element levels, so a row ordinal maps to a
 		// fixed value stride. skipRows would otherwise treat one leaf slot as one
 		// row and undershoot the seek by a factor of the vector length.

--- a/parquet/file/column_reader.go
+++ b/parquet/file/column_reader.go
@@ -120,8 +120,8 @@ type ColumnChunkReader interface {
 	SeekToRow(rowIdx int64) error
 	// seekToRowWithValueStride seeks to rowIdx using row-group row ordinals but
 	// positions the value decoder at rowIdx*valueStride physical values. This is
-	// used by leaf-only VECTOR columns where one logical row contributes a fixed
-	// number of primitive leaf values.
+	// used by VECTOR columns where one logical row contributes a fixed number of
+	// primitive leaf values.
 	seekToRowWithValueStride(rowIdx, valueStride int64) error
 
 	// Skip buffered values

--- a/parquet/file/column_writer.go
+++ b/parquet/file/column_writer.go
@@ -656,9 +656,9 @@ func (w *columnWriter) Close() (err error) {
 }
 
 // rowsForLeafValues converts a count of physical leaf values (slots) to the
-// number of parent rows they represent. For VECTOR columns (Option B) each row
-// contributes effectiveVectorLength leaf slots; for every other column each leaf
-// value is exactly one row at this nesting level. VECTOR page/column statistics
+// number of parent rows they represent. For VECTOR columns each row contributes
+// effectiveVectorLength leaf slots; for every other column each leaf value is
+// exactly one row at this nesting level. VECTOR page/column statistics
 // intentionally remain flattened element-level statistics, not vector-level or
 // lexicographic-vector ordering statistics.
 func (w *columnWriter) rowsForLeafValues(numLeafValues int64) int {
@@ -669,9 +669,9 @@ func (w *columnWriter) rowsForLeafValues(numLeafValues int64) int {
 }
 
 // ErrVectorBatchMisaligned is returned by the typed column writers when a VECTOR
-// column (Option B) is handed a batch whose physical leaf-value count is not a
-// whole multiple of the column's vector_length. A vector value must be written
-// in one piece, so partial vectors are rejected up front.
+// column is handed a batch whose physical leaf-value count is not a whole
+// multiple of the column's vector_length. A vector value must be written in one
+// piece, so partial vectors are rejected up front.
 var ErrVectorBatchMisaligned = errors.New("parquet: VECTOR columns must be written in whole-vector batches")
 
 // validateVectorBatch checks, before any values are written, that n physical

--- a/parquet/file/column_writer.go
+++ b/parquet/file/column_writer.go
@@ -490,8 +490,9 @@ func (w *columnWriter) writeLevels(numValues int64, defLevels, repLevels []int16
 
 		w.WriteRepetitionLevels(repLevels[:numValues])
 	} else {
-		// each value is exactly 1 row
-		w.numBufferedRows += int(numValues)
+		// each value is exactly 1 row, except for VECTOR columns where each row
+		// spans effectiveVectorLength leaf slots
+		w.numBufferedRows += w.rowsForLeafValues(numValues)
 	}
 	return toWrite
 }
@@ -509,7 +510,7 @@ func (w *columnWriter) writeLevelsSpaced(numLevels int64, defLevels, repLevels [
 		}
 		w.WriteRepetitionLevels(repLevels[:numLevels])
 	} else {
-		w.numBufferedRows += int(numLevels)
+		w.numBufferedRows += w.rowsForLeafValues(numLevels)
 	}
 }
 
@@ -654,8 +655,84 @@ func (w *columnWriter) Close() (err error) {
 	return err
 }
 
+// rowsForLeafValues converts a count of physical leaf values (slots) to the
+// number of parent rows they represent. For VECTOR columns (Option B) each row
+// contributes effectiveVectorLength leaf slots; for every other column each leaf
+// value is exactly one row at this nesting level. VECTOR page/column statistics
+// intentionally remain flattened element-level statistics, not vector-level or
+// lexicographic-vector ordering statistics.
+func (w *columnWriter) rowsForLeafValues(numLeafValues int64) int {
+	if vectorLen := w.vectorLengthForBatch(numLeafValues); vectorLen > 0 {
+		return int(numLeafValues / vectorLen)
+	}
+	return int(numLeafValues)
+}
+
+// ErrVectorBatchMisaligned is returned by the typed column writers when a VECTOR
+// column (Option B) is handed a batch whose physical leaf-value count is not a
+// whole multiple of the column's vector_length. A vector value must be written
+// in one piece, so partial vectors are rejected up front.
+var ErrVectorBatchMisaligned = errors.New("parquet: VECTOR columns must be written in whole-vector batches")
+
+// validateVectorBatch checks, before any values are written, that n physical
+// leaf values form whole vectors for a VECTOR column. It is a no-op for every
+// other column. Validating here lets the public WriteBatch/WriteBatchSpaced
+// methods return ErrVectorBatchMisaligned directly instead of surfacing the
+// internal vectorLengthForBatch panic as a recovered "unknown error type".
+func (w *columnWriter) validateVectorBatch(n int64) error {
+	if !w.descr.InVectorColumn() {
+		return nil
+	}
+	vectorLen := int64(w.descr.EffectiveVectorLength())
+	if vectorLen <= 0 || n%vectorLen != 0 {
+		return fmt.Errorf("%w: %d values is not a multiple of vector_length %d", ErrVectorBatchMisaligned, n, vectorLen)
+	}
+	return nil
+}
+
+func (w *columnWriter) vectorLengthForBatch(total int64) int64 {
+	if !w.descr.InVectorColumn() {
+		return 0
+	}
+	vectorLen := int64(w.descr.EffectiveVectorLength())
+	if vectorLen <= 0 || total%vectorLen != 0 {
+		// Unreachable on the public path: WriteBatch/WriteBatchSpaced call
+		// validateVectorBatch up front. Kept as an internal invariant guard.
+		panic(ErrVectorBatchMisaligned)
+	}
+	return vectorLen
+}
+
+func alignBatchToVector(batch, vectorLen int64) int64 {
+	if vectorLen <= 0 {
+		return batch
+	}
+	if aligned := batch - batch%vectorLen; aligned >= vectorLen {
+		return aligned
+	}
+	return vectorLen
+}
+
+func (w *columnWriter) doBatchesAlignedForVector(total int64, repLevels []int16, action func(offset, batch int64)) {
+	if w.descr.InVectorColumn() {
+		w.doBatches(total, repLevels, action)
+		return
+	}
+	doBatches(total, w.props.WriteBatchSize(), action)
+}
+
 func (w *columnWriter) doBatches(total int64, repLevels []int16, action func(offset, batch int64)) {
 	batchSize := w.props.WriteBatchSize()
+	// VECTOR columns: a vector value occupies effectiveVectorLength contiguous
+	// leaf slots and must not be split across data pages. Page flushes are
+	// evaluated once per batch, so batching on whole-vector boundaries keeps
+	// every page boundary on a whole-vector boundary. (VECTOR columns have
+	// max repetition level 0, so without this they would fall into the plain
+	// batching path below and could split a vector across pages.)
+	if vectorLen := w.vectorLengthForBatch(total); vectorLen > 0 {
+		doBatches(total, alignBatchToVector(batchSize, vectorLen), action)
+		return
+	}
 	// if we're writing V1 data pages, have no replevels or the max replevel is 0 then just
 	// use the regular doBatches function
 	if w.props.DataPageVersion() == parquet.DataPageV1 || repLevels == nil || w.descr.MaxRepetitionLevel() == 0 {

--- a/parquet/file/column_writer_types.gen.go
+++ b/parquet/file/column_writer_types.gen.go
@@ -1892,11 +1892,11 @@ func (w *ByteArrayColumnChunkWriter) WriteBatch(values []parquet.ByteArray, defL
 	maxDefLevel := w.descr.MaxDefinitionLevel()
 	isV2WithRep := w.props.DataPageVersion() != parquet.DataPageV1 &&
 		repLevels != nil && w.descr.MaxRepetitionLevel() > 0
-	// VECTOR columns contribute a fixed number of leaf slots per row and carry no
-	// per-element levels. Every batch must cover whole vectors so a vector value
-	// is never split across data pages and rowsForLeafValues only ever sees
-	// whole-vector counts. vectorLen is 0 for non-VECTOR columns, which leaves
-	// the batching below unchanged.
+	// VECTOR columns contribute a fixed number of leaf slots per row
+	// and carry no per-element levels. Every batch must cover whole vectors so a
+	// vector value is never split across data pages and rowsForLeafValues only
+	// ever sees whole-vector counts. vectorLen is 0 for non-VECTOR columns, which
+	// leaves the batching below unchanged.
 	vectorLen := w.vectorLengthForBatch(n)
 	batchSize = alignBatchToVector(batchSize, vectorLen)
 	levelOffset := int64(0)
@@ -2248,11 +2248,11 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatch(values []parquet.FixedLe
 	maxDefLevel := w.descr.MaxDefinitionLevel()
 	isV2WithRep := w.props.DataPageVersion() != parquet.DataPageV1 &&
 		repLevels != nil && w.descr.MaxRepetitionLevel() > 0
-	// VECTOR columns contribute a fixed number of leaf slots per row and carry no
-	// per-element levels. Every batch must cover whole vectors so a vector value
-	// is never split across data pages and rowsForLeafValues only ever sees
-	// whole-vector counts. vectorLen is 0 for non-VECTOR columns, which leaves
-	// the batching below unchanged.
+	// VECTOR columns contribute a fixed number of leaf slots per row
+	// and carry no per-element levels. Every batch must cover whole vectors so a
+	// vector value is never split across data pages and rowsForLeafValues only
+	// ever sees whole-vector counts. vectorLen is 0 for non-VECTOR columns, which
+	// leaves the batching below unchanged.
 	vectorLen := w.vectorLengthForBatch(n)
 	batchSize = alignBatchToVector(batchSize, vectorLen)
 	levelOffset := int64(0)

--- a/parquet/file/column_writer_types.gen.go
+++ b/parquet/file/column_writer_types.gen.go
@@ -1892,11 +1892,11 @@ func (w *ByteArrayColumnChunkWriter) WriteBatch(values []parquet.ByteArray, defL
 	maxDefLevel := w.descr.MaxDefinitionLevel()
 	isV2WithRep := w.props.DataPageVersion() != parquet.DataPageV1 &&
 		repLevels != nil && w.descr.MaxRepetitionLevel() > 0
-	// VECTOR columns (Option B) contribute a fixed number of leaf slots per row
-	// and carry no per-element levels. Every batch must cover whole vectors so a
-	// vector value is never split across data pages and rowsForLeafValues only
-	// ever sees whole-vector counts. vectorLen is 0 for non-VECTOR columns, which
-	// leaves the batching below unchanged.
+	// VECTOR columns contribute a fixed number of leaf slots per row and carry no
+	// per-element levels. Every batch must cover whole vectors so a vector value
+	// is never split across data pages and rowsForLeafValues only ever sees
+	// whole-vector counts. vectorLen is 0 for non-VECTOR columns, which leaves
+	// the batching below unchanged.
 	vectorLen := w.vectorLengthForBatch(n)
 	batchSize = alignBatchToVector(batchSize, vectorLen)
 	levelOffset := int64(0)
@@ -2248,11 +2248,11 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatch(values []parquet.FixedLe
 	maxDefLevel := w.descr.MaxDefinitionLevel()
 	isV2WithRep := w.props.DataPageVersion() != parquet.DataPageV1 &&
 		repLevels != nil && w.descr.MaxRepetitionLevel() > 0
-	// VECTOR columns (Option B) contribute a fixed number of leaf slots per row
-	// and carry no per-element levels. Every batch must cover whole vectors so a
-	// vector value is never split across data pages and rowsForLeafValues only
-	// ever sees whole-vector counts. vectorLen is 0 for non-VECTOR columns, which
-	// leaves the batching below unchanged.
+	// VECTOR columns contribute a fixed number of leaf slots per row and carry no
+	// per-element levels. Every batch must cover whole vectors so a vector value
+	// is never split across data pages and rowsForLeafValues only ever sees
+	// whole-vector counts. vectorLen is 0 for non-VECTOR columns, which leaves
+	// the batching below unchanged.
 	vectorLen := w.vectorLengthForBatch(n)
 	batchSize = alignBatchToVector(batchSize, vectorLen)
 	levelOffset := int64(0)

--- a/parquet/file/column_writer_types.gen.go
+++ b/parquet/file/column_writer_types.gen.go
@@ -81,6 +81,12 @@ func (w *Int32ColumnChunkWriter) WriteBatch(values []int32, defLevels, repLevels
 	case values != nil:
 		n = int64(len(values))
 	}
+	// VECTOR columns reject a partial-vector batch up front so callers get a typed
+	// error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+	// the write path. No-op for every other column.
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
+	}
 	w.doBatches(n, repLevels, func(offset, batch int64) {
 		var vals []int32
 
@@ -139,7 +145,10 @@ func (w *Int32ColumnChunkWriter) WriteBatchSpacedWithError(values []int32, defLe
 	if defLevels == nil {
 		length = len(values)
 	}
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		var vals []int32
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
@@ -175,10 +184,13 @@ func (w *Int32ColumnChunkWriter) WriteDictIndices(indices arrow.Array, defLevels
 	if defLevels == nil {
 		length = indices.Len()
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return err
+	}
 
 	dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 
@@ -343,6 +355,12 @@ func (w *Int64ColumnChunkWriter) WriteBatch(values []int64, defLevels, repLevels
 	case values != nil:
 		n = int64(len(values))
 	}
+	// VECTOR columns reject a partial-vector batch up front so callers get a typed
+	// error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+	// the write path. No-op for every other column.
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
+	}
 	w.doBatches(n, repLevels, func(offset, batch int64) {
 		var vals []int64
 
@@ -401,7 +419,10 @@ func (w *Int64ColumnChunkWriter) WriteBatchSpacedWithError(values []int64, defLe
 	if defLevels == nil {
 		length = len(values)
 	}
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		var vals []int64
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
@@ -437,10 +458,13 @@ func (w *Int64ColumnChunkWriter) WriteDictIndices(indices arrow.Array, defLevels
 	if defLevels == nil {
 		length = indices.Len()
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return err
+	}
 
 	dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 
@@ -605,6 +629,12 @@ func (w *Int96ColumnChunkWriter) WriteBatch(values []parquet.Int96, defLevels, r
 	case values != nil:
 		n = int64(len(values))
 	}
+	// VECTOR columns reject a partial-vector batch up front so callers get a typed
+	// error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+	// the write path. No-op for every other column.
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
+	}
 	w.doBatches(n, repLevels, func(offset, batch int64) {
 		var vals []parquet.Int96
 
@@ -663,7 +693,10 @@ func (w *Int96ColumnChunkWriter) WriteBatchSpacedWithError(values []parquet.Int9
 	if defLevels == nil {
 		length = len(values)
 	}
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		var vals []parquet.Int96
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
@@ -699,10 +732,13 @@ func (w *Int96ColumnChunkWriter) WriteDictIndices(indices arrow.Array, defLevels
 	if defLevels == nil {
 		length = indices.Len()
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return err
+	}
 
 	dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 
@@ -867,6 +903,12 @@ func (w *Float32ColumnChunkWriter) WriteBatch(values []float32, defLevels, repLe
 	case values != nil:
 		n = int64(len(values))
 	}
+	// VECTOR columns reject a partial-vector batch up front so callers get a typed
+	// error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+	// the write path. No-op for every other column.
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
+	}
 	w.doBatches(n, repLevels, func(offset, batch int64) {
 		var vals []float32
 
@@ -925,7 +967,10 @@ func (w *Float32ColumnChunkWriter) WriteBatchSpacedWithError(values []float32, d
 	if defLevels == nil {
 		length = len(values)
 	}
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		var vals []float32
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
@@ -961,10 +1006,13 @@ func (w *Float32ColumnChunkWriter) WriteDictIndices(indices arrow.Array, defLeve
 	if defLevels == nil {
 		length = indices.Len()
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return err
+	}
 
 	dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 
@@ -1129,6 +1177,12 @@ func (w *Float64ColumnChunkWriter) WriteBatch(values []float64, defLevels, repLe
 	case values != nil:
 		n = int64(len(values))
 	}
+	// VECTOR columns reject a partial-vector batch up front so callers get a typed
+	// error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+	// the write path. No-op for every other column.
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
+	}
 	w.doBatches(n, repLevels, func(offset, batch int64) {
 		var vals []float64
 
@@ -1187,7 +1241,10 @@ func (w *Float64ColumnChunkWriter) WriteBatchSpacedWithError(values []float64, d
 	if defLevels == nil {
 		length = len(values)
 	}
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		var vals []float64
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
@@ -1223,10 +1280,13 @@ func (w *Float64ColumnChunkWriter) WriteDictIndices(indices arrow.Array, defLeve
 	if defLevels == nil {
 		length = indices.Len()
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return err
+	}
 
 	dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 
@@ -1394,6 +1454,12 @@ func (w *BooleanColumnChunkWriter) WriteBatch(values []bool, defLevels, repLevel
 	case values != nil:
 		n = int64(len(values))
 	}
+	// VECTOR columns reject a partial-vector batch up front so callers get a typed
+	// error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+	// the write path. No-op for every other column.
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
+	}
 	w.doBatches(n, repLevels, func(offset, batch int64) {
 		var vals []bool
 
@@ -1452,7 +1518,10 @@ func (w *BooleanColumnChunkWriter) WriteBatchSpacedWithError(values []bool, defL
 	if defLevels == nil {
 		length = len(values)
 	}
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		var vals []bool
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
@@ -1492,6 +1561,9 @@ func (w *BooleanColumnChunkWriter) WriteBitmapBatch(bitmap []byte, bitmapOffset 
 		n = int64(len(defLevels))
 	default:
 		n = int64(numValues)
+	}
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
 	}
 
 	w.doBatches(n, repLevels, func(offset, batch int64) {
@@ -1534,8 +1606,11 @@ func (w *BooleanColumnChunkWriter) WriteBitmapBatchSpacedWithError(bitmap []byte
 	if defLevels == nil {
 		length = numValues
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
@@ -1568,10 +1643,13 @@ func (w *BooleanColumnChunkWriter) WriteDictIndices(indices arrow.Array, defLeve
 	if defLevels == nil {
 		length = indices.Len()
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return err
+	}
 
 	dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 
@@ -1799,6 +1877,12 @@ func (w *ByteArrayColumnChunkWriter) WriteBatch(values []parquet.ByteArray, defL
 	case values != nil:
 		n = int64(len(values))
 	}
+	// VECTOR columns reject a partial-vector batch up front so callers get a typed
+	// error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+	// the write path. No-op for every other column.
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
+	}
 	// For variable-length types, we use adaptive batch sizing to ensure
 	// each batch's encoded data stays well within int32 range. This prevents
 	// overflow in FlushCurrentPage when computing uncompressed page size.
@@ -1808,6 +1892,13 @@ func (w *ByteArrayColumnChunkWriter) WriteBatch(values []parquet.ByteArray, defL
 	maxDefLevel := w.descr.MaxDefinitionLevel()
 	isV2WithRep := w.props.DataPageVersion() != parquet.DataPageV1 &&
 		repLevels != nil && w.descr.MaxRepetitionLevel() > 0
+	// VECTOR columns (Option B) contribute a fixed number of leaf slots per row
+	// and carry no per-element levels. Every batch must cover whole vectors so a
+	// vector value is never split across data pages and rowsForLeafValues only
+	// ever sees whole-vector counts. vectorLen is 0 for non-VECTOR columns, which
+	// leaves the batching below unchanged.
+	vectorLen := w.vectorLengthForBatch(n)
+	batchSize = alignBatchToVector(batchSize, vectorLen)
 	levelOffset := int64(0)
 
 	for levelOffset < n {
@@ -1839,6 +1930,10 @@ func (w *ByteArrayColumnChunkWriter) WriteBatch(values []parquet.ByteArray, defL
 				batch--
 			}
 		}
+		// Keep every batch on a whole-vector boundary for VECTOR columns, even after
+		// the data-size scan or V2 alignment trimmed it. A single vector that exceeds
+		// the size cap is still written whole rather than split across pages.
+		batch = alignBatchToVector(batch, vectorLen)
 		if batch < 1 {
 			batch = 1
 		}
@@ -1900,11 +1995,16 @@ func (w *ByteArrayColumnChunkWriter) WriteBatchSpacedWithError(values []parquet.
 	if defLevels == nil {
 		length = len(values)
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
 	const maxSafeBatchDataSize int64 = 1 << 30 // 1GB
 
 	batchSize := w.props.WriteBatchSize()
 	levelOffset := int64(0)
 	n := int64(length)
+	vectorLen := w.vectorLengthForBatch(n)
+	batchSize = alignBatchToVector(batchSize, vectorLen)
 
 	for levelOffset < n {
 		remaining := n - levelOffset
@@ -1921,6 +2021,7 @@ func (w *ByteArrayColumnChunkWriter) WriteBatchSpacedWithError(values []parquet.
 				cumDataSize += valSize
 			}
 		}
+		batch = alignBatchToVector(batch, vectorLen)
 		if batch < 1 {
 			batch = 1
 		}
@@ -1961,10 +2062,13 @@ func (w *ByteArrayColumnChunkWriter) WriteDictIndices(indices arrow.Array, defLe
 	if defLevels == nil {
 		length = indices.Len()
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return err
+	}
 
 	dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 
@@ -2129,6 +2233,12 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatch(values []parquet.FixedLe
 	case values != nil:
 		n = int64(len(values))
 	}
+	// VECTOR columns reject a partial-vector batch up front so callers get a typed
+	// error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+	// the write path. No-op for every other column.
+	if err := w.validateVectorBatch(n); err != nil {
+		return 0, err
+	}
 	// For variable-length types, we use adaptive batch sizing to ensure
 	// each batch's encoded data stays well within int32 range. This prevents
 	// overflow in FlushCurrentPage when computing uncompressed page size.
@@ -2138,6 +2248,13 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatch(values []parquet.FixedLe
 	maxDefLevel := w.descr.MaxDefinitionLevel()
 	isV2WithRep := w.props.DataPageVersion() != parquet.DataPageV1 &&
 		repLevels != nil && w.descr.MaxRepetitionLevel() > 0
+	// VECTOR columns (Option B) contribute a fixed number of leaf slots per row
+	// and carry no per-element levels. Every batch must cover whole vectors so a
+	// vector value is never split across data pages and rowsForLeafValues only
+	// ever sees whole-vector counts. vectorLen is 0 for non-VECTOR columns, which
+	// leaves the batching below unchanged.
+	vectorLen := w.vectorLengthForBatch(n)
+	batchSize = alignBatchToVector(batchSize, vectorLen)
 	levelOffset := int64(0)
 
 	for levelOffset < n {
@@ -2169,6 +2286,10 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatch(values []parquet.FixedLe
 				batch--
 			}
 		}
+		// Keep every batch on a whole-vector boundary for VECTOR columns, even after
+		// the data-size scan or V2 alignment trimmed it. A single vector that exceeds
+		// the size cap is still written whole rather than split across pages.
+		batch = alignBatchToVector(batch, vectorLen)
 		if batch < 1 {
 			batch = 1
 		}
@@ -2230,11 +2351,16 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatchSpacedWithError(values []
 	if defLevels == nil {
 		length = len(values)
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return 0, err
+	}
 	const maxSafeBatchDataSize int64 = 1 << 30 // 1GB
 
 	batchSize := w.props.WriteBatchSize()
 	levelOffset := int64(0)
 	n := int64(length)
+	vectorLen := w.vectorLengthForBatch(n)
+	batchSize = alignBatchToVector(batchSize, vectorLen)
 
 	for levelOffset < n {
 		remaining := n - levelOffset
@@ -2251,6 +2377,7 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteBatchSpacedWithError(values []
 				cumDataSize += valSize
 			}
 		}
+		batch = alignBatchToVector(batch, vectorLen)
 		if batch < 1 {
 			batch = 1
 		}
@@ -2291,10 +2418,13 @@ func (w *FixedLenByteArrayColumnChunkWriter) WriteDictIndices(indices arrow.Arra
 	if defLevels == nil {
 		length = indices.Len()
 	}
+	if err := w.validateVectorBatch(int64(length)); err != nil {
+		return err
+	}
 
 	dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-	doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+	w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
 		info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 		w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 

--- a/parquet/file/column_writer_types.gen.go.tmpl
+++ b/parquet/file/column_writer_types.gen.go.tmpl
@@ -102,7 +102,7 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatch(values []{{.name}}, defLevels, r
   maxDefLevel := w.descr.MaxDefinitionLevel()
   isV2WithRep := w.props.DataPageVersion() != parquet.DataPageV1 &&
     repLevels != nil && w.descr.MaxRepetitionLevel() > 0
-  // VECTOR columns (Option B) contribute a fixed number of leaf slots per row
+  // VECTOR columns contribute a fixed number of leaf slots per row
   // and carry no per-element levels. Every batch must cover whole vectors so a
   // vector value is never split across data pages and rowsForLeafValues only
   // ever sees whole-vector counts. vectorLen is 0 for non-VECTOR columns, which

--- a/parquet/file/column_writer_types.gen.go.tmpl
+++ b/parquet/file/column_writer_types.gen.go.tmpl
@@ -86,6 +86,12 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatch(values []{{.name}}, defLevels, r
   case values != nil:
     n = int64(len(values))
   }
+  // VECTOR columns reject a partial-vector batch up front so callers get a typed
+  // error (ErrVectorBatchMisaligned) rather than a recovered panic from deeper in
+  // the write path. No-op for every other column.
+  if err := w.validateVectorBatch(n); err != nil {
+    return 0, err
+  }
 {{- if .isByteArray}}
   // For variable-length types, we use adaptive batch sizing to ensure
   // each batch's encoded data stays well within int32 range. This prevents
@@ -96,6 +102,13 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatch(values []{{.name}}, defLevels, r
   maxDefLevel := w.descr.MaxDefinitionLevel()
   isV2WithRep := w.props.DataPageVersion() != parquet.DataPageV1 &&
     repLevels != nil && w.descr.MaxRepetitionLevel() > 0
+  // VECTOR columns (Option B) contribute a fixed number of leaf slots per row
+  // and carry no per-element levels. Every batch must cover whole vectors so a
+  // vector value is never split across data pages and rowsForLeafValues only
+  // ever sees whole-vector counts. vectorLen is 0 for non-VECTOR columns, which
+  // leaves the batching below unchanged.
+  vectorLen := w.vectorLengthForBatch(n)
+  batchSize = alignBatchToVector(batchSize, vectorLen)
   levelOffset := int64(0)
 
   for levelOffset < n {
@@ -131,6 +144,10 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatch(values []{{.name}}, defLevels, r
         batch--
       }
     }
+    // Keep every batch on a whole-vector boundary for VECTOR columns, even after
+    // the data-size scan or V2 alignment trimmed it. A single vector that exceeds
+    // the size cap is still written whole rather than split across pages.
+    batch = alignBatchToVector(batch, vectorLen)
     if batch < 1 {
       batch = 1
     }
@@ -210,12 +227,17 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatchSpacedWithError(values []{{.name}
   if defLevels == nil {
     length = len(values)
   }
+  if err := w.validateVectorBatch(int64(length)); err != nil {
+    return 0, err
+  }
 {{- if .isByteArray}}
   const maxSafeBatchDataSize int64 = 1 << 30 // 1GB
 
   batchSize := w.props.WriteBatchSize()
   levelOffset := int64(0)
   n := int64(length)
+  vectorLen := w.vectorLengthForBatch(n)
+  batchSize = alignBatchToVector(batchSize, vectorLen)
 
   for levelOffset < n {
     remaining := n - levelOffset
@@ -236,6 +258,7 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatchSpacedWithError(values []{{.name}
         cumDataSize += valSize
       }
     }
+    batch = alignBatchToVector(batch, vectorLen)
     if batch < 1 {
       batch = 1
     }
@@ -262,7 +285,7 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBatchSpacedWithError(values []{{.name}
     levelOffset += batch
   }
 {{- else}}
-  doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+  w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
     var vals []{{.name}}
     info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
@@ -305,6 +328,9 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBitmapBatch(bitmap []byte, bitmapOffse
   default:
     n = int64(numValues)
   }
+  if err := w.validateVectorBatch(n); err != nil {
+    return 0, err
+  }
 
   w.doBatches(n, repLevels, func(offset, batch int64) {
     toWrite := w.writeLevels(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
@@ -346,8 +372,11 @@ func (w *{{.Name}}ColumnChunkWriter) WriteBitmapBatchSpacedWithError(bitmap []by
   if defLevels == nil {
     length = numValues
   }
+  if err := w.validateVectorBatch(int64(length)); err != nil {
+    return 0, err
+  }
 
-  doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+  w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
     info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
 
     w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
@@ -381,10 +410,13 @@ func (w *{{.Name}}ColumnChunkWriter) WriteDictIndices(indices arrow.Array, defLe
   if defLevels == nil {
     length = indices.Len()
   }
+  if err := w.validateVectorBatch(int64(length)); err != nil {
+    return err
+  }
 
   dictEncoder := w.currentEncoder.(encoding.DictEncoder)
 
-  doBatches(int64(length), w.props.WriteBatchSize(), func(offset, batch int64) {
+  w.doBatchesAlignedForVector(int64(length), repLevels, func(offset, batch int64) {
     info := w.maybeCalculateValidityBits(levelSliceOrNil(defLevels, offset, batch), batch)
     w.writeLevelsSpaced(batch, levelSliceOrNil(defLevels, offset, batch), levelSliceOrNil(repLevels, offset, batch))
 

--- a/parquet/file/column_writer_vector_test.go
+++ b/parquet/file/column_writer_vector_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 // vectorColumnDescr builds the leaf Column for a non-nullable
-// FixedSizeList<float, vectorLen> encoded as a reduced Option B VECTOR leaf.
+// FixedSizeList<float, vectorLen> encoded as a reduced VECTOR leaf.
 func vectorColumnDescr(t *testing.T, vectorLen int32) *schema.Column {
 	t.Helper()
 	return vectorPrimitiveColumnDescr(t, parquet.Types.Float, -1, vectorLen)

--- a/parquet/file/column_writer_vector_test.go
+++ b/parquet/file/column_writer_vector_test.go
@@ -1,0 +1,556 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file_test
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/bitutil"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	arrutils "github.com/apache/arrow-go/v18/internal/utils"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/compress"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/internal/encoding"
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vectorColumnDescr builds the leaf Column for a non-nullable
+// FixedSizeList<float, vectorLen> encoded as a reduced Option B VECTOR leaf.
+func vectorColumnDescr(t *testing.T, vectorLen int32) *schema.Column {
+	t.Helper()
+	return vectorPrimitiveColumnDescr(t, parquet.Types.Float, -1, vectorLen)
+}
+
+// vectorPrimitiveColumnDescr builds the leaf Column for a non-nullable
+// FixedSizeList<primitive, vectorLen> VECTOR leaf of the given physical type.
+// (FixedLenByteArray, written by FixedLenByteArrayColumnChunkWriter's custom
+// batching loop, is reached by passing parquet.Types.FixedLenByteArray.)
+func vectorPrimitiveColumnDescr(t *testing.T, physical parquet.Type, typeLen int, vectorLen int32) *schema.Column {
+	t.Helper()
+	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("v", nil, physical, typeLen, vectorLen, -1))
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{leaf}, -1))
+	return schema.NewSchema(root).Column(0)
+}
+
+// newVectorChunkWriter wires up a buffer sink, metadata builder, page writer and
+// column-chunk writer for descr. Callers type-assert the returned writer to the
+// concrete type they need and read back the bytes via sink.Finish().
+func newVectorChunkWriter(t *testing.T, descr *schema.Column, props *parquet.WriterProperties) (file.ColumnChunkWriter, *encoding.BufferWriter) {
+	t.Helper()
+	sink := encoding.NewBufferWriter(0, mem)
+	meta := metadata.NewColumnChunkMetaDataBuilder(props, descr)
+	pager, err := file.NewPageWriter(sink, compress.Codecs.Uncompressed, compress.DefaultCompressionLevel, meta, -1, -1, mem, false, nil, nil)
+	require.NoError(t, err)
+	return file.NewColumnChunkWriter(meta, pager, props), sink
+}
+
+// newVectorChunkReader opens a column reader over an in-memory chunk of
+// totalValues physical leaf values.
+func newVectorChunkReader(t *testing.T, descr *schema.Column, data []byte, totalValues int64) file.ColumnChunkReader {
+	t.Helper()
+	bufPool := sync.Pool{New: func() interface{} { return memory.NewResizableBuffer(mem) }}
+	pages, err := file.NewPageReader(arrutils.NewByteReader(data), totalValues, compress.Codecs.Uncompressed, mem, nil)
+	require.NoError(t, err)
+	return file.NewColumnReader(descr, pages, mem, &bufPool)
+}
+
+// assertWholeVectorPages verifies every data page holds a whole number of
+// vectors (no vector value split across a page boundary), and optionally that
+// there is more than one data page so the invariant is meaningfully exercised.
+func assertWholeVectorPages(t *testing.T, data []byte, totalValues int64, vectorLen int32, requireMultiple bool) {
+	t.Helper()
+	pr, err := file.NewPageReader(arrutils.NewByteReader(data), totalValues, compress.Codecs.Uncompressed, mem, nil)
+	require.NoError(t, err)
+	pages := 0
+	for pr.Next() {
+		if dp, ok := pr.Page().(file.DataPage); ok {
+			pages++
+			assert.Zero(t, dp.NumValues()%vectorLen, "page %d has %d values, not a multiple of vector length %d", pages, dp.NumValues(), vectorLen)
+		}
+	}
+	require.NoError(t, pr.Err())
+	if requireMultiple {
+		assert.Greater(t, pages, 1, "expected multiple data pages so the page-boundary invariant is meaningfully exercised")
+	}
+}
+
+// A non-nullable VECTOR column must (1) account rows as values/vector_length
+// (not one row per leaf slot) and (2) never split a vector value across data
+// pages.
+func TestVectorColumnWriterRowAccountingAndPaging(t *testing.T) {
+	const vectorLen = 4
+	const numRows = 512
+
+	descr := vectorColumnDescr(t, vectorLen)
+	require.True(t, descr.InVectorColumn())
+	require.EqualValues(t, vectorLen, descr.EffectiveVectorLength())
+	require.EqualValues(t, 0, descr.MaxDefinitionLevel())
+	require.EqualValues(t, 0, descr.MaxRepetitionLevel())
+
+	// Small page size + small batch size to force many pages and a batch size
+	// that is not a multiple of vectorLen, exercising vector-aligned batching.
+	props := parquet.NewWriterProperties(
+		parquet.WithDictionaryDefault(false),
+		parquet.WithDataPageSize(1024),
+		parquet.WithBatchSize(37),
+	)
+	cw, sink := newVectorChunkWriter(t, descr, props)
+	w := cw.(*file.Float32ColumnChunkWriter)
+
+	values := make([]float32, numRows*vectorLen)
+	for i := range values {
+		values[i] = float32(i)
+	}
+	n, err := w.WriteBatch(values, nil, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, len(values), n)
+	require.NoError(t, w.Close())
+
+	// (1) Rows are counted as vectors, not leaf slots.
+	assert.Equal(t, numRows, w.RowsWritten())
+
+	readbuf := sink.Finish()
+	defer readbuf.Release()
+	totalValues := int64(numRows * vectorLen)
+
+	// (2) Every data page holds a whole number of vectors.
+	assertWholeVectorPages(t, readbuf.Bytes(), totalValues, vectorLen, true)
+
+	// Values round-trip intact.
+	rdr := newVectorChunkReader(t, descr, readbuf.Bytes(), totalValues).(*file.Float32ColumnChunkReader)
+	out := make([]float32, totalValues)
+	var got int64
+	for got < totalValues && rdr.HasNext() {
+		_, read, err := rdr.ReadBatch(totalValues-got, out[got:], nil, nil)
+		require.NoError(t, err)
+		got += int64(read)
+	}
+	assert.Equal(t, totalValues, got)
+	assert.Equal(t, values, out)
+}
+
+// WriteBatchSpaced has its own batching path; it must still batch VECTOR data
+// on whole-vector boundaries even when WriteBatchSize is not a multiple of the
+// vector length.
+func TestVectorColumnWriterWriteBatchSpacedAligns(t *testing.T) {
+	const vectorLen = 3
+	const numRows = 50
+
+	descr := vectorColumnDescr(t, vectorLen)
+	props := parquet.NewWriterProperties(
+		parquet.WithDictionaryDefault(false),
+		parquet.WithDataPageSize(128),
+		parquet.WithBatchSize(10), // not a multiple of vectorLen
+	)
+	cw, sink := newVectorChunkWriter(t, descr, props)
+	w := cw.(*file.Float32ColumnChunkWriter)
+
+	values := make([]float32, numRows*vectorLen)
+	for i := range values {
+		values[i] = float32(i)
+	}
+	validBits := make([]byte, bitutil.BytesForBits(int64(len(values))))
+	bitutil.SetBitsTo(validBits, 0, int64(len(values)), true)
+	w.WriteBatchSpaced(values, nil, nil, validBits, 0)
+	require.NoError(t, w.Close())
+	assert.Equal(t, numRows, w.RowsWritten())
+
+	readbuf := sink.Finish()
+	defer readbuf.Release()
+	assertWholeVectorPages(t, readbuf.Bytes(), int64(len(values)), vectorLen, false)
+}
+
+// WriteBitmapBatchSpaced is the boolean-specific spaced path. It must preserve
+// vector-aligned page boundaries and row accounting.
+func TestVectorColumnWriterWriteBitmapBatchSpacedAligns(t *testing.T) {
+	const vectorLen = 3
+	const numRows = 50
+	const totalValues = numRows * vectorLen
+
+	descr := vectorPrimitiveColumnDescr(t, parquet.Types.Boolean, -1, vectorLen)
+	props := parquet.NewWriterProperties(
+		parquet.WithDictionaryDefault(false),
+		parquet.WithDataPageSize(128),
+		parquet.WithBatchSize(10), // not a multiple of vectorLen
+	)
+	cw, sink := newVectorChunkWriter(t, descr, props)
+	w := cw.(*file.BooleanColumnChunkWriter)
+
+	bitmap := make([]byte, bitutil.BytesForBits(totalValues))
+	validBits := make([]byte, bitutil.BytesForBits(totalValues))
+	bitutil.SetBitsTo(validBits, 0, totalValues, true)
+	expected := make([]bool, totalValues)
+	for i := range expected {
+		expected[i] = i%3 != 0
+		bitutil.SetBitTo(bitmap, i, expected[i])
+	}
+
+	w.WriteBitmapBatchSpaced(bitmap, 0, totalValues, nil, nil, validBits, 0)
+	require.NoError(t, w.Close())
+	assert.Equal(t, numRows, w.RowsWritten())
+
+	readbuf := sink.Finish()
+	defer readbuf.Release()
+	assertWholeVectorPages(t, readbuf.Bytes(), totalValues, vectorLen, false)
+
+	rdr := newVectorChunkReader(t, descr, readbuf.Bytes(), totalValues).(*file.BooleanColumnChunkReader)
+	out := make([]bool, totalValues)
+	var got int64
+	for got < totalValues && rdr.HasNext() {
+		_, read, err := rdr.ReadBatch(totalValues-got, out[got:], nil, nil)
+		require.NoError(t, err)
+		got += int64(read)
+	}
+	assert.EqualValues(t, totalValues, got)
+	assert.Equal(t, expected, out)
+}
+
+// WriteDictIndices is used when callers provide pre-dictionary-encoded Arrow
+// indices. It has its own writer path and must also keep VECTOR page batches on
+// whole-vector boundaries.
+func TestVectorColumnWriterWriteDictIndicesAligns(t *testing.T) {
+	const vectorLen = 3
+	const numRows = 50
+	const totalValues = numRows * vectorLen
+
+	descr := vectorPrimitiveColumnDescr(t, parquet.Types.Int32, -1, vectorLen)
+	props := parquet.NewWriterProperties(
+		parquet.WithDictionaryDefault(true),
+		parquet.WithDataPageSize(128),
+		parquet.WithBatchSize(10), // not a multiple of vectorLen
+	)
+	cw, sink := newVectorChunkWriter(t, descr, props)
+	w := cw.(*file.Int32ColumnChunkWriter)
+
+	dictValues := []int32{10, 20, 30}
+	dictBuilder := array.NewInt32Builder(mem)
+	defer dictBuilder.Release()
+	dictBuilder.AppendValues(dictValues, nil)
+	dict := dictBuilder.NewArray()
+	defer dict.Release()
+	require.NoError(t, w.CurrentEncoder().(encoding.DictEncoder).PutDictionary(dict))
+
+	idxBuilder := array.NewInt32Builder(mem)
+	defer idxBuilder.Release()
+	expected := make([]int32, totalValues)
+	for i := range expected {
+		idx := int32(i % len(dictValues))
+		idxBuilder.Append(idx)
+		expected[i] = dictValues[idx]
+	}
+	indices := idxBuilder.NewArray()
+	defer indices.Release()
+
+	require.NoError(t, w.WriteDictIndices(indices, nil, nil))
+	require.NoError(t, w.Close())
+	assert.Equal(t, numRows, w.RowsWritten())
+
+	readbuf := sink.Finish()
+	defer readbuf.Release()
+	assertWholeVectorPages(t, readbuf.Bytes(), totalValues, vectorLen, false)
+
+	rdr := newVectorChunkReader(t, descr, readbuf.Bytes(), totalValues).(*file.Int32ColumnChunkReader)
+	out := make([]int32, totalValues)
+	var got int64
+	for got < totalValues && rdr.HasNext() {
+		_, read, err := rdr.ReadBatch(totalValues-got, out[got:], nil, nil)
+		require.NoError(t, err)
+		got += int64(read)
+	}
+	assert.EqualValues(t, totalValues, got)
+	assert.Equal(t, expected, out)
+}
+
+// Writing a partial vector (a leaf-slot count that is not a whole multiple of
+// the vector length) is rejected up front with the typed
+// file.ErrVectorBatchMisaligned on both the batch and spaced write paths, rather
+// than producing a malformed column or a recovered "unknown error type" panic.
+func TestVectorColumnWriterRejectsPartialVector(t *testing.T) {
+	const vectorLen = 4
+	descr := vectorColumnDescr(t, vectorLen)
+	props := parquet.NewWriterProperties(parquet.WithDictionaryDefault(false))
+
+	// 10 is not a multiple of vectorLen=4. The error must come from the up-front
+	// validateVectorBatch, not from the recovered internal panic: the deferred
+	// recover() prefixes "unknown error type", so its absence proves rejection
+	// happened before any values were written. (The internal panic also wraps
+	// ErrVectorBatchMisaligned, so ErrorIs alone would not catch its removal.)
+	cw, _ := newVectorChunkWriter(t, descr, props)
+	_, err := cw.(*file.Float32ColumnChunkWriter).WriteBatch(make([]float32, 10), nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, file.ErrVectorBatchMisaligned)
+	assert.NotContains(t, err.Error(), "unknown error type")
+
+	// The spaced write path validates the same invariant up front.
+	cw2, _ := newVectorChunkWriter(t, descr, props)
+	values := make([]float32, 10)
+	validBits := make([]byte, bitutil.BytesForBits(int64(len(values))))
+	bitutil.SetBitsTo(validBits, 0, int64(len(values)), true)
+	_, err = cw2.(*file.Float32ColumnChunkWriter).WriteBatchSpacedWithError(values, nil, nil, validBits, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, file.ErrVectorBatchMisaligned)
+	assert.NotContains(t, err.Error(), "unknown error type")
+}
+
+// A VECTOR-repeated leaf contributes no definition or repetition level, so
+// LevelInfo.Increment must leave the running level info unchanged, and the leaf
+// column of a non-nullable vector has no inner levels at all.
+func TestVectorLevelInfoNoOp(t *testing.T) {
+	const vectorLen = 4
+	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("v", nil, parquet.Types.Float, -1, vectorLen, -1))
+
+	// Increment over the VECTOR leaf is a no-op.
+	before := file.LevelInfo{DefLevel: 2, RepLevel: 1, RepeatedAncestorDefLevel: 1}
+	after := before
+	after.Increment(leaf)
+	assert.Equal(t, before, after)
+
+	// Sanity: an optional group still increments the definition level.
+	opt := schema.MustGroup(schema.NewGroupNode("g", parquet.Repetitions.Optional, schema.FieldList{
+		schema.MustPrimitive(schema.NewPrimitiveNode("c", parquet.Repetitions.Required, parquet.Types.Int32, -1, -1)),
+	}, -1))
+	li := file.LevelInfo{}
+	li.Increment(opt)
+	assert.EqualValues(t, 1, li.DefLevel)
+
+	// The leaf column of a required vector has DefLevel/RepLevel 0 (no inner levels).
+	cw, _ := newVectorChunkWriter(t, vectorColumnDescr(t, vectorLen), parquet.NewWriterProperties(parquet.WithDictionaryDefault(false)))
+	got := cw.LevelInfo()
+	assert.EqualValues(t, 0, got.DefLevel)
+	assert.EqualValues(t, 0, got.RepLevel)
+	assert.EqualValues(t, 0, got.RepeatedAncestorDefLevel)
+	require.NoError(t, cw.Close())
+}
+
+// A FixedLenByteArray VECTOR column must (1) write successfully even when the
+// vector length does not divide WriteBatchSize, (2) account rows as
+// values/vector_length, and (3) never split a vector value across data pages.
+// Regression test: the FLBA WriteBatch loop previously batched without any
+// vector awareness, so a non-dividing vector length produced a partial-vector
+// batch and the write failed with a recovered panic.
+func TestVectorFLBAColumnWriterPaging(t *testing.T) {
+	const vectorLen = 3 // does not divide the default WriteBatchSize (1024)
+	const typeLen = 16
+	const numRows = 256
+
+	descr := vectorPrimitiveColumnDescr(t, parquet.Types.FixedLenByteArray, typeLen, vectorLen)
+	require.True(t, descr.InVectorColumn())
+	require.EqualValues(t, vectorLen, descr.EffectiveVectorLength())
+
+	// Small page size + a batch size that is not a multiple of vectorLen, to
+	// stress vector-aligned batching and force many pages.
+	props := parquet.NewWriterProperties(
+		parquet.WithDictionaryDefault(false),
+		parquet.WithDataPageSize(1024),
+		parquet.WithBatchSize(37),
+	)
+	cw, sink := newVectorChunkWriter(t, descr, props)
+	w := cw.(*file.FixedLenByteArrayColumnChunkWriter)
+
+	values := make([]parquet.FixedLenByteArray, numRows*vectorLen)
+	for i := range values {
+		v := make([]byte, typeLen)
+		for k := 0; k < typeLen; k++ {
+			v[k] = byte((i + k) % 251)
+		}
+		values[i] = v
+	}
+	n, err := w.WriteBatch(values, nil, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, len(values), n)
+	require.NoError(t, w.Close())
+
+	// (1) Rows counted as vectors, not leaf slots.
+	assert.Equal(t, numRows, w.RowsWritten())
+
+	readbuf := sink.Finish()
+	defer readbuf.Release()
+	totalValues := int64(numRows * vectorLen)
+
+	// (2) Every data page holds a whole number of vectors.
+	assertWholeVectorPages(t, readbuf.Bytes(), totalValues, vectorLen, true)
+
+	// (3) Values round-trip intact.
+	rdr := newVectorChunkReader(t, descr, readbuf.Bytes(), totalValues).(*file.FixedLenByteArrayColumnChunkReader)
+	out := make([]parquet.FixedLenByteArray, totalValues)
+	var got int64
+	for got < totalValues && rdr.HasNext() {
+		_, read, err := rdr.ReadBatch(totalValues-got, out[got:], nil, nil)
+		require.NoError(t, err)
+		got += int64(read)
+	}
+	assert.Equal(t, totalValues, got)
+	assert.Equal(t, values, out)
+}
+
+// The low-level columnChunkReader.SeekToRow must translate a row ordinal to a
+// fixed value stride for VECTOR columns. Regression test: it previously called
+// skipRows, which treats one leaf slot as one row and undershot the seek by a
+// factor of the vector length. Both DataPageV1 (the row-group-reset fallback)
+// and DataPageV2 (the page-level stride branch) are exercised.
+func TestVectorColumnReaderSeekToRow(t *testing.T) {
+	cases := []struct {
+		name      string
+		props     *parquet.WriterProperties
+		vectorLen int32
+		numRows   int
+		rows      []int64
+	}{
+		{
+			name:      "datapage-v1",
+			props:     parquet.NewWriterProperties(parquet.WithDictionaryDefault(false), parquet.WithDataPageSize(256)),
+			vectorLen: 3, numRows: 500, rows: []int64{0, 1, 7, 250, 499},
+		},
+		{
+			name:      "datapage-v2",
+			props:     parquet.NewWriterProperties(parquet.WithDictionaryDefault(false), parquet.WithDataPageVersion(parquet.DataPageV2), parquet.WithDataPageSize(256)),
+			vectorLen: 5, numRows: 400, rows: []int64{0, 1, 13, 199, 399},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			descr := vectorColumnDescr(t, tc.vectorLen)
+			cw, sink := newVectorChunkWriter(t, descr, tc.props)
+			w := cw.(*file.Float32ColumnChunkWriter)
+			values := make([]float32, tc.numRows*int(tc.vectorLen))
+			for i := range values {
+				values[i] = float32(i)
+			}
+			_, err := w.WriteBatch(values, nil, nil)
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
+
+			readbuf := sink.Finish()
+			defer readbuf.Release()
+			totalValues := int64(tc.numRows) * int64(tc.vectorLen)
+			rdr := newVectorChunkReader(t, descr, readbuf.Bytes(), totalValues).(*file.Float32ColumnChunkReader)
+
+			for _, row := range tc.rows {
+				require.NoError(t, rdr.SeekToRow(row), "seek row %d", row)
+				out := make([]float32, tc.vectorLen)
+				_, read, err := rdr.ReadBatch(int64(tc.vectorLen), out, nil, nil)
+				require.NoError(t, err)
+				require.EqualValues(t, tc.vectorLen, read, "row %d", row)
+				start := int(row) * int(tc.vectorLen)
+				assert.Equal(t, values[start:start+int(tc.vectorLen)], out, "seek row %d landed at wrong stride", row)
+			}
+
+			assert.Error(t, rdr.SeekToRow(-1))
+			assert.Error(t, rdr.SeekToRow(int64(tc.numRows)), "row index equal to parent row count must be out of range")
+		})
+	}
+}
+
+// A dictionary-encoded VECTOR column has a dictionary page before its data
+// pages. The V1/no-offset-index value-stride seek rewinds to the row-group
+// start, which re-streams that dictionary page; the reader must treat the
+// already-configured dictionary as a no-op rather than failing with "more than
+// one dictionary". Seeks include row 0 (fresh) and backward seeks so the rewind
+// path is exercised every time. (Existing seek tests disable dictionaries.)
+func TestVectorColumnReaderSeekToRowDictEncoded(t *testing.T) {
+	const vectorLen = 3
+	const numRows = 400
+
+	descr := vectorColumnDescr(t, vectorLen)
+	props := parquet.NewWriterProperties(
+		parquet.WithDictionaryDefault(true),
+		parquet.WithDataPageSize(128), // small pages -> many data pages after the dictionary
+	)
+	cw, sink := newVectorChunkWriter(t, descr, props)
+	w := cw.(*file.Float32ColumnChunkWriter)
+
+	values := make([]float32, numRows*vectorLen)
+	for i := range values {
+		values[i] = float32(i % 17) // few distinct values -> dictionary-encoded
+	}
+	_, err := w.WriteBatch(values, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	readbuf := sink.Finish()
+	defer readbuf.Release()
+	totalValues := int64(numRows * vectorLen)
+	rdr := newVectorChunkReader(t, descr, readbuf.Bytes(), totalValues).(*file.Float32ColumnChunkReader)
+
+	for _, row := range []int64{0, int64(numRows - 1), 3, 200, 1, 0} {
+		require.NoError(t, rdr.SeekToRow(row), "seek row %d", row)
+		out := make([]float32, vectorLen)
+		_, read, err := rdr.ReadBatch(int64(vectorLen), out, nil, nil)
+		require.NoError(t, err, "read after seek row %d", row)
+		require.EqualValues(t, vectorLen, read, "row %d", row)
+		start := int(row) * vectorLen
+		assert.Equal(t, values[start:start+vectorLen], out, "seek row %d landed at wrong stride", row)
+	}
+}
+
+func TestVectorColumnReaderRejectsMalformedValueCount(t *testing.T) {
+	const vectorLen = 3
+	const numRows = 10
+
+	descr := vectorColumnDescr(t, vectorLen)
+	cw, sink := newVectorChunkWriter(t, descr, parquet.NewWriterProperties(parquet.WithDictionaryDefault(false)))
+	w := cw.(*file.Float32ColumnChunkWriter)
+	_, err := w.WriteBatch(make([]float32, numRows*vectorLen), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	readbuf := sink.Finish()
+	defer readbuf.Release()
+
+	// The low-level NewPageReader API takes a raw value count; make it malformed
+	// to verify VECTOR readers reject chunks that cannot contain whole vectors.
+	rdr := newVectorChunkReader(t, descr, readbuf.Bytes(), int64(numRows*vectorLen-1)).(*file.Float32ColumnChunkReader)
+	assert.Error(t, rdr.SeekToRow(0))
+}
+
+func TestVectorRowGroupReaderRejectsMalformedNumValues(t *testing.T) {
+	const vectorLen = 3
+	const numRows = 4
+
+	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("v", nil, parquet.Types.Float, -1, vectorLen, -1))
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Required, schema.FieldList{leaf}, -1))
+	props := parquet.NewWriterProperties(parquet.WithDictionaryDefault(false))
+
+	var buf bytes.Buffer
+	writer, err := file.NewParquetWriterWithError(&buf, root, file.WithWriterProps(props))
+	require.NoError(t, err)
+	rgw := writer.AppendRowGroup()
+	cwr, err := rgw.NextColumn()
+	require.NoError(t, err)
+	cw := cwr.(*file.Float32ColumnChunkWriter)
+	_, err = cw.WriteBatch(make([]float32, numRows*vectorLen), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, cw.Close())
+	require.NoError(t, rgw.Close())
+	require.NoError(t, writer.Close())
+
+	reader, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	// Keep num_values a multiple of vector_length but inconsistent with the row
+	// count, so the row-group metadata validation catches malformed VECTOR chunks
+	// before a page reader is handed out.
+	reader.MetaData().RowGroups[0].Columns[0].MetaData.NumValues -= int64(vectorLen)
+	_, err = reader.RowGroup(0).GetColumnPageReader(0)
+	require.ErrorContains(t, err, "has 9 values for 4 rows and vector length 3")
+}

--- a/parquet/file/column_writer_vector_test.go
+++ b/parquet/file/column_writer_vector_test.go
@@ -36,20 +36,22 @@ import (
 )
 
 // vectorColumnDescr builds the leaf Column for a non-nullable
-// FixedSizeList<float, vectorLen> encoded as a reduced VECTOR leaf.
+// FixedSizeList<float, vectorLen> encoded in the canonical 3-level VECTOR form.
 func vectorColumnDescr(t *testing.T, vectorLen int32) *schema.Column {
 	t.Helper()
 	return vectorPrimitiveColumnDescr(t, parquet.Types.Float, -1, vectorLen)
 }
 
 // vectorPrimitiveColumnDescr builds the leaf Column for a non-nullable
-// FixedSizeList<primitive, vectorLen> VECTOR leaf of the given physical type.
+// FixedSizeList<primitive, vectorLen> VECTOR field of the given physical type.
 // (FixedLenByteArray, written by FixedLenByteArrayColumnChunkWriter's custom
 // batching loop, is reached by passing parquet.Types.FixedLenByteArray.)
 func vectorPrimitiveColumnDescr(t *testing.T, physical parquet.Type, typeLen int, vectorLen int32) *schema.Column {
 	t.Helper()
-	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("v", nil, physical, typeLen, vectorLen, -1))
-	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{leaf}, -1))
+	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogical("element", parquet.Repetitions.Required, nil, physical, typeLen, -1))
+	list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{leaf}, vectorLen, -1))
+	outer := schema.MustGroup(schema.NewGroupNodeLogical("v", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{outer}, -1))
 	return schema.NewSchema(root).Column(0)
 }
 
@@ -313,17 +315,18 @@ func TestVectorColumnWriterRejectsPartialVector(t *testing.T) {
 	assert.NotContains(t, err.Error(), "unknown error type")
 }
 
-// A VECTOR-repeated leaf contributes no definition or repetition level, so
+// A VECTOR-repeated group contributes no definition or repetition level, so
 // LevelInfo.Increment must leave the running level info unchanged, and the leaf
 // column of a non-nullable vector has no inner levels at all.
 func TestVectorLevelInfoNoOp(t *testing.T) {
 	const vectorLen = 4
-	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("v", nil, parquet.Types.Float, -1, vectorLen, -1))
+	leaf := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+	vec := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{leaf}, vectorLen, -1))
 
-	// Increment over the VECTOR leaf is a no-op.
+	// Increment over the VECTOR group is a no-op.
 	before := file.LevelInfo{DefLevel: 2, RepLevel: 1, RepeatedAncestorDefLevel: 1}
 	after := before
-	after.Increment(leaf)
+	after.Increment(vec)
 	assert.Equal(t, before, after)
 
 	// Sanity: an optional group still increments the definition level.
@@ -528,8 +531,10 @@ func TestVectorRowGroupReaderRejectsMalformedNumValues(t *testing.T) {
 	const vectorLen = 3
 	const numRows = 4
 
-	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("v", nil, parquet.Types.Float, -1, vectorLen, -1))
-	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Required, schema.FieldList{leaf}, -1))
+	leaf := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+	list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{leaf}, vectorLen, -1))
+	outer := schema.MustGroup(schema.NewGroupNodeLogical("v", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Required, schema.FieldList{outer}, -1))
 	props := parquet.NewWriterProperties(parquet.WithDictionaryDefault(false))
 
 	var buf bytes.Buffer

--- a/parquet/file/level_conversion.go
+++ b/parquet/file/level_conversion.go
@@ -108,6 +108,11 @@ func (l *LevelInfo) Increment(n schema.Node) {
 		l.IncrementRepeated()
 	case parquet.Repetitions.Optional:
 		l.IncrementOptional()
+	case parquet.Repetitions.Vector:
+		// VECTOR fields (Option B) repeat a fixed number of times per parent
+		// value without adding a definition or repetition level; the fixed
+		// multiplicity is carried by the schema's vector_length. Intentionally
+		// a no-op, mirroring schema.buildTree.
 	}
 }
 

--- a/parquet/file/level_conversion.go
+++ b/parquet/file/level_conversion.go
@@ -109,8 +109,8 @@ func (l *LevelInfo) Increment(n schema.Node) {
 	case parquet.Repetitions.Optional:
 		l.IncrementOptional()
 	case parquet.Repetitions.Vector:
-		// VECTOR fields (Option B) repeat a fixed number of times per parent
-		// value without adding a definition or repetition level; the fixed
+		// VECTOR fields repeat a fixed number of times per parent value
+		// without adding a definition or repetition level; the fixed
 		// multiplicity is carried by the schema's vector_length. Intentionally
 		// a no-op, mirroring schema.buildTree.
 	}

--- a/parquet/file/page_reader.go
+++ b/parquet/file/page_reader.go
@@ -353,10 +353,14 @@ type serializedPageReader struct {
 	colIdx        int
 	pgIndexReader *metadata.RowGroupPageIndexReader
 
-	nrows    int64
-	rowsSeen int64
-	mem      memory.Allocator
-	codec    compress.Codec
+	// nrows is the physical leaf-value count used to know when the page stream is
+	// exhausted. parentRows, when set by file readers, is the row-group parent row
+	// count used for row-ordinal seek bounds.
+	nrows      int64
+	parentRows int64
+	rowsSeen   int64
+	mem        memory.Allocator
+	codec      compress.Codec
 
 	curPageHdr        *format.PageHeader
 	pageOrd           int16
@@ -687,7 +691,7 @@ func (p *serializedPageReader) readPageHeader(rd parquet.BufferedReader, hdr *fo
 }
 
 func (p *serializedPageReader) SeekToPageWithRow(rowIdx int64) error {
-	if rowIdx < 0 || rowIdx >= p.nrows {
+	if rowIdx < 0 || (p.parentRows > 0 && rowIdx >= p.parentRows) || (p.parentRows <= 0 && rowIdx >= p.nrows) {
 		return fmt.Errorf("parquet: cannot seek column reader to row index %d", rowIdx)
 	}
 

--- a/parquet/file/page_reader.go
+++ b/parquet/file/page_reader.go
@@ -452,7 +452,7 @@ func NewPageReader(r parquet.BufferedReader, nrows int64, compressType compress.
 }
 
 func (p *serializedPageReader) Reset(r parquet.BufferedReader, nrows int64, compressType compress.Compression, ctx *CryptoContext) {
-	p.rowsSeen, p.pageOrd, p.nrows = 0, 0, nrows
+	p.rowsSeen, p.pageOrd, p.nrows, p.parentRows = 0, 0, nrows, 0
 	p.curPageHdr, p.curPage, p.err = nil, nil, nil
 	p.r = r
 

--- a/parquet/file/record_reader.go
+++ b/parquet/file/record_reader.go
@@ -460,18 +460,31 @@ func (rr *recordReader) ResetValues() {
 	rr.recordReaderImpl.ResetValues()
 }
 
-func (rr *recordReader) SeekToRow(recordIdx int64) error {
-	if err := rr.recordReaderImpl.SeekToRow(recordIdx); err != nil {
-		return err
-	}
-
+func (rr *recordReader) resetAfterSeek() {
 	rr.atRecStart = true
 	rr.recordsRead = 0
 	// force re-reading the definition/repetition levels
 	// calling SeekToRow on the underlying column reader will ensure that
 	// the next reads will pull from the correct row
 	rr.levelsPos, rr.levelsWritten = 0, 0
+}
 
+func (rr *recordReader) SeekToRow(recordIdx int64) error {
+	if err := rr.recordReaderImpl.SeekToRow(recordIdx); err != nil {
+		return err
+	}
+	rr.resetAfterSeek()
+	return nil
+}
+
+// SeekToRowWithValueStride seeks by row ordinal but positions the decoder at a
+// fixed multiple of primitive values per row. This is used by leaf-only VECTOR
+// columns where one logical row contributes valueStride physical leaf values.
+func (rr *recordReader) SeekToRowWithValueStride(recordIdx, valueStride int64) error {
+	if err := rr.seekToRowWithValueStride(recordIdx, valueStride); err != nil {
+		return err
+	}
+	rr.resetAfterSeek()
 	return nil
 }
 

--- a/parquet/file/record_reader.go
+++ b/parquet/file/record_reader.go
@@ -478,8 +478,8 @@ func (rr *recordReader) SeekToRow(recordIdx int64) error {
 }
 
 // SeekToRowWithValueStride seeks by row ordinal but positions the decoder at a
-// fixed multiple of primitive values per row. This is used by leaf-only VECTOR
-// columns where one logical row contributes valueStride physical leaf values.
+// fixed multiple of primitive values per row. This is used by VECTOR columns
+// where one logical row contributes valueStride physical leaf values.
 func (rr *recordReader) SeekToRowWithValueStride(recordIdx, valueStride int64) error {
 	if err := rr.seekToRowWithValueStride(recordIdx, valueStride); err != nil {
 		return err

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -85,6 +85,29 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 	if err != nil {
 		return nil, err
 	}
+	// parentRows scopes row-ordinal seek bounds to VECTOR columns only. A VECTOR
+	// leaf stores parent_row_count*vector_length physical values, so its page
+	// stream's num_values count is not the parent-row count and a row ordinal
+	// must be bounded by the row-group row count instead. For every other column
+	// parentRows stays 0 and the page reader keeps its num_values-based bound:
+	// using the row count there would be a looser bound that could admit
+	// out-of-range seeks for optional/repeated columns whose num_values differs
+	// from the row count (the no-offset-index page scan advances by num_values).
+	var parentRows int64
+	if descr := r.fileMetadata.Schema.Column(i); descr.InVectorColumn() {
+		vectorLen := int64(descr.EffectiveVectorLength())
+		if col.NumValues()%vectorLen != 0 {
+			return nil, fmt.Errorf("parquet: VECTOR column %q has %d values, not a multiple of vector length %d", descr.Path(), col.NumValues(), vectorLen)
+		}
+		wantValues, ok := utils.Mul64(r.rgMetadata.NumRows(), vectorLen)
+		if !ok {
+			return nil, fmt.Errorf("parquet: VECTOR column %q row count overflows vector length %d", descr.Path(), vectorLen)
+		}
+		if col.NumValues() != wantValues {
+			return nil, fmt.Errorf("parquet: VECTOR column %q has %d values for %d rows and vector length %d", descr.Path(), col.NumValues(), r.rgMetadata.NumRows(), vectorLen)
+		}
+		parentRows = r.rgMetadata.NumRows()
+	}
 
 	rgIdxRdr, err := r.rgPageIndexReader()
 	if err != nil {
@@ -128,6 +151,7 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 			pgIndexReader:     rgIdxRdr,
 			maxPageHeaderSize: defaultMaxPageHeaderSize,
 			nrows:             col.NumValues(),
+			parentRows:        parentRows,
 			mem:               r.props.Allocator(),
 		}
 		return pr, pr.init(col.Compression(), nil)
@@ -157,6 +181,7 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 			pgIndexReader:     rgIdxRdr,
 			maxPageHeaderSize: defaultMaxPageHeaderSize,
 			nrows:             col.NumValues(),
+			parentRows:        parentRows,
 			mem:               r.props.Allocator(),
 			cryptoCtx:         ctx,
 		}
@@ -181,6 +206,7 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 		pgIndexReader:     rgIdxRdr,
 		maxPageHeaderSize: defaultMaxPageHeaderSize,
 		nrows:             col.NumValues(),
+		parentRows:        parentRows,
 		mem:               r.props.Allocator(),
 		cryptoCtx:         ctx,
 	}

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -86,7 +86,7 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 		return nil, err
 	}
 	// parentRows scopes row-ordinal seek bounds to VECTOR columns only. A VECTOR
-	// leaf stores parent_row_count*vector_length physical values, so its page
+	// column stores parent_row_count*vector_length leaf slots, so its page
 	// stream's num_values count is not the parent-row count and a row ordinal
 	// must be bounded by the row-group row count instead. For every other column
 	// parentRows stays 0 and the page reader keeps its num_values-based bound:

--- a/parquet/internal/gen-go/parquet/parquet.go
+++ b/parquet/internal/gen-go/parquet/parquet.go
@@ -227,6 +227,7 @@ const (
 	FieldRepetitionType_REQUIRED FieldRepetitionType = 0
 	FieldRepetitionType_OPTIONAL FieldRepetitionType = 1
 	FieldRepetitionType_REPEATED FieldRepetitionType = 2
+	FieldRepetitionType_VECTOR FieldRepetitionType = 3
 )
 
 func (p FieldRepetitionType) String() string {
@@ -234,6 +235,7 @@ func (p FieldRepetitionType) String() string {
 	case FieldRepetitionType_REQUIRED: return "REQUIRED"
 	case FieldRepetitionType_OPTIONAL: return "OPTIONAL"
 	case FieldRepetitionType_REPEATED: return "REPEATED"
+	case FieldRepetitionType_VECTOR: return "VECTOR"
 	}
 	return "<UNSET>"
 }
@@ -243,6 +245,7 @@ func FieldRepetitionTypeFromString(s string) (FieldRepetitionType, error) {
 	case "REQUIRED": return FieldRepetitionType_REQUIRED, nil
 	case "OPTIONAL": return FieldRepetitionType_OPTIONAL, nil
 	case "REPEATED": return FieldRepetitionType_REPEATED, nil
+	case "VECTOR": return FieldRepetitionType_VECTOR, nil
 	}
 	return FieldRepetitionType(0), fmt.Errorf("not a valid FieldRepetitionType string")
 }
@@ -5853,6 +5856,9 @@ type SchemaElement struct {
 	Precision *int32 `thrift:"precision,8" db:"precision" json:"precision,omitempty"`
 	FieldID *int32 `thrift:"field_id,9" db:"field_id" json:"field_id,omitempty"`
 	LogicalType *LogicalType `thrift:"logicalType,10" db:"logicalType" json:"logicalType,omitempty"`
+	// EXPERIMENTAL: The fixed number of times the field repeats per parent
+	// value when repetition_type is VECTOR.
+	VectorLength *int32 `thrift:"vector_length,11" db:"vector_length" json:"vector_length,omitempty"`
 }
 
 func NewSchemaElement() *SchemaElement {
@@ -5946,6 +5952,15 @@ func (p *SchemaElement) GetLogicalType() *LogicalType {
 	return p.LogicalType
 }
 
+var SchemaElement_VectorLength_DEFAULT int32
+
+func (p *SchemaElement) GetVectorLength() int32 {
+	if !p.IsSetVectorLength() {
+		return SchemaElement_VectorLength_DEFAULT
+	}
+	return *p.VectorLength
+}
+
 func (p *SchemaElement) IsSetType() bool {
 	return p.Type != nil
 }
@@ -5980,6 +5995,10 @@ func (p *SchemaElement) IsSetFieldID() bool {
 
 func (p *SchemaElement) IsSetLogicalType() bool {
 	return p.LogicalType != nil
+}
+
+func (p *SchemaElement) IsSetVectorLength() bool {
+	return p.VectorLength != nil
 }
 
 func (p *SchemaElement) Read(ctx context.Context, iprot thrift.TProtocol) error {
@@ -6099,6 +6118,16 @@ func (p *SchemaElement) Read(ctx context.Context, iprot thrift.TProtocol) error 
 					return err
 				}
 			}
+		case 11:
+			if fieldTypeId == thrift.I32 {
+				if err := p.ReadField11(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
 		default:
 			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
 				return err
@@ -6209,6 +6238,15 @@ func (p *SchemaElement) ReadField10(ctx context.Context, iprot thrift.TProtocol)
 	return nil
 }
 
+func (p *SchemaElement) ReadField11(ctx context.Context, iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI32(ctx); err != nil {
+		return thrift.PrependError("error reading field 11: ", err)
+	} else {
+		p.VectorLength = &v
+	}
+	return nil
+}
+
 func (p *SchemaElement) Write(ctx context.Context, oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin(ctx, "SchemaElement"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -6224,6 +6262,7 @@ func (p *SchemaElement) Write(ctx context.Context, oprot thrift.TProtocol) error
 		if err := p.writeField8(ctx, oprot); err != nil { return err }
 		if err := p.writeField9(ctx, oprot); err != nil { return err }
 		if err := p.writeField10(ctx, oprot); err != nil { return err }
+		if err := p.writeField11(ctx, oprot); err != nil { return err }
 	}
 	if err := oprot.WriteFieldStop(ctx); err != nil {
 		return thrift.PrependError("write field stop error: ", err)
@@ -6382,6 +6421,21 @@ func (p *SchemaElement) writeField10(ctx context.Context, oprot thrift.TProtocol
 	return err
 }
 
+func (p *SchemaElement) writeField11(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if p.IsSetVectorLength() {
+		if err := oprot.WriteFieldBegin(ctx, "vector_length", thrift.I32, 11); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 11:vector_length: ", p), err)
+		}
+		if err := oprot.WriteI32(ctx, int32(*p.VectorLength)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.vector_length (11) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(ctx); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 11:vector_length: ", p), err)
+		}
+	}
+	return err
+}
+
 func (p *SchemaElement) Equals(other *SchemaElement) bool {
 	if p == other {
 		return true
@@ -6438,6 +6492,12 @@ func (p *SchemaElement) Equals(other *SchemaElement) bool {
 		if (*p.FieldID) != (*other.FieldID) { return false }
 	}
 	if !p.LogicalType.Equals(other.LogicalType) { return false }
+	if p.VectorLength != other.VectorLength {
+		if p.VectorLength == nil || other.VectorLength == nil {
+			return false
+		}
+		if (*p.VectorLength) != (*other.VectorLength) { return false }
+	}
 	return true
 }
 

--- a/parquet/internal/gen-go/parquet/parquet.go
+++ b/parquet/internal/gen-go/parquet/parquet.go
@@ -4807,6 +4807,86 @@ func (p *GeographyType) Validate() error {
 	return nil
 }
 
+// VectorType annotates the outer group of a fixed-size vector field.
+type VectorType struct {
+}
+
+func NewVectorType() *VectorType {
+	return &VectorType{}
+}
+
+func (p *VectorType) Read(ctx context.Context, iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin(ctx)
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP { break }
+		if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+			return err
+		}
+		if err := iprot.ReadFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(ctx); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *VectorType) Write(ctx context.Context, oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin(ctx, "VectorType"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+	}
+	if err := oprot.WriteFieldStop(ctx); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(ctx); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *VectorType) Equals(other *VectorType) bool {
+	if p == other {
+		return true
+	} else if p == nil || other == nil {
+		return false
+	}
+	return true
+}
+
+func (p *VectorType) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("VectorType(%+v)", *p)
+}
+
+func (p *VectorType) LogValue() slog.Value {
+	if p == nil {
+		return slog.AnyValue(nil)
+	}
+	v := thrift.SlogTStructWrapper{
+		Type: "*parquet.VectorType",
+		Value: p,
+	}
+	return slog.AnyValue(v)
+}
+
+var _ slog.LogValuer = (*VectorType)(nil)
+
+func (p *VectorType) Validate() error {
+	return nil
+}
+
 // LogicalType annotations to replace ConvertedType.
 // 
 // To maintain compatibility, implementations using LogicalType for a
@@ -4831,6 +4911,7 @@ func (p *GeographyType) Validate() error {
 //  - VARIANT
 //  - GEOMETRY
 //  - GEOGRAPHY
+//  - VECTOR
 // 
 type LogicalType struct {
 	STRING *StringType `thrift:"STRING,1" db:"STRING" json:"STRING,omitempty"`
@@ -4851,6 +4932,7 @@ type LogicalType struct {
 	VARIANT *VariantType `thrift:"VARIANT,16" db:"VARIANT" json:"VARIANT,omitempty"`
 	GEOMETRY *GeometryType `thrift:"GEOMETRY,17" db:"GEOMETRY" json:"GEOMETRY,omitempty"`
 	GEOGRAPHY *GeographyType `thrift:"GEOGRAPHY,18" db:"GEOGRAPHY" json:"GEOGRAPHY,omitempty"`
+	VECTOR *VectorType `thrift:"VECTOR,19" db:"VECTOR" json:"VECTOR,omitempty"`
 }
 
 func NewLogicalType() *LogicalType {
@@ -5010,6 +5092,15 @@ func (p *LogicalType) GetGEOGRAPHY() *GeographyType {
 	return p.GEOGRAPHY
 }
 
+var LogicalType_VECTOR_DEFAULT *VectorType
+
+func (p *LogicalType) GetVECTOR() *VectorType {
+	if !p.IsSetVECTOR() {
+		return LogicalType_VECTOR_DEFAULT
+	}
+	return p.VECTOR
+}
+
 func (p *LogicalType) CountSetFieldsLogicalType() int {
 	count := 0
 	if (p.IsSetSTRING()) {
@@ -5061,6 +5152,9 @@ func (p *LogicalType) CountSetFieldsLogicalType() int {
 		count++
 	}
 	if (p.IsSetGEOGRAPHY()) {
+		count++
+	}
+	if (p.IsSetVECTOR()) {
 		count++
 	}
 	return count
@@ -5133,6 +5227,10 @@ func (p *LogicalType) IsSetGEOMETRY() bool {
 
 func (p *LogicalType) IsSetGEOGRAPHY() bool {
 	return p.GEOGRAPHY != nil
+}
+
+func (p *LogicalType) IsSetVECTOR() bool {
+	return p.VECTOR != nil
 }
 
 func (p *LogicalType) Read(ctx context.Context, iprot thrift.TProtocol) error {
@@ -5320,6 +5418,16 @@ func (p *LogicalType) Read(ctx context.Context, iprot thrift.TProtocol) error {
 					return err
 				}
 			}
+		case 19:
+			if fieldTypeId == thrift.STRUCT {
+				if err := p.ReadField19(ctx, iprot); err != nil {
+					return err
+				}
+			} else {
+				if err := iprot.Skip(ctx, fieldTypeId); err != nil {
+					return err
+				}
+			}
 		default:
 			if err := iprot.Skip(ctx, fieldTypeId); err != nil {
 				return err
@@ -5471,6 +5579,14 @@ func (p *LogicalType) ReadField18(ctx context.Context, iprot thrift.TProtocol) e
 	return nil
 }
 
+func (p *LogicalType) ReadField19(ctx context.Context, iprot thrift.TProtocol) error {
+	p.VECTOR = &VectorType{}
+	if err := p.VECTOR.Read(ctx, iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.VECTOR), err)
+	}
+	return nil
+}
+
 func (p *LogicalType) Write(ctx context.Context, oprot thrift.TProtocol) error {
 	if c := p.CountSetFieldsLogicalType(); c != 1 {
 		return fmt.Errorf("%T write union: exactly one field must be set (%d set)", p, c)
@@ -5496,6 +5612,7 @@ func (p *LogicalType) Write(ctx context.Context, oprot thrift.TProtocol) error {
 		if err := p.writeField16(ctx, oprot); err != nil { return err }
 		if err := p.writeField17(ctx, oprot); err != nil { return err }
 		if err := p.writeField18(ctx, oprot); err != nil { return err }
+		if err := p.writeField19(ctx, oprot); err != nil { return err }
 	}
 	if err := oprot.WriteFieldStop(ctx); err != nil {
 		return thrift.PrependError("write field stop error: ", err)
@@ -5761,6 +5878,21 @@ func (p *LogicalType) writeField18(ctx context.Context, oprot thrift.TProtocol) 
 	return err
 }
 
+func (p *LogicalType) writeField19(ctx context.Context, oprot thrift.TProtocol) (err error) {
+	if p.IsSetVECTOR() {
+		if err := oprot.WriteFieldBegin(ctx, "VECTOR", thrift.STRUCT, 19); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 19:VECTOR: ", p), err)
+		}
+		if err := p.VECTOR.Write(ctx, oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.VECTOR), err)
+		}
+		if err := oprot.WriteFieldEnd(ctx); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 19:VECTOR: ", p), err)
+		}
+	}
+	return err
+}
+
 func (p *LogicalType) Equals(other *LogicalType) bool {
 	if p == other {
 		return true
@@ -5784,6 +5916,7 @@ func (p *LogicalType) Equals(other *LogicalType) bool {
 	if !p.VARIANT.Equals(other.VARIANT) { return false }
 	if !p.GEOMETRY.Equals(other.GEOMETRY) { return false }
 	if !p.GEOGRAPHY.Equals(other.GEOGRAPHY) { return false }
+	if !p.VECTOR.Equals(other.VECTOR) { return false }
 	return true
 }
 
@@ -5856,7 +5989,7 @@ type SchemaElement struct {
 	Precision *int32 `thrift:"precision,8" db:"precision" json:"precision,omitempty"`
 	FieldID *int32 `thrift:"field_id,9" db:"field_id" json:"field_id,omitempty"`
 	LogicalType *LogicalType `thrift:"logicalType,10" db:"logicalType" json:"logicalType,omitempty"`
-	// EXPERIMENTAL: The fixed number of times the field repeats per parent
+	// EXPERIMENTAL: The fixed number of times the group repeats per parent
 	// value when repetition_type is VECTOR.
 	VectorLength *int32 `thrift:"vector_length,11" db:"vector_length" json:"vector_length,omitempty"`
 }

--- a/parquet/internal/thrift/vector_roundtrip_test.go
+++ b/parquet/internal/thrift/vector_roundtrip_test.go
@@ -17,16 +17,18 @@
 package thrift_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
 	"github.com/apache/arrow-go/v18/parquet/internal/thrift"
+	apachethrift "github.com/apache/thrift/lib/go/thrift"
 )
 
-// Verifies the hand-applied VECTOR repetition / vector_length additions to the
-// generated parquet.go round-trip through the Thrift compact protocol that
-// Parquet uses on disk.
+// Verifies the hand-applied VECTOR repetition / logical type / vector_length
+// additions to the generated parquet.go round-trip through the Thrift compact
+// protocol that Parquet uses on disk.
 func TestVectorThriftRoundTrip(t *testing.T) {
 	// Enum surface.
 	if got := format.FieldRepetitionType_VECTOR.String(); got != "VECTOR" {
@@ -36,32 +38,41 @@ func TestVectorThriftRoundTrip(t *testing.T) {
 		t.Fatalf("FieldRepetitionTypeFromString(VECTOR) = %v, %v", v, err)
 	}
 
-	// Uses VECTOR-repeated primitive leaf carrying vector_length.
-	vecRep := format.FieldRepetitionType_VECTOR
-	phys := format.Type_FLOAT
-	vlen := int32(768)
-	leaf := &format.SchemaElement{
+	// Canonical VECTOR uses an outer group annotated with LogicalType.VECTOR and
+	// a VECTOR-repeated middle group carrying vector_length.
+	outerRep := format.FieldRepetitionType_REQUIRED
+	childCount := int32(1)
+	outer := &format.SchemaElement{
 		Name:           "embedding",
-		Type:           &phys,
+		RepetitionType: &outerRep,
+		NumChildren:    &childCount,
+		LogicalType:    &format.LogicalType{VECTOR: format.NewVectorType()},
+	}
+	vecRep := format.FieldRepetitionType_VECTOR
+	vlen := int32(768)
+	middle := &format.SchemaElement{
+		Name:           "list",
 		RepetitionType: &vecRep,
+		NumChildren:    &childCount,
 		VectorLength:   &vlen,
 	}
 
 	ser := thrift.NewThriftSerializer()
-	b, err := ser.Write(context.Background(), leaf)
-	if err != nil {
-		t.Fatalf("serialize %q: %v", leaf.Name, err)
-	}
-	gotLeaf := format.NewSchemaElement()
-	if _, err := thrift.DeserializeThrift(gotLeaf, b); err != nil {
-		t.Fatalf("deserialize %q: %v", leaf.Name, err)
-	}
-	if !leaf.Equals(gotLeaf) {
-		t.Fatalf("round-trip mismatch for %q:\n have %s\n want %s", leaf.Name, gotLeaf, leaf)
+	for _, elem := range []*format.SchemaElement{outer, middle} {
+		b, err := ser.Write(context.Background(), elem)
+		if err != nil {
+			t.Fatalf("serialize %q: %v", elem.Name, err)
+		}
+		got := format.NewSchemaElement()
+		if _, err := thrift.DeserializeThrift(got, b); err != nil {
+			t.Fatalf("deserialize %q: %v", elem.Name, err)
+		}
+		if !elem.Equals(got) {
+			t.Fatalf("round-trip mismatch for %q:\n have %s\n want %s", elem.Name, got, elem)
+		}
 	}
 
-	// Specifically confirm vector_length (field 11) survived the wire.
-	b, err = ser.Write(context.Background(), leaf)
+	b, err := ser.Write(context.Background(), middle)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +86,30 @@ func TestVectorThriftRoundTrip(t *testing.T) {
 	if got.GetRepetitionType() != format.FieldRepetitionType_VECTOR {
 		t.Fatalf("repetition_type not preserved: %v", got.GetRepetitionType())
 	}
-	if got.GetType() != format.Type_FLOAT {
-		t.Fatalf("physical type not preserved: %v", got.GetType())
+
+	// Binary protocol exposes field ids directly; make sure vector_length uses
+	// SchemaElement field id 11.
+	buf := apachethrift.NewTMemoryBuffer()
+	bin := apachethrift.NewTBinaryProtocolConf(buf, nil)
+	if err := middle.Write(context.Background(), bin); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte{byte(apachethrift.I32), 0x00, 0x0b}) {
+		t.Fatalf("vector_length field id 11 not found in binary thrift: %x", buf.Bytes())
+	}
+	if bytes.Contains(buf.Bytes(), []byte{byte(apachethrift.I32), 0x00, 0x0c}) {
+		t.Fatalf("unexpected vector_length field id 12 found in binary thrift: %x", buf.Bytes())
+	}
+
+	b, err = ser.Write(context.Background(), outer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got = format.NewSchemaElement()
+	if _, err := thrift.DeserializeThrift(got, b); err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsSetLogicalType() || !got.GetLogicalType().IsSetVECTOR() {
+		t.Fatalf("VECTOR logical type not preserved: %v", got.GetLogicalType())
 	}
 }

--- a/parquet/internal/thrift/vector_roundtrip_test.go
+++ b/parquet/internal/thrift/vector_roundtrip_test.go
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package thrift_test
+
+import (
+	"context"
+	"testing"
+
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
+	"github.com/apache/arrow-go/v18/parquet/internal/thrift"
+)
+
+// Verifies the hand-applied VECTOR repetition / vector_length additions to the
+// generated parquet.go round-trip through the Thrift compact protocol that
+// Parquet uses on disk.
+func TestVectorThriftRoundTrip(t *testing.T) {
+	// Enum surface.
+	if got := format.FieldRepetitionType_VECTOR.String(); got != "VECTOR" {
+		t.Fatalf("FieldRepetitionType_VECTOR.String() = %q, want VECTOR", got)
+	}
+	if v, err := format.FieldRepetitionTypeFromString("VECTOR"); err != nil || v != format.FieldRepetitionType_VECTOR {
+		t.Fatalf("FieldRepetitionTypeFromString(VECTOR) = %v, %v", v, err)
+	}
+
+	// Reduced Option B uses a VECTOR-repeated primitive leaf carrying
+	// vector_length.
+	vecRep := format.FieldRepetitionType_VECTOR
+	phys := format.Type_FLOAT
+	vlen := int32(768)
+	leaf := &format.SchemaElement{
+		Name:           "embedding",
+		Type:           &phys,
+		RepetitionType: &vecRep,
+		VectorLength:   &vlen,
+	}
+
+	ser := thrift.NewThriftSerializer()
+	b, err := ser.Write(context.Background(), leaf)
+	if err != nil {
+		t.Fatalf("serialize %q: %v", leaf.Name, err)
+	}
+	gotLeaf := format.NewSchemaElement()
+	if _, err := thrift.DeserializeThrift(gotLeaf, b); err != nil {
+		t.Fatalf("deserialize %q: %v", leaf.Name, err)
+	}
+	if !leaf.Equals(gotLeaf) {
+		t.Fatalf("round-trip mismatch for %q:\n have %s\n want %s", leaf.Name, gotLeaf, leaf)
+	}
+
+	// Specifically confirm vector_length (field 11) survived the wire.
+	b, err = ser.Write(context.Background(), leaf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := format.NewSchemaElement()
+	if _, err := thrift.DeserializeThrift(got, b); err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsSetVectorLength() || got.GetVectorLength() != 768 {
+		t.Fatalf("vector_length not preserved: isset=%v val=%d", got.IsSetVectorLength(), got.GetVectorLength())
+	}
+	if got.GetRepetitionType() != format.FieldRepetitionType_VECTOR {
+		t.Fatalf("repetition_type not preserved: %v", got.GetRepetitionType())
+	}
+	if got.GetType() != format.Type_FLOAT {
+		t.Fatalf("physical type not preserved: %v", got.GetType())
+	}
+}

--- a/parquet/internal/thrift/vector_roundtrip_test.go
+++ b/parquet/internal/thrift/vector_roundtrip_test.go
@@ -36,8 +36,7 @@ func TestVectorThriftRoundTrip(t *testing.T) {
 		t.Fatalf("FieldRepetitionTypeFromString(VECTOR) = %v, %v", v, err)
 	}
 
-	// Reduced Option B uses a VECTOR-repeated primitive leaf carrying
-	// vector_length.
+	// Uses VECTOR-repeated primitive leaf carrying vector_length.
 	vecRep := format.FieldRepetitionType_VECTOR
 	phys := format.Type_FLOAT
 	vlen := int32(768)

--- a/parquet/metadata/file.go
+++ b/parquet/metadata/file.go
@@ -313,7 +313,9 @@ func NewFileMetaData(data []byte, fileDecryptor encryption.FileDecryptor) (*File
 		FileDecryptor: fileDecryptor,
 	}
 
-	f.initSchema()
+	if err := f.initSchema(); err != nil {
+		return nil, err
+	}
 	f.initColumnOrders()
 
 	return f, nil
@@ -361,8 +363,8 @@ func (f *FileMetaData) initSchema() error {
 	if err != nil {
 		return err
 	}
-	f.Schema = schema.NewSchema(root.(*schema.GroupNode))
-	return nil
+	f.Schema, err = schema.NewSchemaChecked(root.(*schema.GroupNode))
+	return err
 }
 
 func (f *FileMetaData) initColumnOrders() {

--- a/parquet/metadata/metadata_test.go
+++ b/parquet/metadata/metadata_test.go
@@ -86,26 +86,36 @@ func assertStats(t *testing.T, m *metadata.ColumnChunkMetaData) metadata.TypedSt
 }
 
 func TestNewFileMetaDataRejectsInvalidVectorSchema(t *testing.T) {
-	rootChildren := int32(1)
-	optionalChildren := int32(1)
+	oneChild := int32(1)
 	vectorLen := int32(4)
 	fileMeta := format.NewFileMetaData()
 	fileMeta.Schema = []*format.SchemaElement{
 		{
 			Name:           "schema",
 			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_REQUIRED),
-			NumChildren:    &rootChildren,
+			NumChildren:    &oneChild,
 		},
 		{
-			Name:           "optional_parent",
-			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_OPTIONAL),
-			NumChildren:    &optionalChildren,
+			Name:           "repeated_parent",
+			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_REPEATED),
+			NumChildren:    &oneChild,
 		},
 		{
 			Name:           "v",
+			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_REQUIRED),
+			NumChildren:    &oneChild,
+			LogicalType:    &format.LogicalType{VECTOR: format.NewVectorType()},
+		},
+		{
+			Name:           "list",
 			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_VECTOR),
-			Type:           format.TypePtr(format.Type_FLOAT),
+			NumChildren:    &oneChild,
 			VectorLength:   &vectorLen,
+		},
+		{
+			Name:           "element",
+			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_REQUIRED),
+			Type:           format.TypePtr(format.Type_FLOAT),
 		},
 	}
 
@@ -114,7 +124,7 @@ func TestNewFileMetaDataRejectsInvalidVectorSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = metadata.NewFileMetaData(buf.Bytes(), nil)
-	require.ErrorContains(t, err, "VECTOR columns must be non-nullable")
+	require.ErrorContains(t, err, "VECTOR columns with repeated ancestors")
 }
 
 func TestBuildAccess(t *testing.T) {

--- a/parquet/metadata/metadata_test.go
+++ b/parquet/metadata/metadata_test.go
@@ -17,6 +17,7 @@
 package metadata_test
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
+	"github.com/apache/arrow-go/v18/parquet/internal/thrift"
 	"github.com/apache/arrow-go/v18/parquet/metadata"
 	"github.com/apache/arrow-go/v18/parquet/schema"
 	"github.com/stretchr/testify/assert"
@@ -80,6 +83,38 @@ func assertStats(t *testing.T, m *metadata.ColumnChunkMetaData) metadata.TypedSt
 	assert.NoError(t, err)
 	assert.NotNil(t, s)
 	return s
+}
+
+func TestNewFileMetaDataRejectsInvalidVectorSchema(t *testing.T) {
+	rootChildren := int32(1)
+	optionalChildren := int32(1)
+	vectorLen := int32(4)
+	fileMeta := format.NewFileMetaData()
+	fileMeta.Schema = []*format.SchemaElement{
+		{
+			Name:           "schema",
+			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_REQUIRED),
+			NumChildren:    &rootChildren,
+		},
+		{
+			Name:           "optional_parent",
+			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_OPTIONAL),
+			NumChildren:    &optionalChildren,
+		},
+		{
+			Name:           "v",
+			RepetitionType: format.FieldRepetitionTypePtr(format.FieldRepetitionType_VECTOR),
+			Type:           format.TypePtr(format.Type_FLOAT),
+			VectorLength:   &vectorLen,
+		},
+	}
+
+	var buf bytes.Buffer
+	_, err := thrift.NewThriftSerializer().Serialize(fileMeta, &buf, nil)
+	require.NoError(t, err)
+
+	_, err = metadata.NewFileMetaData(buf.Bytes(), nil)
+	require.ErrorContains(t, err, "VECTOR columns must be non-nullable")
 }
 
 func TestBuildAccess(t *testing.T) {

--- a/parquet/parquet_vector.thrift
+++ b/parquet/parquet_vector.thrift
@@ -14,26 +14,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// EXPERIMENTAL: VECTOR repetition — reduced Option B.
+// EXPERIMENTAL: VECTOR logical type + repetition.
 //
 // This is a *fragment*, not a complete IDL. arrow-go generates
 // parquet/internal/gen-go/parquet/parquet.go from a full upstream
-// parquet.thrift that is supplied externally at generation time (see the
+// parquet.thrift supplied externally at generation time (see the
 // `//go:generate thrift -o internal -r --gen go ../parquet.thrift` directive
-// in parquet/doc.go); that complete file is not vendored in this repository.
+// in parquet/doc.go); that complete file is not vendored here.
 //
 // The VECTOR additions below are not yet part of upstream apache/parquet-format.
 // Until they are, the corresponding additions in the generated parquet.go were
 // applied by hand, matching the Thrift 0.21.0 code generator that produced the
 // rest of that file. Byte-identical regeneration therefore requires:
 //   1. merging the snippets below into the upstream parquet.thrift, and
-//   2. running the Thrift 0.21.0 compiler (the version that produced the
-//      current parquet.go; newer compilers reformat the entire file).
+//   2. running the Thrift 0.21.0 compiler (newer compilers reformat the file).
 //
 // This fragment is the source of truth for the IDL; keep it in sync with the
 // hand-applied changes in parquet/internal/gen-go/parquet/parquet.go.
 //
-// Reference: rok/arrow#51 (Parquet C++ Option B prototype) and the
+// Reference: rok/arrow#51 (Parquet C++ prototype) and the
 // "Fixed-size list type for Parquet" design document.
 
 // ---------------------------------------------------------------------------
@@ -52,43 +51,39 @@ enum FieldRepetitionType {
   /** The field is repeated and can contain 0 or more values */
   REPEATED = 2;
 
-  // EXPERIMENTAL VECTOR layout rules (kept out of the doc comment so they are
-  // not copied into generated code):
-  //
-  // A VECTOR field repeats exactly vector_length times for every parent value
-  // and, unlike REPEATED, does not increase the maximum definition or
-  // repetition level of its descendants: readers reconstruct vector values
-  // from the fixed multiplicity declared in the schema instead of decoding
-  // repetition levels.
-  //
-  // This reduced Option B implementation only allows VECTOR on primitive leaf
-  // fields:
-  //
-  //   vector <element-type> <name> [vector_length];
-  //
-  // - The VECTOR leaf carries vector_length and MUST be a primitive field.
-  // - The vector value and its element values are non-nullable in this reduced
-  //   implementation. Nullable Arrow FixedSizeList values or nullable elements
-  //   are represented with the standard LIST encoding instead.
-  // - For each parent record, writers MUST emit exactly vector_length physical
-  //   leaf values contiguously. Column chunk num_values is therefore
-  //   parent_row_count * vector_length.
-  // - Writers MUST NOT split the slots of one vector value across data pages;
-  //   pages begin and end on whole-vector boundaries.
-  // - Statistics are computed over flattened element values, not over
-  //   lexicographically ordered vector values.
-  // - vector_length MUST be positive: zero-length fixed-size lists are not
-  //   represented as VECTOR and use the LIST encoding instead.
-  //
-  // Readers that do not understand VECTOR are expected to reject the file.
-
   // EXPERIMENTAL: fixed-size repetition.
+  //
+  // VECTOR repeats exactly vector_length times for every parent value and,
+  // unlike REPEATED, does not increase the maximum definition or repetition
+  // level of descendants. It is used only on the middle group of the canonical
+  // VECTOR layout:
+  //
+  //   required group embedding (VECTOR) {
+  //     vector group list [vector_length] {
+  //       required float element;
+  //     }
+  //   }
+  //
+  // The VECTOR-repeated group carries vector_length, has exactly one element
+  // child, and is the single child of an outer group annotated with
+  // LogicalType.VECTOR. Writers emit vector_length element slots contiguously
+  // per vector and do not split one vector across data pages.
   VECTOR = 3;
 }
 
-// The reduced leaf-only layout does not add a LogicalType union member: vectors
-// are identified solely by FieldRepetitionType.VECTOR plus vector_length on the
-// primitive leaf.
+// ---------------------------------------------------------------------------
+// struct VectorType + LogicalType union member
+// ---------------------------------------------------------------------------
+
+// EXPERIMENTAL: annotation for the outer group of a fixed-size vector field.
+struct VectorType {}
+
+union LogicalType {
+  // ... existing fields 1..18 ...
+
+  // EXPERIMENTAL: fixed-size vector logical type.
+  19: VectorType VECTOR;
+}
 
 // ---------------------------------------------------------------------------
 // struct SchemaElement  (add vector_length, field id 11)
@@ -97,15 +92,8 @@ enum FieldRepetitionType {
 struct SchemaElement {
   // ... existing fields 1..10 ...
 
-  // Field id 11 matches the apache/parquet-format Option B draft
-  // (pitrou:vector-repetition) so VECTOR files interoperate with a
-  // draft-conformant reader.
-  //
   // vector_length MUST be set, and positive, when repetition_type is VECTOR
-  // and MUST NOT be set otherwise.  Zero-length vectors are not representable
-  // as VECTOR and use the LIST encoding (see FieldRepetitionType.VECTOR).
-
-  // EXPERIMENTAL: The fixed number of times the field repeats per parent
-  // value when repetition_type is VECTOR.
+  // and MUST NOT be set otherwise. Zero-length vectors are not represented as
+  // VECTOR and use the standard LIST encoding.
   11: optional i32 vector_length;
 }

--- a/parquet/parquet_vector.thrift
+++ b/parquet/parquet_vector.thrift
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// EXPERIMENTAL: VECTOR repetition — reduced Option B.
+//
+// This is a *fragment*, not a complete IDL. arrow-go generates
+// parquet/internal/gen-go/parquet/parquet.go from a full upstream
+// parquet.thrift that is supplied externally at generation time (see the
+// `//go:generate thrift -o internal -r --gen go ../parquet.thrift` directive
+// in parquet/doc.go); that complete file is not vendored in this repository.
+//
+// The VECTOR additions below are not yet part of upstream apache/parquet-format.
+// Until they are, the corresponding additions in the generated parquet.go were
+// applied by hand, matching the Thrift 0.21.0 code generator that produced the
+// rest of that file. Byte-identical regeneration therefore requires:
+//   1. merging the snippets below into the upstream parquet.thrift, and
+//   2. running the Thrift 0.21.0 compiler (the version that produced the
+//      current parquet.go; newer compilers reformat the entire file).
+//
+// This fragment is the source of truth for the IDL; keep it in sync with the
+// hand-applied changes in parquet/internal/gen-go/parquet/parquet.go.
+//
+// Reference: rok/arrow#51 (Parquet C++ Option B prototype) and the
+// "Fixed-size list type for Parquet" design document.
+
+// ---------------------------------------------------------------------------
+// enum FieldRepetitionType  (add the VECTOR member)
+// ---------------------------------------------------------------------------
+
+enum FieldRepetitionType {
+  /** The field is required (can not be null) and each parent value MUST have
+   * exactly one value. */
+  REQUIRED = 0;
+
+  /** The field is optional (can be null) and each parent value can have 0 or
+   * 1 values. */
+  OPTIONAL = 1;
+
+  /** The field is repeated and can contain 0 or more values */
+  REPEATED = 2;
+
+  // EXPERIMENTAL VECTOR layout rules (kept out of the doc comment so they are
+  // not copied into generated code):
+  //
+  // A VECTOR field repeats exactly vector_length times for every parent value
+  // and, unlike REPEATED, does not increase the maximum definition or
+  // repetition level of its descendants: readers reconstruct vector values
+  // from the fixed multiplicity declared in the schema instead of decoding
+  // repetition levels.
+  //
+  // This reduced Option B implementation only allows VECTOR on primitive leaf
+  // fields:
+  //
+  //   vector <element-type> <name> [vector_length];
+  //
+  // - The VECTOR leaf carries vector_length and MUST be a primitive field.
+  // - The vector value and its element values are non-nullable in this reduced
+  //   implementation. Nullable Arrow FixedSizeList values or nullable elements
+  //   are represented with the standard LIST encoding instead.
+  // - For each parent record, writers MUST emit exactly vector_length physical
+  //   leaf values contiguously. Column chunk num_values is therefore
+  //   parent_row_count * vector_length.
+  // - Writers MUST NOT split the slots of one vector value across data pages;
+  //   pages begin and end on whole-vector boundaries.
+  // - Statistics are computed over flattened element values, not over
+  //   lexicographically ordered vector values.
+  // - vector_length MUST be positive: zero-length fixed-size lists are not
+  //   represented as VECTOR and use the LIST encoding instead.
+  //
+  // Readers that do not understand VECTOR are expected to reject the file.
+
+  // EXPERIMENTAL: fixed-size repetition.
+  VECTOR = 3;
+}
+
+// The reduced leaf-only layout does not add a LogicalType union member: vectors
+// are identified solely by FieldRepetitionType.VECTOR plus vector_length on the
+// primitive leaf.
+
+// ---------------------------------------------------------------------------
+// struct SchemaElement  (add vector_length, field id 11)
+// ---------------------------------------------------------------------------
+
+struct SchemaElement {
+  // ... existing fields 1..10 ...
+
+  // Field id 11 matches the apache/parquet-format Option B draft
+  // (pitrou:vector-repetition) so VECTOR files interoperate with a
+  // draft-conformant reader.
+  //
+  // vector_length MUST be set, and positive, when repetition_type is VECTOR
+  // and MUST NOT be set otherwise.  Zero-length vectors are not representable
+  // as VECTOR and use the LIST encoding (see FieldRepetitionType.VECTOR).
+
+  // EXPERIMENTAL: The fixed number of times the field repeats per parent
+  // value when repetition_type is VECTOR.
+  11: optional i32 vector_length;
+}

--- a/parquet/pqarrow/column_readers.go
+++ b/parquet/pqarrow/column_readers.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -170,6 +171,22 @@ func (lr *leafReader) SeekToRow(rowIdx int64) error {
 
 	lr.recordRdr.SetPageReader(pr)
 	return lr.recordRdr.SeekToRow(offset)
+}
+
+func (lr *leafReader) SeekToRowWithValueStride(rowIdx, valueStride int64) error {
+	pr, offset, err := lr.input.FindChunkForRow(rowIdx)
+	if err != nil {
+		return err
+	}
+
+	lr.recordRdr.SetPageReader(pr)
+	seeker, ok := lr.recordRdr.(interface {
+		SeekToRowWithValueStride(int64, int64) error
+	})
+	if !ok {
+		return errors.New("parquet: record reader does not support value-stride seeking")
+	}
+	return seeker.SeekToRowWithValueStride(offset, valueStride)
 }
 
 // nextRowGroup advances to the next row group. remainingRows is the number of
@@ -540,6 +557,111 @@ func newFixedSizeListReader(rctx *readerCtx, field *arrow.Field, info file.Level
 			&lr,
 		},
 	}
+}
+
+func mulVectorLen(value int64, listSize int32) (int64, error) {
+	if listSize <= 0 {
+		return 0, fmt.Errorf("VECTOR FixedSizeList must have a positive list size, got %d", listSize)
+	}
+	if value > math.MaxInt64/int64(listSize) {
+		return 0, errors.New("VECTOR FixedSizeList length overflow")
+	}
+	return value * int64(listSize), nil
+}
+
+// vectorFixedSizeListReader reads a Parquet VECTOR column (Option B) into an
+// Arrow FixedSizeList. In this phase only dense (non-nullable) vectors are
+// supported: the column has no per-element repetition or definition levels, so
+// the child leaf holds exactly listSize values per row and is reshaped into a
+// FixedSizeList without consulting any levels.
+type vectorFixedSizeListReader struct {
+	rctx     *readerCtx
+	field    *arrow.Field
+	info     file.LevelInfo
+	itemRdr  *ColumnReader
+	listSize int32
+	refCount atomic.Int64
+}
+
+func newVectorFixedSizeListReader(rctx *readerCtx, field *arrow.Field, info file.LevelInfo, listSize int32, childRdr *ColumnReader) *ColumnReader {
+	childRdr.Retain()
+	lr := &vectorFixedSizeListReader{rctx: rctx, field: field, info: info, itemRdr: childRdr, listSize: listSize}
+	lr.refCount.Add(1)
+	return &ColumnReader{lr}
+}
+
+func (lr *vectorFixedSizeListReader) Retain() { lr.refCount.Add(1) }
+
+func (lr *vectorFixedSizeListReader) Release() {
+	if lr.refCount.Add(-1) == 0 {
+		if lr.itemRdr != nil {
+			lr.itemRdr.Release()
+			lr.itemRdr = nil
+		}
+	}
+}
+
+func (lr *vectorFixedSizeListReader) GetDefLevels() ([]int16, error) {
+	return lr.itemRdr.GetDefLevels()
+}
+func (lr *vectorFixedSizeListReader) GetRepLevels() ([]int16, error) {
+	return lr.itemRdr.GetRepLevels()
+}
+func (lr *vectorFixedSizeListReader) Field() *arrow.Field        { return lr.field }
+func (lr *vectorFixedSizeListReader) IsOrHasRepeatedChild() bool { return false }
+
+func (lr *vectorFixedSizeListReader) SeekToRow(rowIdx int64) error {
+	seeker, ok := lr.itemRdr.colReaderImpl.(interface {
+		SeekToRowWithValueStride(int64, int64) error
+	})
+	if !ok {
+		return errors.New("parquet: VECTOR child reader does not support value-stride seeking")
+	}
+	return seeker.SeekToRowWithValueStride(rowIdx, int64(lr.listSize))
+}
+
+func (lr *vectorFixedSizeListReader) LoadBatch(nrecords int64) error {
+	// Each parent record contributes listSize leaf slots and there are no
+	// per-element levels, so the child reads nrecords*listSize values.
+	childRecords, err := mulVectorLen(nrecords, lr.listSize)
+	if err != nil {
+		return err
+	}
+	return lr.itemRdr.LoadBatch(childRecords)
+}
+
+func (lr *vectorFixedSizeListReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
+	if lr.field.Nullable || lr.info.HasNullableValues() {
+		return nil, fmt.Errorf("%w: reading nullable VECTOR columns is not supported yet", arrow.ErrNotImplemented)
+	}
+
+	childBound, err := mulVectorLen(lenBound, lr.listSize)
+	if err != nil {
+		return nil, err
+	}
+	childChunked, err := lr.itemRdr.BuildArray(childBound)
+	if err != nil {
+		return nil, err
+	}
+	defer childChunked.Release()
+
+	childData, err := chunksToSingle(childChunked, lr.rctx.mem)
+	if err != nil {
+		return nil, err
+	}
+	defer childData.Release()
+
+	if childData.Len()%int(lr.listSize) != 0 {
+		return nil, fmt.Errorf("VECTOR FixedSizeList child length %d is not divisible by list size %d",
+			childData.Len(), lr.listSize)
+	}
+	outRows := childData.Len() / int(lr.listSize)
+
+	data := array.NewData(lr.field.Type, outRows, []*memory.Buffer{nil}, []arrow.ArrayData{childData}, 0, 0)
+	defer data.Release()
+	out := array.MakeFromData(data)
+	defer out.Release()
+	return arrow.NewChunked(lr.field.Type, []arrow.Array{out}), nil
 }
 
 // helper function to combine chunks into a single array.

--- a/parquet/pqarrow/column_readers.go
+++ b/parquet/pqarrow/column_readers.go
@@ -569,7 +569,7 @@ func mulVectorLen(value int64, listSize int32) (int64, error) {
 	return value * int64(listSize), nil
 }
 
-// vectorFixedSizeListReader reads a Parquet VECTOR column (Option B) into an
+// vectorFixedSizeListReader reads a Parquet VECTOR column into an
 // Arrow FixedSizeList. In this phase only dense (non-nullable) vectors are
 // supported: the column has no per-element repetition or definition levels, so
 // the child leaf holds exactly listSize values per row and is reshaped into a
@@ -632,7 +632,7 @@ func (lr *vectorFixedSizeListReader) LoadBatch(nrecords int64) error {
 
 func (lr *vectorFixedSizeListReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
 	if lr.field.Nullable || lr.info.HasNullableValues() {
-		return nil, fmt.Errorf("%w: reading nullable VECTOR columns is not supported yet", arrow.ErrNotImplemented)
+		return nil, fmt.Errorf("%w: reading nullable VECTOR columns is not supported", arrow.ErrNotImplemented)
 	}
 
 	childBound, err := mulVectorLen(lenBound, lr.listSize)

--- a/parquet/pqarrow/column_readers.go
+++ b/parquet/pqarrow/column_readers.go
@@ -631,7 +631,8 @@ func (lr *vectorFixedSizeListReader) LoadBatch(nrecords int64) error {
 }
 
 func (lr *vectorFixedSizeListReader) BuildArray(lenBound int64) (*arrow.Chunked, error) {
-	if lr.field.Nullable || lr.info.HasNullableValues() {
+	fslType := lr.field.Type.(*arrow.FixedSizeListType)
+	if lr.field.Nullable || lr.info.HasNullableValues() || fslType.ElemField().Nullable {
 		return nil, fmt.Errorf("%w: reading nullable VECTOR columns is not supported", arrow.ErrNotImplemented)
 	}
 

--- a/parquet/pqarrow/encode_arrow.go
+++ b/parquet/pqarrow/encode_arrow.go
@@ -83,7 +83,7 @@ type arrowColumnWriter struct {
 //
 // Using an arrow column writer is a convenience to avoid having to process the arrow array yourself
 // and determine the correct definition and repetition levels manually.
-func newArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *SchemaManifest, rgw file.RowGroupWriter, leafColIdx int) (arrowColumnWriter, error) {
+func newArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *SchemaManifest, rgw file.RowGroupWriter, leafColIdx int, writeFixedSizeListAsVector bool) (arrowColumnWriter, error) {
 	if data.Len() == 0 {
 		return arrowColumnWriter{leafCount: calcLeafCount(data.DataType()), rgw: rgw}, nil
 	}
@@ -138,9 +138,9 @@ func newArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *Sch
 		defer arrToWrite.Release()
 
 		if arrToWrite.Len() > 0 {
-			bldr, err := newMultipathLevelBuilder(arrToWrite, isNullable)
+			bldr, err := newMultipathLevelBuilderWithVector(arrToWrite, isNullable, writeFixedSizeListAsVector)
 			if err != nil {
-				return arrowColumnWriter{}, nil
+				return arrowColumnWriter{}, err
 			}
 			if leafCount != bldr.leafCount() {
 				return arrowColumnWriter{}, fmt.Errorf("data type leaf_count != builder leaf_count: %d - %d", leafCount, bldr.leafCount())

--- a/parquet/pqarrow/encode_arrow.go
+++ b/parquet/pqarrow/encode_arrow.go
@@ -83,7 +83,7 @@ type arrowColumnWriter struct {
 //
 // Using an arrow column writer is a convenience to avoid having to process the arrow array yourself
 // and determine the correct definition and repetition levels manually.
-func newArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *SchemaManifest, rgw file.RowGroupWriter, leafColIdx int, writeFixedSizeListAsVector bool) (arrowColumnWriter, error) {
+func newArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *SchemaManifest, rgw file.RowGroupWriter, leafColIdx int) (arrowColumnWriter, error) {
 	if data.Len() == 0 {
 		return arrowColumnWriter{leafCount: calcLeafCount(data.DataType()), rgw: rgw}, nil
 	}
@@ -125,6 +125,7 @@ func newArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *Sch
 		return arrowColumnWriter{}, err
 	}
 	isNullable = nullableRoot(manifest, schemaField)
+	writeFixedSizeListAsVector := schemaField.IsVector
 
 	builders := make([]*multipathLevelBuilder, 0)
 	for values < size {

--- a/parquet/pqarrow/file_reader.go
+++ b/parquet/pqarrow/file_reader.go
@@ -641,7 +641,12 @@ func (fr *FileReader) getReader(ctx context.Context, field *SchemaField, arrowFi
 		case *arrow.ListType, *arrow.LargeListType:
 			out = newListReader(&rctx, &arrowField, field.LevelInfo, childReader, fr.Props)
 		case *arrow.FixedSizeListType:
-			out = newFixedSizeListReader(&rctx, &arrowField, field.LevelInfo, childReader, fr.Props)
+			if field.IsVector {
+				out = newVectorFixedSizeListReader(&rctx, &arrowField, field.LevelInfo,
+					arrowField.Type.(*arrow.FixedSizeListType).Len(), childReader)
+			} else {
+				out = newFixedSizeListReader(&rctx, &arrowField, field.LevelInfo, childReader, fr.Props)
+			}
 		default:
 			return nil, fmt.Errorf("unknown list type: %s", field.Field.String())
 		}

--- a/parquet/pqarrow/file_writer.go
+++ b/parquet/pqarrow/file_writer.go
@@ -445,7 +445,7 @@ func (fw *FileWriter) WriteColumnChunked(data *arrow.Chunked, offset, size int64
 	if fw.closed {
 		return fmt.Errorf("invalid write call: FileWriter is already closed")
 	}
-	acw, err := newArrowColumnWriter(data, offset, size, fw.manifest, fw.rgw, fw.colIdx, fw.arrowProps.writeFixedSizeListAsVector)
+	acw, err := newArrowColumnWriter(data, offset, size, fw.manifest, fw.rgw, fw.colIdx)
 	if err != nil {
 		return err
 	}

--- a/parquet/pqarrow/file_writer.go
+++ b/parquet/pqarrow/file_writer.go
@@ -445,7 +445,7 @@ func (fw *FileWriter) WriteColumnChunked(data *arrow.Chunked, offset, size int64
 	if fw.closed {
 		return fmt.Errorf("invalid write call: FileWriter is already closed")
 	}
-	acw, err := newArrowColumnWriter(data, offset, size, fw.manifest, fw.rgw, fw.colIdx)
+	acw, err := newArrowColumnWriter(data, offset, size, fw.manifest, fw.rgw, fw.colIdx, fw.arrowProps.writeFixedSizeListAsVector)
 	if err != nil {
 		return err
 	}

--- a/parquet/pqarrow/path_builder.go
+++ b/parquet/pqarrow/path_builder.go
@@ -310,10 +310,10 @@ type pathBuilder struct {
 	paths            []pathInfo
 	nullableInParent bool
 
-	// writeFixedSizeListAsVector mirrors ArrowWriterProperties: when set, an
-	// eligible top-level FixedSizeList column is encoded as Parquet VECTOR
-	// instead of the standard LIST encoding. Must use the same eligibility
-	// predicate as ToParquet so the schema and the generated levels agree.
+	// writeFixedSizeListAsVector is set from the schema manifest when this
+	// top-level FixedSizeList column is encoded as Parquet VECTOR instead of the
+	// standard LIST encoding. Must use the same eligibility predicate as
+	// ToParquet so the schema and generated levels agree.
 	writeFixedSizeListAsVector bool
 	// atRoot is true only for the very first Visit (the top-level column field).
 	// We allow VECTOR only for top-level FixedSizeList columns, so the flag is

--- a/parquet/pqarrow/path_builder.go
+++ b/parquet/pqarrow/path_builder.go
@@ -310,6 +310,17 @@ type pathBuilder struct {
 	paths            []pathInfo
 	nullableInParent bool
 
+	// writeFixedSizeListAsVector mirrors ArrowWriterProperties: when set, an
+	// eligible top-level FixedSizeList column is encoded as Parquet VECTOR
+	// (Option B) instead of the standard LIST encoding. Must use the same
+	// eligibility predicate as ToParquet so the schema and the generated levels
+	// agree.
+	writeFixedSizeListAsVector bool
+	// atRoot is true only for the very first Visit (the top-level column field).
+	// Phase 1 encodes VECTOR only for top-level FixedSizeList columns, so the
+	// flag is consumed once and cleared as soon as we descend into any child.
+	atRoot bool
+
 	refCount *atomic.Int64
 }
 
@@ -403,6 +414,8 @@ func (p *pathBuilder) visitListLike(arr arrow.Array, selector rangeSelector, def
 }
 
 func (p *pathBuilder) Visit(arr arrow.Array) error {
+	atRoot := p.atRoot
+	p.atRoot = false
 	switch arr.DataType().ID() {
 	case arrow.LIST, arrow.MAP:
 		larr, ok := arr.(*array.List)
@@ -421,9 +434,16 @@ func (p *pathBuilder) Visit(arr arrow.Array) error {
 			larr.ListValues())
 	case arrow.FIXED_SIZE_LIST:
 		larr := arr.(*array.FixedSizeList)
-		listSize := larr.DataType().(*arrow.FixedSizeListType).Len()
+		fslType := larr.DataType().(*arrow.FixedSizeListType)
+		// Option B: encode an eligible top-level FixedSizeList column as VECTOR.
+		// This must match the schema decision in ToParquet (top-level only,
+		// non-nullable value and element, positive length, fixed-width primitive
+		// element) so the parquet schema and the generated def/rep levels agree.
+		if atRoot && p.writeFixedSizeListAsVector && isVectorEligibleFixedSizeList(p.nullableInParent, fslType) {
+			return p.visitVector(larr, fslType)
+		}
 		return p.visitListLike(arr,
-			fixedSizeRangeSelector{listSize},
+			fixedSizeRangeSelector{fslType.Len()},
 			0, // defLevelIfEmpty = maxDefLevel (after all increments)
 			larr.ListValues())
 	case arrow.DICTIONARY:
@@ -461,6 +481,27 @@ func (p *pathBuilder) Visit(arr arrow.Array) error {
 		p.addTerminalInfo(arr)
 		return nil
 	}
+}
+
+// visitVector handles the Option B dense VECTOR case: a non-nullable
+// FixedSizeList with a non-nullable element contributes exactly fslType.Len()
+// leaf values per row and no definition or repetition levels. The fixed-size
+// child is flattened to the leaf (accounting for the array's slice offset).
+func (p *pathBuilder) visitVector(larr *array.FixedSizeList, fslType *arrow.FixedSizeListType) error {
+	if larr.NullN() > 0 {
+		return fmt.Errorf("parquet: VECTOR column %s is non-nullable but contains null vector values", larr.DataType())
+	}
+	listSize := int64(fslType.Len())
+	start, _ := larr.ValueOffsets(0)
+	values := array.NewSlice(larr.ListValues(), start, start+int64(larr.Len())*listSize)
+	defer values.Release()
+	if values.NullN() > 0 {
+		return fmt.Errorf("parquet: VECTOR column %s has non-nullable elements but contains null element values", larr.DataType())
+	}
+
+	p.nullableInParent = false
+	p.addTerminalInfo(values)
+	return nil
 }
 
 func (p *pathBuilder) addTerminalInfo(arr arrow.Array) {
@@ -529,11 +570,21 @@ func (m *multipathLevelBuilder) Release() {
 }
 
 func newMultipathLevelBuilder(arr arrow.Array, fieldNullable bool) (*multipathLevelBuilder, error) {
+	return newMultipathLevelBuilderWithVector(arr, fieldNullable, false)
+}
+
+func newMultipathLevelBuilderWithVector(arr arrow.Array, fieldNullable, writeFixedSizeListAsVector bool) (*multipathLevelBuilder, error) {
 	ret := &multipathLevelBuilder{
 		refCount:  utils.NewRefCount(1),
 		rootRange: elemRange{int64(0), int64(arr.Data().Len())},
 		data:      arr.Data(),
-		builder:   pathBuilder{nullableInParent: fieldNullable, paths: make([]pathInfo, 0), refCount: utils.NewRefCount(1)},
+		builder: pathBuilder{
+			nullableInParent:           fieldNullable,
+			paths:                      make([]pathInfo, 0),
+			refCount:                   utils.NewRefCount(1),
+			writeFixedSizeListAsVector: writeFixedSizeListAsVector,
+			atRoot:                     true,
+		},
 	}
 	if err := ret.builder.Visit(arr); err != nil {
 		return nil, err

--- a/parquet/pqarrow/path_builder.go
+++ b/parquet/pqarrow/path_builder.go
@@ -312,13 +312,12 @@ type pathBuilder struct {
 
 	// writeFixedSizeListAsVector mirrors ArrowWriterProperties: when set, an
 	// eligible top-level FixedSizeList column is encoded as Parquet VECTOR
-	// (Option B) instead of the standard LIST encoding. Must use the same
-	// eligibility predicate as ToParquet so the schema and the generated levels
-	// agree.
+	// instead of the standard LIST encoding. Must use the same eligibility
+	// predicate as ToParquet so the schema and the generated levels agree.
 	writeFixedSizeListAsVector bool
 	// atRoot is true only for the very first Visit (the top-level column field).
-	// Phase 1 encodes VECTOR only for top-level FixedSizeList columns, so the
-	// flag is consumed once and cleared as soon as we descend into any child.
+	// We allow VECTOR only for top-level FixedSizeList columns, so the flag is
+	// consumed once and cleared as soon as we descend into any child.
 	atRoot bool
 
 	refCount *atomic.Int64
@@ -435,7 +434,7 @@ func (p *pathBuilder) Visit(arr arrow.Array) error {
 	case arrow.FIXED_SIZE_LIST:
 		larr := arr.(*array.FixedSizeList)
 		fslType := larr.DataType().(*arrow.FixedSizeListType)
-		// Option B: encode an eligible top-level FixedSizeList column as VECTOR.
+		// Encode an eligible top-level FixedSizeList column as VECTOR.
 		// This must match the schema decision in ToParquet (top-level only,
 		// non-nullable value and element, positive length, fixed-width primitive
 		// element) so the parquet schema and the generated def/rep levels agree.
@@ -483,10 +482,10 @@ func (p *pathBuilder) Visit(arr arrow.Array) error {
 	}
 }
 
-// visitVector handles the Option B dense VECTOR case: a non-nullable
-// FixedSizeList with a non-nullable element contributes exactly fslType.Len()
-// leaf values per row and no definition or repetition levels. The fixed-size
-// child is flattened to the leaf (accounting for the array's slice offset).
+// visitVector handles the dense VECTOR case: a non-nullable FixedSizeList with
+// a non-nullable element contributes exactly fslType.Len() leaf values per row
+// and no definition or repetition levels. The fixed-size child is flattened to
+// the leaf (accounting for the array's slice offset).
 func (p *pathBuilder) visitVector(larr *array.FixedSizeList, fslType *arrow.FixedSizeListType) error {
 	if larr.NullN() > 0 {
 		return fmt.Errorf("parquet: VECTOR column %s is non-nullable but contains null vector values", larr.DataType())

--- a/parquet/pqarrow/properties.go
+++ b/parquet/pqarrow/properties.go
@@ -121,9 +121,9 @@ func WithNoMapLogicalType() WriterOption {
 }
 
 // WithVectorEncoding is EXPERIMENTAL. It enables encoding supported Arrow
-// FixedSizeList columns as the Parquet VECTOR repetition type (Option B)
-// instead of the standard 3-level LIST encoding, eliminating per-element
-// repetition levels for fixed-shape data.
+// FixedSizeList columns as the Parquet VECTOR repetition type instead of the
+// standard 3-level LIST encoding, eliminating per-element repetition levels for
+// fixed-shape data.
 //
 // In this initial form only top-level, non-nullable FixedSizeList values with a
 // positive list size and a fixed-width primitive element are encoded as VECTOR;

--- a/parquet/pqarrow/properties.go
+++ b/parquet/pqarrow/properties.go
@@ -121,9 +121,8 @@ func WithNoMapLogicalType() WriterOption {
 }
 
 // WithVectorEncoding is EXPERIMENTAL. It enables encoding supported Arrow
-// FixedSizeList columns as the Parquet VECTOR repetition type instead of the
-// standard 3-level LIST encoding, eliminating per-element repetition levels for
-// fixed-shape data.
+// FixedSizeList columns as Parquet VECTOR instead of the standard LIST encoding,
+// eliminating per-element repetition levels for fixed-shape data.
 //
 // In this initial form only top-level, non-nullable FixedSizeList values with a
 // positive list size and a fixed-width primitive element are encoded as VECTOR;
@@ -135,19 +134,21 @@ func WithNoMapLogicalType() WriterOption {
 // error.
 //
 // VECTOR is not yet part of apache/parquet-format and is identified on disk by
-// FieldRepetitionType.VECTOR (= 3) plus SchemaElement.vector_length. A reader
-// that predates VECTOR support does not necessarily fail loudly: lacking a case
+// LogicalType.VECTOR on the outer group plus FieldRepetitionType.VECTOR (= 3)
+// and SchemaElement.vector_length on the middle group. A reader that predates
+// VECTOR support does not necessarily fail loudly: lacking a case
 // for the new repetition type, it may silently misread the column as a flat
 // required column with vector_length times too many values and the wrong row
 // count. Treat VECTOR as non-portable and only write it for consumers known to
 // understand it, until the repetition type is standardized.
 //
 // Without WithStoreSchema, a VECTOR column read back through pqarrow names its
-// element field "element" and carries no field-level metadata. WithStoreSchema
-// restores the FixedSizeList field's own metadata and the element type (for
-// example a timestamp's timezone); as with the standard LIST encoding it does
-// not restore user metadata attached to the inner element field. The element
-// values, element type, list size, and shape always round-trip either way.
+// element field "element" and does not preserve user field metadata.
+// WithStoreSchema restores the FixedSizeList field's own metadata and the
+// element type (for example a timestamp's timezone); as with the standard LIST
+// encoding it does not restore user metadata attached to the inner element
+// field. The element values, element type, list size, and shape always
+// round-trip either way.
 func WithVectorEncoding() WriterOption {
 	return func(c *config) {
 		c.props.writeFixedSizeListAsVector = true

--- a/parquet/pqarrow/properties.go
+++ b/parquet/pqarrow/properties.go
@@ -27,13 +27,14 @@ import (
 // ArrowWriterProperties are used to determine how to manipulate the arrow data
 // when writing it to a parquet file.
 type ArrowWriterProperties struct {
-	mem                      memory.Allocator
-	timestampAsInt96         bool
-	coerceTimestamps         bool
-	coerceTimestampUnit      arrow.TimeUnit
-	allowTruncatedTimestamps bool
-	storeSchema              bool
-	noMapLogicalType         bool
+	mem                        memory.Allocator
+	timestampAsInt96           bool
+	coerceTimestamps           bool
+	coerceTimestampUnit        arrow.TimeUnit
+	allowTruncatedTimestamps   bool
+	storeSchema                bool
+	noMapLogicalType           bool
+	writeFixedSizeListAsVector bool
 	// compliantNestedTypes     bool
 }
 
@@ -116,6 +117,40 @@ func WithStoreSchema() WriterOption {
 func WithNoMapLogicalType() WriterOption {
 	return func(c *config) {
 		c.props.noMapLogicalType = true
+	}
+}
+
+// WithVectorEncoding is EXPERIMENTAL. It enables encoding supported Arrow
+// FixedSizeList columns as the Parquet VECTOR repetition type (Option B)
+// instead of the standard 3-level LIST encoding, eliminating per-element
+// repetition levels for fixed-shape data.
+//
+// In this initial form only top-level, non-nullable FixedSizeList values with a
+// positive list size and a fixed-width primitive element are encoded as VECTOR;
+// every other FixedSizeList (nullable values or elements, zero-length,
+// variable-width, dictionary, extension, struct, nested-list elements, or nested
+// FixedSizeList fields) transparently falls back to the standard LIST encoding.
+// VECTOR does not broaden Parquet's Arrow type support: if an element type is
+// not supported by the standard Parquet conversion, writing still returns an
+// error.
+//
+// VECTOR is not yet part of apache/parquet-format and is identified on disk by
+// FieldRepetitionType.VECTOR (= 3) plus SchemaElement.vector_length. A reader
+// that predates VECTOR support does not necessarily fail loudly: lacking a case
+// for the new repetition type, it may silently misread the column as a flat
+// required column with vector_length times too many values and the wrong row
+// count. Treat VECTOR as non-portable and only write it for consumers known to
+// understand it, until the repetition type is standardized.
+//
+// Without WithStoreSchema, a VECTOR column read back through pqarrow names its
+// element field "element" and carries no field-level metadata. WithStoreSchema
+// restores the FixedSizeList field's own metadata and the element type (for
+// example a timestamp's timezone); as with the standard LIST encoding it does
+// not restore user metadata attached to the inner element field. The element
+// values, element type, list size, and shape always round-trip either way.
+func WithVectorEncoding() WriterOption {
+	return func(c *config) {
+		c.props.writeFixedSizeListAsVector = true
 	}
 }
 

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -45,9 +45,8 @@ type SchemaField struct {
 	ColIndex  int
 	LevelInfo file.LevelInfo
 
-	// IsVector is true when this field is backed by a Parquet VECTOR leaf
-	// i.e. an Arrow FixedSizeList encoded without per-element repetition
-	// levels.
+	// IsVector is true when this field is backed by a Parquet VECTOR column,
+	// i.e. an Arrow FixedSizeList encoded without per-element repetition levels.
 	IsVector bool
 }
 
@@ -267,10 +266,14 @@ func isVectorEligibleFixedSizeList(fieldNullable bool, fsl *arrow.FixedSizeListT
 	return !fieldNullable && fsl.Len() > 0 && !fsl.ElemField().Nullable && isSupportedVectorElementType(fsl.Elem())
 }
 
-// fixedSizeListToNode builds the Parquet VECTOR leaf for an Arrow
+// fixedSizeListToNode builds the canonical Parquet VECTOR group for an Arrow
 // FixedSizeList field:
 //
-//	vector <element-physical-type> <name> [N]
+//	required group <name> (VECTOR) {
+//	  vector group list [N] {
+//	    required <element-physical-type> element;
+//	  }
+//	}
 //
 // It returns ok=false (and a nil node) when the field is not a VECTOR-eligible
 // FixedSizeList for the current phase, signaling the caller to fall back to the
@@ -291,7 +294,15 @@ func fixedSizeListToNode(name string, field arrow.Field, props *parquet.WriterPr
 	if err != nil {
 		return nil, false, err
 	}
-	n, err := schema.NewPrimitiveNodeLogicalVector(name, logicalType, typ, length, fsl.Len(), fieldIDFromMeta(field.Metadata))
+	element, err := schema.NewPrimitiveNodeLogical("element", repFromNullable(elemField.Nullable), logicalType, typ, length, fieldIDFromMeta(elemField.Metadata))
+	if err != nil {
+		return nil, false, err
+	}
+	vector, err := schema.NewGroupNodeVector("list", schema.FieldList{element}, fsl.Len(), -1)
+	if err != nil {
+		return nil, false, err
+	}
+	n, err := schema.NewGroupNodeLogical(name, repFromNullable(field.Nullable), schema.FieldList{vector}, schema.VectorLogicalType{}, fieldIDFromMeta(field.Metadata))
 	if err != nil {
 		return nil, false, err
 	}
@@ -990,19 +1001,55 @@ func markVectorSubtree(field *SchemaField) {
 	}
 }
 
-// vectorPrimitiveToSchemaField reconstructs an Arrow FixedSizeList from a
-// reduced Parquet VECTOR primitive leaf:
+func isVectorLogicalGroup(n *schema.GroupNode) bool {
+	return n.LogicalType().Equals(schema.VectorLogicalType{})
+}
+
+// vectorToSchemaField reconstructs an Arrow FixedSizeList from the canonical
+// Parquet VECTOR group form:
 //
-//	vector <element-physical-type> <name> [N]
+//	<required|optional> group <name> (VECTOR) {
+//	  vector group list [N] {
+//	    <required|optional> <element-type> element;
+//	  }
+//	}
 //
-// Supports non-nullable fixed-width primitive elements only.
-func vectorPrimitiveToSchemaField(primitive *schema.PrimitiveNode, currentLevels file.LevelInfo, ctx *schemaTree, parent, out *SchemaField) error {
-	if primitive.VectorLength() <= 0 {
-		return errors.New("VECTOR primitive nodes must have a positive vector_length")
+// This implementation supports required vectors with required fixed-width
+// primitive elements.
+func vectorToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *schemaTree, parent, out *SchemaField) error {
+	if n.RepetitionType() != parquet.Repetitions.Required {
+		return errors.New("nullable or repeated VECTOR logical groups are not supported")
 	}
-	if currentLevels.DefLevel != 0 || currentLevels.RepLevel != 0 || currentLevels.RepeatedAncestorDefLevel != 0 {
-		return errors.New("VECTOR columns must be non-nullable and must not have repeated ancestors")
+	if n.NumFields() != 1 {
+		return errors.New("VECTOR groups must have a single VECTOR-repeated child")
 	}
+
+	currentLevels.Increment(n)
+	vectorLevel := currentLevels
+	child := n.Field(0)
+	if child.RepetitionType() != parquet.Repetitions.Vector || child.Type() != schema.Group {
+		return errors.New("VECTOR groups must contain a VECTOR-repeated group child")
+	}
+	vectorGroup := child.(*schema.GroupNode)
+	if vectorGroup.VectorLength() <= 0 {
+		return errors.New("VECTOR-repeated groups must have positive vector_length")
+	}
+	if vectorGroup.NumFields() != 1 {
+		return errors.New("VECTOR-repeated groups must have a single element child")
+	}
+	if !vectorGroup.LogicalType().IsNone() {
+		return errors.New("VECTOR-repeated groups must not have a logical type")
+	}
+
+	element := vectorGroup.Field(0)
+	if element.Type() != schema.Primitive {
+		return fmt.Errorf("%w: reading VECTOR columns with non-primitive elements is not supported", arrow.ErrNotImplemented)
+	}
+	primitive := element.(*schema.PrimitiveNode)
+	if primitive.RepetitionType() != parquet.Repetitions.Required {
+		return errors.New("nullable or repeated VECTOR elements are not supported")
+	}
+
 	colIndex := ctx.schema.ColumnIndexByNode(primitive)
 	arrowType, err := getArrowType(primitive.PhysicalType(), primitive.LogicalType(), primitive.TypeLength())
 	if err != nil {
@@ -1015,37 +1062,44 @@ func vectorPrimitiveToSchemaField(primitive *schema.PrimitiveNode, currentLevels
 		arrowType = &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrowType}
 	}
 
+	currentLevels.Increment(primitive)
 	out.Children = makeSchemaFields(1)
 	childField := &out.Children[0]
 	ctx.LinkParent(out, parent)
 	ctx.LinkParent(childField, out)
 
-	itemField := arrow.Field{Name: "element", Type: arrowType, Nullable: false}
+	var itemMetadata arrow.Metadata
+	if primitive.FieldID() >= 0 {
+		itemMetadata = createFieldMeta(int(primitive.FieldID()))
+	}
+	itemField := arrow.Field{Name: primitive.Name(), Type: arrowType, Nullable: primitive.RepetitionType() == parquet.Repetitions.Optional, Metadata: itemMetadata}
 	populateLeaf(colIndex, &itemField, currentLevels, ctx, out, childField)
 	markVectorSubtree(childField)
 
 	out.Field = &arrow.Field{
-		Name:     primitive.Name(),
-		Type:     arrow.FixedSizeListOfField(primitive.VectorLength(), *childField.Field),
-		Nullable: false,
-		Metadata: createFieldMeta(int(primitive.FieldID())),
+		Name:     n.Name(),
+		Type:     arrow.FixedSizeListOfField(vectorGroup.VectorLength(), *childField.Field),
+		Nullable: n.RepetitionType() == parquet.Repetitions.Optional,
+		Metadata: createFieldMeta(int(n.FieldID())),
 	}
-	out.LevelInfo = currentLevels
+	out.LevelInfo = vectorLevel
 	out.IsVector = true
 	return nil
 }
 
 func groupToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *schemaTree, parent, out *SchemaField) error {
+	if isVectorLogicalGroup(n) {
+		return vectorToSchemaField(n, currentLevels, ctx, parent, out)
+	}
+	if n.RepetitionType() == parquet.Repetitions.Vector {
+		return errors.New("VECTOR-repeated groups must be the single child of a group annotated with the VECTOR logical type")
+	}
 	if n.LogicalType().Equals(schema.NewListLogicalType()) {
 		return listToSchemaField(n, currentLevels, ctx, parent, out)
 	} else if n.LogicalType().Equals(schema.MapLogicalType{}) {
 		return mapToSchemaField(n, currentLevels, ctx, parent, out)
 	} else if n.LogicalType().Equals(schema.VariantLogicalType{}) {
 		return variantToSchemaField(n, currentLevels, ctx, parent, out)
-	}
-
-	if n.RepetitionType() == parquet.Repetitions.Vector {
-		return errors.New("VECTOR repetition is only supported on primitive leaf nodes")
 	}
 
 	if n.RepetitionType() == parquet.Repetitions.Repeated {
@@ -1115,7 +1169,7 @@ func nodeToSchemaField(n schema.Node, currentLevels file.LevelInfo, ctx *schemaT
 	}
 
 	if primitive.RepetitionType() == parquet.Repetitions.Vector {
-		return vectorPrimitiveToSchemaField(primitive, currentLevels, ctx, parent, out)
+		return errors.New("VECTOR repetition on primitive nodes is not supported; vectors must use the 3-level VECTOR group structure")
 	}
 
 	if primitive.RepetitionType() == parquet.Repetitions.Repeated {
@@ -1199,11 +1253,11 @@ func getNestedFactory(origin, inferred arrow.DataType) func(fieldList []arrow.Fi
 		}
 	case arrow.FIXED_SIZE_LIST:
 		// A VECTOR column is reconstructed directly as a FixedSizeList
-		// (see vectorPrimitiveToSchemaField), so its inferred id is
-		// FIXED_SIZE_LIST rather than LIST. Without this case getNestedFactory
-		// returns nil and applyOriginalStorageMetadata bails out before applying
-		// the stored Arrow element type/metadata (e.g. a timestamp's timezone or
-		// user field metadata), unlike the standard LIST-encoded path.
+		// (see vectorToSchemaField), so its inferred id is FIXED_SIZE_LIST rather
+		// than LIST. Without this case getNestedFactory returns nil and
+		// applyOriginalStorageMetadata bails out before applying the stored Arrow
+		// element type/metadata (e.g. a timestamp's timezone or user field
+		// metadata), unlike the standard LIST-encoded path.
 		if origin.ID() == arrow.FIXED_SIZE_LIST {
 			sz := origin.(*arrow.FixedSizeListType).Len()
 			return func(list []arrow.Field) arrow.DataType {

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -46,8 +46,8 @@ type SchemaField struct {
 	LevelInfo file.LevelInfo
 
 	// IsVector is true when this field is backed by a Parquet VECTOR leaf
-	// (Option B), i.e. an Arrow FixedSizeList encoded without per-element
-	// repetition levels.
+	// i.e. an Arrow FixedSizeList encoded without per-element repetition
+	// levels.
 	IsVector bool
 }
 
@@ -247,10 +247,10 @@ func repFromNullable(isnullable bool) parquet.Repetition {
 }
 
 // isSupportedVectorElementType reports whether an Arrow FixedSizeList element
-// type is encodable as a Parquet VECTOR element in this initial (Phase 1)
-// implementation: only fixed-width primitive elements qualify. Nested,
-// variable-width, dictionary, extension, and null elements fall back to the
-// standard LIST encoding.
+// type is encodable as a Parquet VECTOR element in initial implementation:
+// only fixed-width primitive elements qualify. Nested, variable-width,
+// dictionary, extension, and null elements fall back to the standard LIST
+// encoding.
 func isSupportedVectorElementType(dt arrow.DataType) bool {
 	switch dt.ID() {
 	case arrow.DICTIONARY, arrow.EXTENSION, arrow.NULL:
@@ -267,14 +267,14 @@ func isVectorEligibleFixedSizeList(fieldNullable bool, fsl *arrow.FixedSizeListT
 	return !fieldNullable && fsl.Len() > 0 && !fsl.ElemField().Nullable && isSupportedVectorElementType(fsl.Elem())
 }
 
-// fixedSizeListToNode builds the reduced Option B Parquet VECTOR leaf for an
-// Arrow FixedSizeList field:
+// fixedSizeListToNode builds the Parquet VECTOR leaf for an Arrow
+// FixedSizeList field:
 //
 //	vector <element-physical-type> <name> [N]
 //
 // It returns ok=false (and a nil node) when the field is not a VECTOR-eligible
 // FixedSizeList for the current phase, signaling the caller to fall back to the
-// standard LIST encoding. Phase 1 only encodes dense vectors: the list value
+// standard LIST encoding. This only encodes dense vectors: the list value
 // and its element must both be non-nullable, the list size positive, and the
 // element a fixed-width primitive.
 func fixedSizeListToNode(name string, field arrow.Field, props *parquet.WriterProperties, arrprops ArrowWriterProperties) (schema.Node, bool, error) {
@@ -442,11 +442,11 @@ func ToParquet(sc *arrow.Schema, props *parquet.WriterProperties, arrprops Arrow
 
 	nodes := make(schema.FieldList, 0, sc.NumFields())
 	for _, f := range sc.Fields() {
-		// EXPERIMENTAL (Option B): encode eligible top-level FixedSizeList
-		// columns as Parquet VECTOR. The decision is made here, at the top
-		// level, so Phase 1 only ever produces dense (no nullable/repeated
-		// ancestor) vectors; nested FixedSizeLists go through the normal
-		// fieldToNode path and use the standard LIST encoding.
+		// EXPERIMENTAL: encode eligible top-level FixedSizeList columns as
+		// Parquet VECTOR. The decision is made here, at the top level, so
+		// this only produces dense (no nullable/repeated ancestor) vectors;
+		// nested FixedSizeLists go through the normal fieldToNode path and
+		// use the standard LIST encoding.
 		if arrprops.writeFixedSizeListAsVector && f.Type.ID() == arrow.FIXED_SIZE_LIST {
 			n, ok, err := fixedSizeListToNode(f.Name, f, props, arrprops)
 			if err != nil {
@@ -991,11 +991,11 @@ func markVectorSubtree(field *SchemaField) {
 }
 
 // vectorPrimitiveToSchemaField reconstructs an Arrow FixedSizeList from a
-// reduced Option B Parquet VECTOR primitive leaf:
+// reduced Parquet VECTOR primitive leaf:
 //
 //	vector <element-physical-type> <name> [N]
 //
-// Phase 1 supports non-nullable fixed-width primitive elements only.
+// Supports non-nullable fixed-width primitive elements only.
 func vectorPrimitiveToSchemaField(primitive *schema.PrimitiveNode, currentLevels file.LevelInfo, ctx *schemaTree, parent, out *SchemaField) error {
 	if primitive.VectorLength() <= 0 {
 		return errors.New("VECTOR primitive nodes must have a positive vector_length")
@@ -1198,8 +1198,8 @@ func getNestedFactory(origin, inferred arrow.DataType) func(fieldList []arrow.Fi
 			}
 		}
 	case arrow.FIXED_SIZE_LIST:
-		// A VECTOR column (Option B) is reconstructed directly as a
-		// FixedSizeList (see vectorPrimitiveToSchemaField), so its inferred id is
+		// A VECTOR column is reconstructed directly as a FixedSizeList
+		// (see vectorPrimitiveToSchemaField), so its inferred id is
 		// FIXED_SIZE_LIST rather than LIST. Without this case getNestedFactory
 		// returns nil and applyOriginalStorageMetadata bails out before applying
 		// the stored Arrow element type/metadata (e.g. a timestamp's timezone or

--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -44,6 +44,11 @@ type SchemaField struct {
 	Children  []SchemaField
 	ColIndex  int
 	LevelInfo file.LevelInfo
+
+	// IsVector is true when this field is backed by a Parquet VECTOR leaf
+	// (Option B), i.e. an Arrow FixedSizeList encoded without per-element
+	// repetition levels.
+	IsVector bool
 }
 
 // IsLeaf returns true if the SchemaField is a leaf column, ie: ColIndex != -1
@@ -241,6 +246,58 @@ func repFromNullable(isnullable bool) parquet.Repetition {
 	return parquet.Repetitions.Required
 }
 
+// isSupportedVectorElementType reports whether an Arrow FixedSizeList element
+// type is encodable as a Parquet VECTOR element in this initial (Phase 1)
+// implementation: only fixed-width primitive elements qualify. Nested,
+// variable-width, dictionary, extension, and null elements fall back to the
+// standard LIST encoding.
+func isSupportedVectorElementType(dt arrow.DataType) bool {
+	switch dt.ID() {
+	case arrow.DICTIONARY, arrow.EXTENSION, arrow.NULL:
+		return false
+	}
+	if arrow.IsNested(dt.ID()) {
+		return false
+	}
+	_, fixedWidth := dt.(arrow.FixedWidthDataType)
+	return fixedWidth
+}
+
+func isVectorEligibleFixedSizeList(fieldNullable bool, fsl *arrow.FixedSizeListType) bool {
+	return !fieldNullable && fsl.Len() > 0 && !fsl.ElemField().Nullable && isSupportedVectorElementType(fsl.Elem())
+}
+
+// fixedSizeListToNode builds the reduced Option B Parquet VECTOR leaf for an
+// Arrow FixedSizeList field:
+//
+//	vector <element-physical-type> <name> [N]
+//
+// It returns ok=false (and a nil node) when the field is not a VECTOR-eligible
+// FixedSizeList for the current phase, signaling the caller to fall back to the
+// standard LIST encoding. Phase 1 only encodes dense vectors: the list value
+// and its element must both be non-nullable, the list size positive, and the
+// element a fixed-width primitive.
+func fixedSizeListToNode(name string, field arrow.Field, props *parquet.WriterProperties, arrprops ArrowWriterProperties) (schema.Node, bool, error) {
+	fsl, ok := field.Type.(*arrow.FixedSizeListType)
+	if !ok {
+		return nil, false, nil
+	}
+	elemField := fsl.ElemField()
+	if !isVectorEligibleFixedSizeList(field.Nullable, fsl) {
+		return nil, false, nil
+	}
+
+	typ, logicalType, length, err := getParquetType(elemField.Type, props, arrprops)
+	if err != nil {
+		return nil, false, err
+	}
+	n, err := schema.NewPrimitiveNodeLogicalVector(name, logicalType, typ, length, fsl.Len(), fieldIDFromMeta(field.Metadata))
+	if err != nil {
+		return nil, false, err
+	}
+	return n, true, nil
+}
+
 func variantToNode(t *extensions.VariantType, field arrow.Field, props *parquet.WriterProperties, arrProps ArrowWriterProperties) (schema.Node, error) {
 	fields := make(schema.FieldList, 1, 3)
 	var err error
@@ -385,6 +442,21 @@ func ToParquet(sc *arrow.Schema, props *parquet.WriterProperties, arrprops Arrow
 
 	nodes := make(schema.FieldList, 0, sc.NumFields())
 	for _, f := range sc.Fields() {
+		// EXPERIMENTAL (Option B): encode eligible top-level FixedSizeList
+		// columns as Parquet VECTOR. The decision is made here, at the top
+		// level, so Phase 1 only ever produces dense (no nullable/repeated
+		// ancestor) vectors; nested FixedSizeLists go through the normal
+		// fieldToNode path and use the standard LIST encoding.
+		if arrprops.writeFixedSizeListAsVector && f.Type.ID() == arrow.FIXED_SIZE_LIST {
+			n, ok, err := fixedSizeListToNode(f.Name, f, props, arrprops)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				nodes = append(nodes, n)
+				continue
+			}
+		}
 		n, err := fieldToNode(f.Name, f, props, arrprops)
 		if err != nil {
 			return nil, err
@@ -909,6 +981,60 @@ func variantToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx
 	return err
 }
 
+// markVectorSubtree flags a reconstructed VECTOR field and all of its
+// descendants as belonging to a VECTOR-repeated subtree.
+func markVectorSubtree(field *SchemaField) {
+	field.IsVector = true
+	for i := range field.Children {
+		markVectorSubtree(&field.Children[i])
+	}
+}
+
+// vectorPrimitiveToSchemaField reconstructs an Arrow FixedSizeList from a
+// reduced Option B Parquet VECTOR primitive leaf:
+//
+//	vector <element-physical-type> <name> [N]
+//
+// Phase 1 supports non-nullable fixed-width primitive elements only.
+func vectorPrimitiveToSchemaField(primitive *schema.PrimitiveNode, currentLevels file.LevelInfo, ctx *schemaTree, parent, out *SchemaField) error {
+	if primitive.VectorLength() <= 0 {
+		return errors.New("VECTOR primitive nodes must have a positive vector_length")
+	}
+	if currentLevels.DefLevel != 0 || currentLevels.RepLevel != 0 || currentLevels.RepeatedAncestorDefLevel != 0 {
+		return errors.New("VECTOR columns must be non-nullable and must not have repeated ancestors")
+	}
+	colIndex := ctx.schema.ColumnIndexByNode(primitive)
+	arrowType, err := getArrowType(primitive.PhysicalType(), primitive.LogicalType(), primitive.TypeLength())
+	if err != nil {
+		return err
+	}
+	if primitive.PhysicalType() == parquet.Types.ByteArray || !isSupportedVectorElementType(arrowType) {
+		return fmt.Errorf("%w: reading VECTOR columns with variable-width or non-primitive elements is not supported", arrow.ErrNotImplemented)
+	}
+	if ctx.props.ReadDict(colIndex) && isDictionaryReadSupported(arrowType) {
+		arrowType = &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrowType}
+	}
+
+	out.Children = makeSchemaFields(1)
+	childField := &out.Children[0]
+	ctx.LinkParent(out, parent)
+	ctx.LinkParent(childField, out)
+
+	itemField := arrow.Field{Name: "element", Type: arrowType, Nullable: false}
+	populateLeaf(colIndex, &itemField, currentLevels, ctx, out, childField)
+	markVectorSubtree(childField)
+
+	out.Field = &arrow.Field{
+		Name:     primitive.Name(),
+		Type:     arrow.FixedSizeListOfField(primitive.VectorLength(), *childField.Field),
+		Nullable: false,
+		Metadata: createFieldMeta(int(primitive.FieldID())),
+	}
+	out.LevelInfo = currentLevels
+	out.IsVector = true
+	return nil
+}
+
 func groupToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *schemaTree, parent, out *SchemaField) error {
 	if n.LogicalType().Equals(schema.NewListLogicalType()) {
 		return listToSchemaField(n, currentLevels, ctx, parent, out)
@@ -916,6 +1042,10 @@ func groupToSchemaField(n *schema.GroupNode, currentLevels file.LevelInfo, ctx *
 		return mapToSchemaField(n, currentLevels, ctx, parent, out)
 	} else if n.LogicalType().Equals(schema.VariantLogicalType{}) {
 		return variantToSchemaField(n, currentLevels, ctx, parent, out)
+	}
+
+	if n.RepetitionType() == parquet.Repetitions.Vector {
+		return errors.New("VECTOR repetition is only supported on primitive leaf nodes")
 	}
 
 	if n.RepetitionType() == parquet.Repetitions.Repeated {
@@ -982,6 +1112,10 @@ func nodeToSchemaField(n schema.Node, currentLevels file.LevelInfo, ctx *schemaT
 		case arrow.BINARY:
 			arrowType = arrow.BinaryTypes.LargeBinary
 		}
+	}
+
+	if primitive.RepetitionType() == parquet.Repetitions.Vector {
+		return vectorPrimitiveToSchemaField(primitive, currentLevels, ctx, parent, out)
 	}
 
 	if primitive.RepetitionType() == parquet.Repetitions.Repeated {
@@ -1061,6 +1195,19 @@ func getNestedFactory(origin, inferred arrow.DataType) func(fieldList []arrow.Fi
 		case arrow.LARGE_LIST:
 			return func(list []arrow.Field) arrow.DataType {
 				return arrow.LargeListOfField(list[0])
+			}
+		}
+	case arrow.FIXED_SIZE_LIST:
+		// A VECTOR column (Option B) is reconstructed directly as a
+		// FixedSizeList (see vectorPrimitiveToSchemaField), so its inferred id is
+		// FIXED_SIZE_LIST rather than LIST. Without this case getNestedFactory
+		// returns nil and applyOriginalStorageMetadata bails out before applying
+		// the stored Arrow element type/metadata (e.g. a timestamp's timezone or
+		// user field metadata), unlike the standard LIST-encoded path.
+		if origin.ID() == arrow.FIXED_SIZE_LIST {
+			sz := origin.(*arrow.FixedSizeListType).Len()
+			return func(list []arrow.Field) arrow.DataType {
+				return arrow.FixedSizeListOfField(sz, list[0])
 			}
 		}
 	case arrow.MAP:

--- a/parquet/pqarrow/schema_vector_test.go
+++ b/parquet/pqarrow/schema_vector_test.go
@@ -115,8 +115,8 @@ func TestToParquetFixedSizeListVector(t *testing.T) {
 }
 
 // A FixedSizeList nested inside a (top-level) struct must NOT become a VECTOR in
-// Phase 1: only top-level FixedSizeList columns are eligible, so nested ones use
-// the standard LIST encoding.
+// Only top-level FixedSizeList columns are eligible, so nested ones use the
+// standard LIST encoding.
 func TestToParquetNestedFixedSizeListStaysList(t *testing.T) {
 	inner := fslField("emb", arrow.PrimitiveTypes.Float32, 16, false, false)
 	cases := []arrow.Field{
@@ -125,7 +125,7 @@ func TestToParquetNestedFixedSizeListStaysList(t *testing.T) {
 	}
 	for _, field := range cases {
 		ps := toParquetVector(t, field, true /* enableVector */)
-		assert.False(t, treeHasVector(ps.Root().Field(0)), "nested FixedSizeList must not be encoded as VECTOR in Phase 1")
+		assert.False(t, treeHasVector(ps.Root().Field(0)), "nested FixedSizeList must not be encoded as VECTOR")
 	}
 }
 

--- a/parquet/pqarrow/schema_vector_test.go
+++ b/parquet/pqarrow/schema_vector_test.go
@@ -1,0 +1,205 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pqarrow_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/extensions"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func toParquetVector(t *testing.T, field arrow.Field, enableVector bool) *schema.Schema {
+	t.Helper()
+	asc := arrow.NewSchema([]arrow.Field{field}, nil)
+	var opts []pqarrow.WriterOption
+	if enableVector {
+		opts = append(opts, pqarrow.WithVectorEncoding())
+	}
+	ps, err := pqarrow.ToParquet(asc, nil, pqarrow.NewArrowWriterProperties(opts...))
+	require.NoError(t, err)
+	return ps
+}
+
+func isVectorLeaf(n schema.Node) bool {
+	return n.Type() == schema.Primitive && n.RepetitionType() == parquet.Repetitions.Vector
+}
+
+func treeHasVector(n schema.Node) bool {
+	if n.RepetitionType() == parquet.Repetitions.Vector {
+		return true
+	}
+	g, ok := n.(*schema.GroupNode)
+	if !ok {
+		return false
+	}
+	for i := 0; i < g.NumFields(); i++ {
+		if treeHasVector(g.Field(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+func fslField(name string, elem arrow.DataType, size int32, valNullable, elemNullable bool) arrow.Field {
+	listType := arrow.FixedSizeListOfField(size, arrow.Field{Name: "element", Type: elem, Nullable: elemNullable})
+	return arrow.Field{Name: name, Type: listType, Nullable: valNullable}
+}
+
+func TestToParquetFixedSizeListVector(t *testing.T) {
+	cases := []struct {
+		name         string
+		field        arrow.Field
+		enableVector bool
+		wantVector   bool
+		wantLen      int32
+		wantPhysical parquet.Type
+	}{
+		{"float32 dense enabled", fslField("emb", arrow.PrimitiveTypes.Float32, 128, false, false), true, true, 128, parquet.Types.Float},
+		{"int32 dense enabled", fslField("v", arrow.PrimitiveTypes.Int32, 3, false, false), true, true, 3, parquet.Types.Int32},
+		{"float64 dense enabled", fslField("v", arrow.PrimitiveTypes.Float64, 8, false, false), true, true, 8, parquet.Types.Double},
+		{"flag disabled -> LIST", fslField("emb", arrow.PrimitiveTypes.Float32, 128, false, false), false, false, 0, 0},
+		{"nullable value -> LIST", fslField("emb", arrow.PrimitiveTypes.Float32, 128, true, false), true, false, 0, 0},
+		{"nullable element -> LIST", fslField("emb", arrow.PrimitiveTypes.Float32, 128, false, true), true, false, 0, 0},
+		{"string element -> LIST", fslField("emb", arrow.BinaryTypes.String, 4, false, false), true, false, 0, 0},
+		{"dictionary element -> LIST", fslField("emb", &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int8, ValueType: arrow.PrimitiveTypes.Int32}, 4, false, false), true, false, 0, 0},
+		{"extension element -> LIST", fslField("emb", extensions.NewUUIDType(), 4, false, false), true, false, 0, 0},
+		{"fixed-size-list element -> LIST", fslField("outer", arrow.FixedSizeListOf(2, arrow.PrimitiveTypes.Float32), 4, false, false), true, false, 0, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ps := toParquetVector(t, tc.field, tc.enableVector)
+			top := ps.Root().Field(0)
+
+			if !tc.wantVector {
+				assert.False(t, treeHasVector(top), "expected no VECTOR node in the schema")
+				return
+			}
+
+			require.True(t, isVectorLeaf(top), "top-level field should be a VECTOR primitive leaf")
+			elem := top.(*schema.PrimitiveNode)
+			assert.Equal(t, parquet.Repetitions.Vector, elem.RepetitionType())
+			assert.Equal(t, tc.wantLen, elem.VectorLength())
+			assert.Equal(t, tc.wantPhysical, elem.PhysicalType())
+			assert.Equal(t, tc.field.Name, elem.Name())
+
+			// The leaf column carries the effective vector length and no inner levels.
+			require.Equal(t, 1, ps.NumColumns())
+			col := ps.Column(0)
+			assert.True(t, col.InVectorColumn())
+			assert.Equal(t, tc.wantLen, col.EffectiveVectorLength())
+			assert.EqualValues(t, 0, col.MaxDefinitionLevel())
+			assert.EqualValues(t, 0, col.MaxRepetitionLevel())
+		})
+	}
+}
+
+// A FixedSizeList nested inside a (top-level) struct must NOT become a VECTOR in
+// Phase 1: only top-level FixedSizeList columns are eligible, so nested ones use
+// the standard LIST encoding.
+func TestToParquetNestedFixedSizeListStaysList(t *testing.T) {
+	inner := fslField("emb", arrow.PrimitiveTypes.Float32, 16, false, false)
+	cases := []arrow.Field{
+		{Name: "s", Type: arrow.StructOf(inner)},
+		{Name: "l", Type: arrow.ListOfField(inner)},
+	}
+	for _, field := range cases {
+		ps := toParquetVector(t, field, true /* enableVector */)
+		assert.False(t, treeHasVector(ps.Root().Field(0)), "nested FixedSizeList must not be encoded as VECTOR in Phase 1")
+	}
+}
+
+// The read-side schema manifest reconstructs a VECTOR primitive leaf into an
+// Arrow FixedSizeList (with IsVector set) without needing a stored Arrow schema.
+func TestVectorSchemaManifestReconstruction(t *testing.T) {
+	field := fslField("emb", arrow.PrimitiveTypes.Float32, 128, false, false)
+	ps := toParquetVector(t, field, true)
+
+	manifest, err := pqarrow.NewSchemaManifest(ps, nil, &pqarrow.ArrowReadProperties{})
+	require.NoError(t, err)
+	require.Len(t, manifest.Fields, 1)
+
+	f := manifest.Fields[0]
+	assert.True(t, f.IsVector, "reconstructed field should be marked as VECTOR")
+	require.NotNil(t, f.Field)
+	fsl, ok := f.Field.Type.(*arrow.FixedSizeListType)
+	require.True(t, ok, "reconstructed type should be FixedSizeList, got %s", f.Field.Type)
+	assert.EqualValues(t, 128, fsl.Len())
+	assert.Equal(t, arrow.FLOAT32, fsl.Elem().ID())
+	assert.False(t, f.Field.Nullable)
+	assert.EqualValues(t, 0, f.LevelInfo.DefLevel)
+	assert.EqualValues(t, 0, f.LevelInfo.RepLevel)
+
+	require.Len(t, f.Children, 1)
+	leaf := f.Children[0]
+	assert.True(t, leaf.IsLeaf())
+	assert.True(t, leaf.IsVector)
+	assert.Equal(t, "element", leaf.Field.Name)
+	assert.Equal(t, arrow.FLOAT32, leaf.Field.Type.ID())
+	assert.False(t, leaf.Field.Nullable)
+}
+
+func TestVectorSchemaManifestRejectsNullableOrRepeatedVector(t *testing.T) {
+	makeLeaf := func() *schema.PrimitiveNode {
+		return schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("emb", nil, parquet.Types.Float, -1, 128, -1))
+	}
+
+	cases := []struct {
+		name string
+		node func() schema.Node
+	}{
+		{
+			name: "optional parent",
+			node: func() schema.Node {
+				return schema.MustGroup(schema.NewGroupNode("s", parquet.Repetitions.Optional, schema.FieldList{makeLeaf()}, -1))
+			},
+		},
+		{
+			name: "repeated parent",
+			node: func() schema.Node {
+				return schema.MustGroup(schema.NewGroupNode("items", parquet.Repetitions.Repeated, schema.FieldList{makeLeaf()}, -1))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{tc.node()}, -1))
+			require.Panics(t, func() { schema.NewSchema(root) })
+		})
+	}
+}
+
+// Without the vector flag the same FixedSizeList is a LIST on disk and the
+// manifest field is not marked as VECTOR.
+func TestVectorSchemaManifestListFallback(t *testing.T) {
+	field := fslField("emb", arrow.PrimitiveTypes.Float32, 128, false, false)
+	ps := toParquetVector(t, field, false)
+
+	manifest, err := pqarrow.NewSchemaManifest(ps, nil, &pqarrow.ArrowReadProperties{})
+	require.NoError(t, err)
+	require.Len(t, manifest.Fields, 1)
+	assert.False(t, manifest.Fields[0].IsVector)
+	_, isFSL := manifest.Fields[0].Field.Type.(*arrow.FixedSizeListType)
+	assert.False(t, isFSL, "LIST-encoded column should not reconstruct as FixedSizeList without a stored Arrow schema")
+}

--- a/parquet/pqarrow/schema_vector_test.go
+++ b/parquet/pqarrow/schema_vector_test.go
@@ -40,8 +40,9 @@ func toParquetVector(t *testing.T, field arrow.Field, enableVector bool) *schema
 	return ps
 }
 
-func isVectorLeaf(n schema.Node) bool {
-	return n.Type() == schema.Primitive && n.RepetitionType() == parquet.Repetitions.Vector
+func isVectorField(n schema.Node) bool {
+	g, ok := n.(*schema.GroupNode)
+	return ok && g.LogicalType().Equals(schema.VectorLogicalType{})
 }
 
 func treeHasVector(n schema.Node) bool {
@@ -96,12 +97,17 @@ func TestToParquetFixedSizeListVector(t *testing.T) {
 				return
 			}
 
-			require.True(t, isVectorLeaf(top), "top-level field should be a VECTOR primitive leaf")
-			elem := top.(*schema.PrimitiveNode)
-			assert.Equal(t, parquet.Repetitions.Vector, elem.RepetitionType())
-			assert.Equal(t, tc.wantLen, elem.VectorLength())
+			require.True(t, isVectorField(top), "top-level field should be a VECTOR logical group")
+			outer := top.(*schema.GroupNode)
+			assert.Equal(t, tc.field.Name, outer.Name())
+			require.Equal(t, 1, outer.NumFields())
+			vec := outer.Field(0).(*schema.GroupNode)
+			assert.Equal(t, parquet.Repetitions.Vector, vec.RepetitionType())
+			assert.Equal(t, tc.wantLen, vec.VectorLength())
+			require.Equal(t, 1, vec.NumFields())
+			elem := vec.Field(0).(*schema.PrimitiveNode)
 			assert.Equal(t, tc.wantPhysical, elem.PhysicalType())
-			assert.Equal(t, tc.field.Name, elem.Name())
+			assert.Equal(t, "element", elem.Name())
 
 			// The leaf column carries the effective vector length and no inner levels.
 			require.Equal(t, 1, ps.NumColumns())
@@ -129,7 +135,7 @@ func TestToParquetNestedFixedSizeListStaysList(t *testing.T) {
 	}
 }
 
-// The read-side schema manifest reconstructs a VECTOR primitive leaf into an
+// The read-side schema manifest reconstructs a VECTOR logical group into an
 // Arrow FixedSizeList (with IsVector set) without needing a stored Arrow schema.
 func TestVectorSchemaManifestReconstruction(t *testing.T) {
 	field := fslField("emb", arrow.PrimitiveTypes.Float32, 128, false, false)
@@ -159,35 +165,13 @@ func TestVectorSchemaManifestReconstruction(t *testing.T) {
 	assert.False(t, leaf.Field.Nullable)
 }
 
-func TestVectorSchemaManifestRejectsNullableOrRepeatedVector(t *testing.T) {
-	makeLeaf := func() *schema.PrimitiveNode {
-		return schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("emb", nil, parquet.Types.Float, -1, 128, -1))
-	}
-
-	cases := []struct {
-		name string
-		node func() schema.Node
-	}{
-		{
-			name: "optional parent",
-			node: func() schema.Node {
-				return schema.MustGroup(schema.NewGroupNode("s", parquet.Repetitions.Optional, schema.FieldList{makeLeaf()}, -1))
-			},
-		},
-		{
-			name: "repeated parent",
-			node: func() schema.Node {
-				return schema.MustGroup(schema.NewGroupNode("items", parquet.Repetitions.Repeated, schema.FieldList{makeLeaf()}, -1))
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{tc.node()}, -1))
-			require.Panics(t, func() { schema.NewSchema(root) })
-		})
-	}
+func TestVectorSchemaManifestRejectsRepeatedVectorAncestor(t *testing.T) {
+	element := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+	vec := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{element}, 128, -1))
+	field := schema.MustGroup(schema.NewGroupNodeLogical("emb", parquet.Repetitions.Required, schema.FieldList{vec}, schema.VectorLogicalType{}, -1))
+	repeated := schema.MustGroup(schema.NewGroupNode("items", parquet.Repetitions.Repeated, schema.FieldList{field}, -1))
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{repeated}, -1))
+	require.Panics(t, func() { schema.NewSchema(root) })
 }
 
 // Without the vector flag the same FixedSizeList is a LIST on disk and the

--- a/parquet/pqarrow/vector_fallback_test.go
+++ b/parquet/pqarrow/vector_fallback_test.go
@@ -66,7 +66,7 @@ func columnIsVector(t *testing.T, data []byte, i int) bool {
 
 // TestVectorFallbackRoundTrips checks that, with WithVectorEncoding enabled, a
 // FixedSizeList that is NOT VECTOR-eligible is transparently written as the
-// standard LIST encoding (no VECTOR leaf on disk) and still round-trips
+// standard LIST encoding (no VECTOR column on disk) and still round-trips
 // losslessly through pqarrow.
 func TestVectorFallbackRoundTrips(t *testing.T) {
 	mem := memory.DefaultAllocator

--- a/parquet/pqarrow/vector_fallback_test.go
+++ b/parquet/pqarrow/vector_fallback_test.go
@@ -1,0 +1,303 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pqarrow_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vectorWriteRead writes cols under sc with WithVectorEncoding enabled (and the
+// Arrow schema stored, so FixedSizeList types are preserved on read), then reads
+// the file back. It returns the parquet bytes (for on-disk schema inspection)
+// and the reconstructed table (caller releases).
+func vectorWriteRead(t *testing.T, mem memory.Allocator, sc *arrow.Schema, cols []arrow.Array, chunkSize int64) ([]byte, arrow.Table) {
+	t.Helper()
+	nrows := int64(cols[0].Len())
+	rec := array.NewRecordBatch(sc, cols, nrows)
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(sc, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	var buf bytes.Buffer
+	wp := parquet.NewWriterProperties(parquet.WithAllocator(mem))
+	awp := pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem), pqarrow.WithVectorEncoding(), pqarrow.WithStoreSchema())
+	require.NoError(t, pqarrow.WriteTable(tbl, &buf, chunkSize, wp, awp))
+
+	got, err := pqarrow.ReadTable(context.Background(), bytes.NewReader(buf.Bytes()),
+		parquet.NewReaderProperties(mem), pqarrow.ArrowReadProperties{}, mem)
+	require.NoError(t, err)
+	return buf.Bytes(), got
+}
+
+// columnIsVector reports whether leaf column i of the written parquet file is a
+// VECTOR column.
+func columnIsVector(t *testing.T, data []byte, i int) bool {
+	t.Helper()
+	rdr, err := file.NewParquetReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer rdr.Close()
+	return rdr.MetaData().Schema.Column(i).InVectorColumn()
+}
+
+// TestVectorFallbackRoundTrips checks that, with WithVectorEncoding enabled, a
+// FixedSizeList that is NOT VECTOR-eligible is transparently written as the
+// standard LIST encoding (no VECTOR leaf on disk) and still round-trips
+// losslessly through pqarrow.
+func TestVectorFallbackRoundTrips(t *testing.T) {
+	mem := memory.DefaultAllocator
+	f32 := arrow.PrimitiveTypes.Float32
+
+	cases := []struct {
+		name  string
+		field arrow.Field
+		build func() arrow.Array
+	}{
+		{
+			// A nullable FixedSizeList *value* (field.Nullable) is ineligible
+			// regardless of whether actual nulls are present, so it falls back to
+			// LIST. (Writing an actual null FixedSizeList row is a separate,
+			// pre-existing arrow-go limitation and is not exercised here.)
+			name:  "nullable_value_type",
+			field: fslField("v", f32, 3, true /*valNullable*/, false),
+			build: func() arrow.Array {
+				b := array.NewFixedSizeListBuilderWithField(mem, 3, arrow.Field{Name: "element", Type: f32})
+				defer b.Release()
+				vb := b.ValueBuilder().(*array.Float32Builder)
+				for i := 0; i < 4; i++ {
+					b.Append(true)
+					vb.AppendValues([]float32{float32(i), float32(i) + 1, float32(i) + 2}, nil)
+				}
+				return b.NewArray()
+			},
+		},
+		{
+			name:  "nullable_element",
+			field: fslField("v", f32, 2, false, true /*elemNullable*/),
+			build: func() arrow.Array {
+				b := array.NewFixedSizeListBuilderWithField(mem, 2, arrow.Field{Name: "element", Type: f32, Nullable: true})
+				defer b.Release()
+				vb := b.ValueBuilder().(*array.Float32Builder)
+				b.Append(true)
+				vb.Append(1)
+				vb.AppendNull()
+				b.Append(true)
+				vb.Append(3)
+				vb.Append(4)
+				return b.NewArray()
+			},
+		},
+		{
+			name:  "nested_fixed_size_list_element",
+			field: fslField("v", arrow.FixedSizeListOf(2, f32), 3, false, false),
+			build: func() arrow.Array {
+				outerElem := arrow.Field{Name: "element", Type: arrow.FixedSizeListOf(2, f32)}
+				b := array.NewFixedSizeListBuilderWithField(mem, 3, outerElem)
+				defer b.Release()
+				inner := b.ValueBuilder().(*array.FixedSizeListBuilder)
+				vb := inner.ValueBuilder().(*array.Float32Builder)
+				for i := 0; i < 4; i++ { // 4 outer rows
+					b.Append(true)
+					for k := 0; k < 3; k++ { // 3 inner lists per outer row
+						inner.Append(true)
+						vb.AppendValues([]float32{float32(i*10 + k), float32(i*10 + k + 1)}, nil)
+					}
+				}
+				return b.NewArray()
+			},
+		},
+		{
+			name:  "string_element",
+			field: fslField("v", arrow.BinaryTypes.String, 2, false, false),
+			build: func() arrow.Array {
+				b := array.NewFixedSizeListBuilderWithField(mem, 2, arrow.Field{Name: "element", Type: arrow.BinaryTypes.String})
+				defer b.Release()
+				vb := b.ValueBuilder().(*array.StringBuilder)
+				for i := 0; i < 5; i++ {
+					b.Append(true)
+					vb.Append("a")
+					vb.Append("bb")
+				}
+				return b.NewArray()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			arr := tc.build()
+			defer arr.Release()
+			sc := arrow.NewSchema([]arrow.Field{tc.field}, nil)
+
+			data, got := vectorWriteRead(t, mem, sc, []arrow.Array{arr}, int64(arr.Len()))
+			defer got.Release()
+
+			// Every leaf column must use the standard LIST encoding, not VECTOR.
+			rdr, err := file.NewParquetReader(bytes.NewReader(data))
+			require.NoError(t, err)
+			for i := 0; i < rdr.MetaData().Schema.NumColumns(); i++ {
+				assert.False(t, rdr.MetaData().Schema.Column(i).InVectorColumn(),
+					"ineligible FixedSizeList must fall back to LIST, but leaf %d is VECTOR", i)
+			}
+			rdr.Close()
+
+			require.EqualValues(t, arr.Len(), got.NumRows())
+			require.Truef(t, arrow.TypeEqual(arr.DataType(), got.Schema().Field(0).Type),
+				"type changed on round-trip: %s -> %s", arr.DataType(), got.Schema().Field(0).Type)
+			concat, err := array.Concatenate(got.Column(0).Data().Chunks(), mem)
+			require.NoError(t, err)
+			defer concat.Release()
+			assert.Truef(t, array.Equal(arr, concat), "fallback round-trip mismatch\n want %v\n got  %v", arr, concat)
+		})
+	}
+}
+
+// TestVectorMultipleAndMixedColumns writes a schema that mixes two
+// VECTOR-eligible FixedSizeList columns with a plain primitive column and an
+// ineligible (nullable) FixedSizeList column, and checks that exactly the
+// eligible columns are encoded as VECTOR while everything round-trips.
+func TestVectorMultipleAndMixedColumns(t *testing.T) {
+	mem := memory.DefaultAllocator
+	const numRows = 200
+
+	// col 0: plain int64
+	idB := array.NewInt64Builder(mem)
+	defer idB.Release()
+	// col 1: VECTOR-eligible FixedSizeList<float32, 4>
+	emb1Field := arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Float32, Nullable: false}
+	emb1B := array.NewFixedSizeListBuilderWithField(mem, 4, emb1Field)
+	defer emb1B.Release()
+	emb1V := emb1B.ValueBuilder().(*array.Float32Builder)
+	// col 2: VECTOR-eligible FixedSizeList<int32, 3>
+	emb2Field := arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int32, Nullable: false}
+	emb2B := array.NewFixedSizeListBuilderWithField(mem, 3, emb2Field)
+	defer emb2B.Release()
+	emb2V := emb2B.ValueBuilder().(*array.Int32Builder)
+	// col 3: ineligible (nullable) FixedSizeList<float32, 2> -> LIST fallback
+	emb3B := array.NewFixedSizeListBuilderWithField(mem, 2, arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Float32})
+	defer emb3B.Release()
+	emb3V := emb3B.ValueBuilder().(*array.Float32Builder)
+
+	for i := 0; i < numRows; i++ {
+		idB.Append(int64(i))
+		emb1B.Append(true)
+		for j := 0; j < 4; j++ {
+			emb1V.Append(float32(i) + float32(j)*0.1)
+		}
+		emb2B.Append(true)
+		for j := int32(0); j < 3; j++ {
+			emb2V.Append(int32(i)*10 + j)
+		}
+		emb3B.Append(true)
+		emb3V.Append(float32(i))
+		emb3V.Append(float32(i) + 0.5)
+	}
+
+	cols := []arrow.Array{idB.NewArray(), emb1B.NewArray(), emb2B.NewArray(), emb3B.NewArray()}
+	for _, c := range cols {
+		defer c.Release()
+	}
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+		{Name: "emb1", Type: cols[1].DataType(), Nullable: false},
+		{Name: "emb2", Type: cols[2].DataType(), Nullable: false},
+		{Name: "emb3", Type: cols[3].DataType(), Nullable: true},
+	}, nil)
+
+	data, got := vectorWriteRead(t, mem, sc, cols, numRows)
+	defer got.Release()
+
+	// Leaf columns: 0=id, 1=emb1 element, 2=emb2 element, 3=emb3 element.
+	assert.False(t, columnIsVector(t, data, 0), "plain int64 column must not be VECTOR")
+	assert.True(t, columnIsVector(t, data, 1), "emb1 must be VECTOR")
+	assert.True(t, columnIsVector(t, data, 2), "emb2 must be VECTOR")
+	assert.False(t, columnIsVector(t, data, 3), "nullable emb3 must fall back to LIST")
+
+	require.EqualValues(t, numRows, got.NumRows())
+	for i := 0; i < len(cols); i++ {
+		concat, err := array.Concatenate(got.Column(i).Data().Chunks(), mem)
+		require.NoError(t, err)
+		assert.Truef(t, array.Equal(cols[i], concat), "column %d round-trip mismatch", i)
+		concat.Release()
+	}
+}
+
+// TestVectorMultiRowGroupRowCount writes a VECTOR column across several row
+// groups and explicitly checks that each row group's metadata reports parent
+// rows (not leaf slots) and that the values round-trip across the boundaries.
+func TestVectorMultiRowGroupRowCount(t *testing.T) {
+	mem := memory.DefaultAllocator
+	const (
+		listSize     = int32(3)
+		numRows      = 1000
+		rowsPerGroup = 250 // -> 4 row groups
+	)
+
+	elemField := arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Float32, Nullable: false}
+	b := array.NewFixedSizeListBuilderWithField(mem, listSize, elemField)
+	defer b.Release()
+	vb := b.ValueBuilder().(*array.Float32Builder)
+	for i := 0; i < numRows; i++ {
+		b.Append(true)
+		for j := int32(0); j < listSize; j++ {
+			vb.Append(float32(i)*float32(listSize) + float32(j))
+		}
+	}
+	arr := b.NewArray()
+	defer arr.Release()
+	sc := arrow.NewSchema([]arrow.Field{{Name: "emb", Type: arr.DataType(), Nullable: false}}, nil)
+
+	data, got := vectorWriteRead(t, mem, sc, []arrow.Array{arr}, rowsPerGroup)
+	defer got.Release()
+
+	require.True(t, columnIsVector(t, data, 0), "column must be VECTOR")
+
+	rdr, err := file.NewParquetReader(bytes.NewReader(data))
+	require.NoError(t, err)
+	defer rdr.Close()
+	md := rdr.MetaData()
+	require.Equal(t, numRows/rowsPerGroup, rdr.NumRowGroups(), "expected one row group per chunk")
+	require.EqualValues(t, numRows, md.NumRows, "file num_rows must be parent rows")
+
+	var totalRows int64
+	for i := 0; i < rdr.NumRowGroups(); i++ {
+		rg := md.RowGroup(i)
+		// Parent rows per group, not leaf slots (= rows * vector_length).
+		require.EqualValues(t, rowsPerGroup, rg.NumRows(), "row group %d num_rows", i)
+		col, err := rg.ColumnChunk(0)
+		require.NoError(t, err)
+		require.EqualValues(t, int64(rowsPerGroup)*int64(listSize), col.NumValues(), "row group %d num_values", i)
+		totalRows += rg.NumRows()
+	}
+	require.EqualValues(t, numRows, totalRows)
+
+	require.EqualValues(t, numRows, got.NumRows())
+	concat, err := array.Concatenate(got.Column(0).Data().Chunks(), mem)
+	require.NoError(t, err)
+	defer concat.Release()
+	assert.True(t, array.Equal(arr, concat), "multi-row-group VECTOR round-trip mismatch")
+}

--- a/parquet/pqarrow/write_vector_test.go
+++ b/parquet/pqarrow/write_vector_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// End-to-end WRITE path for Phase 1: a non-nullable FixedSizeList<float32, N>
-// written with WithVectorEncoding produces a VECTOR primitive leaf on disk that
+// End-to-end WRITE path: a non-nullable FixedSizeList<float32, N> written
+// with WithVectorEncoding produces a VECTOR primitive leaf on disk that
 // holds the flattened values with no inner levels, and the row count is the
 // number of vectors (not leaf slots).
 func TestWriteFixedSizeListAsVector(t *testing.T) {
@@ -534,8 +534,8 @@ func TestVectorColumnReaderSeekToRowWithOffsetIndex(t *testing.T) {
 }
 
 // assertColumnIsVector opens the written parquet bytes and asserts the single
-// top-level column was actually encoded as a VECTOR leaf (Option B), not as a
-// LIST fallback, so the round-trip really exercises the VECTOR write/read path.
+// top-level column was actually encoded as a VECTOR leaf, not as a LIST
+// fallback, so the round-trip really exercises the VECTOR write/read path.
 func assertColumnIsVector(t *testing.T, b []byte, vectorLen int32) {
 	t.Helper()
 	rdr, err := file.NewParquetReader(bytes.NewReader(b))

--- a/parquet/pqarrow/write_vector_test.go
+++ b/parquet/pqarrow/write_vector_test.go
@@ -1,0 +1,624 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pqarrow_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/float16"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/compress"
+	"github.com/apache/arrow-go/v18/parquet/file"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// End-to-end WRITE path for Phase 1: a non-nullable FixedSizeList<float32, N>
+// written with WithVectorEncoding produces a VECTOR primitive leaf on disk that
+// holds the flattened values with no inner levels, and the row count is the
+// number of vectors (not leaf slots).
+func TestWriteFixedSizeListAsVector(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	const (
+		listSize = int32(4)
+		numRows  = 256
+	)
+	elemType := arrow.PrimitiveTypes.Float32
+	elemField := arrow.Field{Name: "element", Type: elemType, Nullable: false}
+	fslType := arrow.FixedSizeListOfField(listSize, elemField)
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "emb", Type: fslType, Nullable: false}}, nil)
+
+	bldr := array.NewFixedSizeListBuilderWithField(mem, listSize, elemField)
+	defer bldr.Release()
+	vb := bldr.ValueBuilder().(*array.Float32Builder)
+	expected := make([]float32, 0, numRows*int(listSize))
+	for i := 0; i < numRows; i++ {
+		bldr.Append(true)
+		for j := int32(0); j < listSize; j++ {
+			v := float32(i)*float32(listSize) + float32(j)
+			vb.Append(v)
+			expected = append(expected, v)
+		}
+	}
+	fslArr := bldr.NewArray()
+	defer fslArr.Release()
+
+	rec := array.NewRecordBatch(arrowSchema, []arrow.Array{fslArr}, numRows)
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	var buf bytes.Buffer
+	props := parquet.NewWriterProperties(parquet.WithAllocator(mem), parquet.WithDataPageSize(2048))
+	arrProps := pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem), pqarrow.WithVectorEncoding())
+	require.NoError(t, pqarrow.WriteTable(tbl, &buf, numRows, props, arrProps))
+
+	rdr, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	md := rdr.MetaData()
+	assert.EqualValues(t, numRows, md.NumRows)
+	require.Equal(t, 1, md.Schema.NumColumns())
+
+	descr := md.Schema.Column(0)
+	assert.True(t, descr.InVectorColumn(), "round-tripped schema column should be a VECTOR column")
+	assert.EqualValues(t, listSize, descr.EffectiveVectorLength())
+	assert.EqualValues(t, 0, descr.MaxDefinitionLevel())
+	assert.EqualValues(t, 0, descr.MaxRepetitionLevel())
+	assert.Equal(t, "emb", descr.Path())
+	assert.Equal(t, parquet.Types.Float, descr.PhysicalType())
+
+	rgr := rdr.RowGroup(0)
+	assert.EqualValues(t, numRows, rgr.NumRows())
+	cr, err := rgr.Column(0)
+	require.NoError(t, err)
+	fr := cr.(*file.Float32ColumnChunkReader)
+
+	out := make([]float32, numRows*int(listSize))
+	var total int64
+	for fr.HasNext() && total < int64(len(out)) {
+		n, _, err := fr.ReadBatch(int64(len(out))-total, out[total:], nil, nil)
+		require.NoError(t, err)
+		total += n
+	}
+	assert.EqualValues(t, numRows*int(listSize), total)
+	assert.Equal(t, expected, out)
+}
+
+// With the flag off, the same FixedSizeList is written as a standard LIST and
+// the on-disk column is not a VECTOR column.
+func TestWriteFixedSizeListWithoutVectorFlag(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	const listSize = int32(3)
+	elemType := arrow.PrimitiveTypes.Int32
+	elemField := arrow.Field{Name: "element", Type: elemType, Nullable: false}
+	fslType := arrow.FixedSizeListOfField(listSize, elemField)
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "v", Type: fslType, Nullable: false}}, nil)
+
+	bldr := array.NewFixedSizeListBuilderWithField(mem, listSize, elemField)
+	defer bldr.Release()
+	vb := bldr.ValueBuilder().(*array.Int32Builder)
+	for i := 0; i < 10; i++ {
+		bldr.Append(true)
+		for j := int32(0); j < listSize; j++ {
+			vb.Append(int32(i))
+		}
+	}
+	fslArr := bldr.NewArray()
+	defer fslArr.Release()
+	rec := array.NewRecordBatch(arrowSchema, []arrow.Array{fslArr}, 10)
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	var buf bytes.Buffer
+	props := parquet.NewWriterProperties(parquet.WithAllocator(mem))
+	require.NoError(t, pqarrow.WriteTable(tbl, &buf, 10, props, pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem))))
+
+	rdr, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	descr := rdr.MetaData().Schema.Column(0)
+	assert.False(t, descr.InVectorColumn(), "without the flag the column must use the standard LIST encoding")
+}
+
+// TestVectorAdditionalElementTypesRoundTrip is the single end-to-end VECTOR
+// round-trip matrix: it builds a non-nullable FixedSizeList<elem, listSize> of
+// numRows rows, writes it with WithVectorEncoding (plus per-case writer props),
+// reads it back, and asserts the reconstructed column is a VECTOR-encoded
+// FixedSizeList equal to the input. It covers every supported element family and
+// cross-feature combination (compression, dictionary-read), so the per-type
+// round-trips do not need standalone tests.
+func TestVectorAdditionalElementTypesRoundTrip(t *testing.T) {
+	// flbaPageProps stresses the FixedLenByteArray writer's custom batching loop
+	// (used by FixedSizeBinary/Float16) across many pages. Combined with a list
+	// size that does NOT divide WriteBatchSize (1024), it guards the regression
+	// where a vector value was split across a page boundary and the write failed.
+	flbaPageProps := []parquet.WriterProperty{parquet.WithDictionaryDefault(false), parquet.WithDataPageSize(2048)}
+
+	cases := []struct {
+		name      string
+		elemField arrow.Field
+		listSize  int32
+		numRows   int
+		fill      func(vb array.Builder, numRows int, listSize int32)
+		wrProps   []parquet.WriterProperty
+		readDict  bool
+	}{
+		{
+			name:      "bool-snappy",
+			elemField: arrow.Field{Name: "element", Type: arrow.FixedWidthTypes.Boolean, Nullable: false},
+			listSize:  2, numRows: 3,
+			wrProps: []parquet.WriterProperty{parquet.WithCompression(compress.Codecs.Snappy)},
+			fill: func(vb array.Builder, _ int, _ int32) {
+				b := vb.(*array.BooleanBuilder)
+				b.AppendValues([]bool{true, false, true, true, false, false}, nil)
+			},
+		},
+		{
+			name:      "int64-zstd-read-dict-requested",
+			elemField: arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int64, Nullable: false},
+			listSize:  2, numRows: 3,
+			wrProps:  []parquet.WriterProperty{parquet.WithCompression(compress.Codecs.Zstd)},
+			readDict: true,
+			fill: func(vb array.Builder, _ int, _ int32) {
+				b := vb.(*array.Int64Builder)
+				b.AppendValues([]int64{1, 2, 3, 4, 5, 6}, nil)
+			},
+		},
+		{
+			name:      "date32",
+			elemField: arrow.Field{Name: "element", Type: arrow.FixedWidthTypes.Date32, Nullable: false},
+			listSize:  2, numRows: 3,
+			fill: func(vb array.Builder, _ int, _ int32) {
+				b := vb.(*array.Date32Builder)
+				b.AppendValues([]arrow.Date32{1, 2, 3, 4, 5, 6}, nil)
+			},
+		},
+		{
+			name:      "timestamp-us",
+			elemField: arrow.Field{Name: "element", Type: arrow.FixedWidthTypes.Timestamp_us, Nullable: false},
+			listSize:  2, numRows: 3,
+			fill: func(vb array.Builder, _ int, _ int32) {
+				b := vb.(*array.TimestampBuilder)
+				b.AppendValues([]arrow.Timestamp{10, 20, 30, 40, 50, 60}, nil)
+			},
+		},
+		{
+			name:      "decimal128",
+			elemField: arrow.Field{Name: "element", Type: &arrow.Decimal128Type{Precision: 12, Scale: 2}, Nullable: false},
+			listSize:  2, numRows: 3,
+			fill: func(vb array.Builder, _ int, _ int32) {
+				b := vb.(*array.Decimal128Builder)
+				for _, v := range []string{"1.23", "2.34", "3.45", "4.56", "5.67", "6.78"} {
+					require.NoError(t, b.AppendValueFromString(v))
+				}
+			},
+		},
+		{
+			name:      "decimal256",
+			elemField: arrow.Field{Name: "element", Type: &arrow.Decimal256Type{Precision: 40, Scale: 4}, Nullable: false},
+			listSize:  2, numRows: 3,
+			fill: func(vb array.Builder, _ int, _ int32) {
+				b := vb.(*array.Decimal256Builder)
+				for _, v := range []string{"1.2345", "2.3456", "3.4567", "4.5678", "5.6789", "6.7890"} {
+					require.NoError(t, b.AppendValueFromString(v))
+				}
+			},
+		},
+		{
+			name:      "float32-many-pages",
+			elemField: arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Float32, Nullable: false},
+			listSize:  4, numRows: 256,
+			wrProps: []parquet.WriterProperty{parquet.WithDataPageSize(2048)},
+			fill:    fillFloat32Vector,
+		},
+		{
+			name:      "float64",
+			elemField: arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Float64, Nullable: false},
+			listSize:  8, numRows: 128,
+			fill: func(vb array.Builder, numRows int, listSize int32) {
+				b := vb.(*array.Float64Builder)
+				for i := 0; i < numRows*int(listSize); i++ {
+					b.Append(float64(i))
+				}
+			},
+		},
+		// FixedSizeBinary and Float16 map to the FixedLenByteArray physical type
+		// (the custom batching loop). The list sizes 3/768/100 do not divide
+		// WriteBatchSize (1024), exercising the FLBA whole-vector page batching.
+		{
+			name:      "fixed_size_binary-len3",
+			elemField: arrow.Field{Name: "element", Type: &arrow.FixedSizeBinaryType{ByteWidth: 8}, Nullable: false},
+			listSize:  3, numRows: 256, wrProps: flbaPageProps, fill: fillFixedSizeBinaryVector,
+		},
+		{
+			name:      "fixed_size_binary-len768",
+			elemField: arrow.Field{Name: "element", Type: &arrow.FixedSizeBinaryType{ByteWidth: 8}, Nullable: false},
+			listSize:  768, numRows: 8, wrProps: flbaPageProps, fill: fillFixedSizeBinaryVector,
+		},
+		{
+			name:      "float16-len3",
+			elemField: arrow.Field{Name: "element", Type: &arrow.Float16Type{}, Nullable: false},
+			listSize:  3, numRows: 256, wrProps: flbaPageProps, fill: fillFloat16Vector,
+		},
+		{
+			name:      "float16-len100",
+			elemField: arrow.Field{Name: "element", Type: &arrow.Float16Type{}, Nullable: false},
+			listSize:  100, numRows: 128, wrProps: flbaPageProps, fill: fillFloat16Vector,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+
+			fslType := arrow.FixedSizeListOfField(tc.listSize, tc.elemField)
+			field := arrow.Field{Name: "v", Type: fslType, Nullable: false}
+			arrowSchema := arrow.NewSchema([]arrow.Field{field}, nil)
+			bldr := array.NewFixedSizeListBuilderWithField(mem, tc.listSize, tc.elemField)
+			defer bldr.Release()
+			for i := 0; i < tc.numRows; i++ {
+				bldr.Append(true)
+			}
+			tc.fill(bldr.ValueBuilder(), tc.numRows, tc.listSize)
+			arr := bldr.NewArray()
+			defer arr.Release()
+			require.EqualValues(t, tc.numRows, arr.Len())
+			rec := array.NewRecordBatch(arrowSchema, []arrow.Array{arr}, int64(tc.numRows))
+			defer rec.Release()
+			tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+			defer tbl.Release()
+
+			var buf bytes.Buffer
+			wrProps := append([]parquet.WriterProperty{parquet.WithAllocator(mem)}, tc.wrProps...)
+			require.NoError(t, pqarrow.WriteTable(tbl, &buf, int64(tc.numRows),
+				parquet.NewWriterProperties(wrProps...),
+				pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem), pqarrow.WithVectorEncoding())))
+			assertColumnIsVector(t, buf.Bytes(), tc.listSize)
+
+			readProps := pqarrow.ArrowReadProperties{}
+			if tc.readDict {
+				readProps.SetReadDict(0, true)
+			}
+			got, err := pqarrow.ReadTable(context.Background(), bytes.NewReader(buf.Bytes()),
+				parquet.NewReaderProperties(mem), readProps, mem)
+			require.NoError(t, err)
+			defer got.Release()
+			require.EqualValues(t, tc.numRows, got.NumRows())
+			require.Equal(t, field.Type, got.Schema().Field(0).Type)
+			require.False(t, got.Schema().Field(0).Nullable)
+
+			// Concatenate across however many chunks the reader produced, then
+			// compare the whole reconstructed array (type + values) to the input.
+			concat, err := array.Concatenate(got.Column(0).Data().Chunks(), mem)
+			require.NoError(t, err)
+			defer concat.Release()
+			assert.Truef(t, array.Equal(arr, concat), "round-trip mismatch\n want %v\n got  %v", arr, concat)
+		})
+	}
+}
+
+func fillFloat32Vector(vb array.Builder, numRows int, listSize int32) {
+	b := vb.(*array.Float32Builder)
+	for i := 0; i < numRows*int(listSize); i++ {
+		b.Append(float32(i))
+	}
+}
+
+func fillFixedSizeBinaryVector(vb array.Builder, numRows int, listSize int32) {
+	b := vb.(*array.FixedSizeBinaryBuilder)
+	for i := 0; i < numRows*int(listSize); i++ {
+		v := make([]byte, 8)
+		for k := range v {
+			v[k] = byte((i + k) % 251)
+		}
+		b.Append(v)
+	}
+}
+
+func fillFloat16Vector(vb array.Builder, numRows int, listSize int32) {
+	b := vb.(*array.Float16Builder)
+	for i := 0; i < numRows*int(listSize); i++ {
+		b.Append(float16.New(float32(i) * 0.5))
+	}
+}
+
+func TestVectorEncodingRejectsUnexpectedNulls(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	const listSize = int32(2)
+	elem := arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int32, Nullable: false}
+	fslType := arrow.FixedSizeListOfField(listSize, elem)
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "v", Type: fslType, Nullable: false}}, nil)
+
+	cases := []struct {
+		name string
+		fill func(*array.FixedSizeListBuilder)
+	}{
+		{
+			name: "null vector value",
+			fill: func(b *array.FixedSizeListBuilder) {
+				vb := b.ValueBuilder().(*array.Int32Builder)
+				b.Append(false)
+				vb.AppendValues([]int32{1, 2}, nil)
+			},
+		},
+		{
+			name: "null element value",
+			fill: func(b *array.FixedSizeListBuilder) {
+				vb := b.ValueBuilder().(*array.Int32Builder)
+				b.Append(true)
+				vb.Append(1)
+				vb.AppendNull()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bldr := array.NewFixedSizeListBuilderWithField(mem, listSize, elem)
+			defer bldr.Release()
+			tc.fill(bldr)
+			arr := bldr.NewArray()
+			defer arr.Release()
+			rec := array.NewRecordBatch(arrowSchema, []arrow.Array{arr}, int64(arr.Len()))
+			defer rec.Release()
+			tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+			defer tbl.Release()
+
+			var buf bytes.Buffer
+			err := pqarrow.WriteTable(tbl, &buf, int64(arr.Len()), parquet.NewWriterProperties(parquet.WithAllocator(mem)),
+				pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem), pqarrow.WithVectorEncoding()))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestVectorRecordReaderSeekToRow(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	const (
+		listSize = int32(3)
+		numRows  = 10
+	)
+	elemField := arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int32, Nullable: false}
+	fslType := arrow.FixedSizeListOfField(listSize, elemField)
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "v", Type: fslType, Nullable: false}}, nil)
+
+	bldr := array.NewFixedSizeListBuilderWithField(mem, listSize, elemField)
+	defer bldr.Release()
+	vb := bldr.ValueBuilder().(*array.Int32Builder)
+	for i := 0; i < numRows; i++ {
+		bldr.Append(true)
+		for j := int32(0); j < listSize; j++ {
+			vb.Append(int32(i*10 + int(j)))
+		}
+	}
+	fslArr := bldr.NewArray()
+	defer fslArr.Release()
+	rec := array.NewRecordBatch(arrowSchema, []arrow.Array{fslArr}, numRows)
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	var buf bytes.Buffer
+	props := parquet.NewWriterProperties(
+		parquet.WithAllocator(mem),
+		parquet.WithDictionaryDefault(false),
+		parquet.WithDataPageSize(64),
+	)
+	arrProps := pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem), pqarrow.WithVectorEncoding())
+	// Use multiple row groups so SeekToRow must select the row group by parent
+	// row, not by row*vector_length.
+	require.NoError(t, pqarrow.WriteTable(tbl, &buf, 5, props, arrProps))
+
+	pr, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	defer pr.Close()
+	reader, err := pqarrow.NewFileReader(pr, pqarrow.ArrowReadProperties{BatchSize: 2}, mem)
+	require.NoError(t, err)
+	rr, err := reader.GetRecordReader(context.Background(), nil, nil)
+	require.NoError(t, err)
+	defer rr.Release()
+
+	for _, row := range []int64{0, 1, 2, 4, 5, 8, 9} {
+		require.NoError(t, rr.SeekToRow(row), "seek row %d", row)
+		require.True(t, rr.Next(), "next after seek row %d: %v", row, rr.Err())
+
+		batch := rr.RecordBatch()
+		require.Greater(t, int(batch.NumRows()), 0)
+		fsl := batch.Column(0).(*array.FixedSizeList)
+		child := fsl.ListValues().(*array.Int32)
+		base := fsl.Offset() * int(listSize)
+		for j := int32(0); j < listSize; j++ {
+			assert.Equal(t, int32(row*10+int64(j)), child.Value(base+int(j)), "row %d element %d", row, j)
+		}
+	}
+}
+
+func TestVectorColumnReaderSeekToRowWithOffsetIndex(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	const (
+		listSize = int32(3)
+		numRows  = 200
+	)
+	elemField := arrow.Field{Name: "element", Type: arrow.PrimitiveTypes.Int32, Nullable: false}
+	fslType := arrow.FixedSizeListOfField(listSize, elemField)
+	arrowSchema := arrow.NewSchema([]arrow.Field{{Name: "v", Type: fslType, Nullable: false}}, nil)
+
+	bldr := array.NewFixedSizeListBuilderWithField(mem, listSize, elemField)
+	defer bldr.Release()
+	vb := bldr.ValueBuilder().(*array.Int32Builder)
+	for i := 0; i < numRows; i++ {
+		bldr.Append(true)
+		for j := int32(0); j < listSize; j++ {
+			vb.Append(int32(i*10 + int(j)))
+		}
+	}
+	fslArr := bldr.NewArray()
+	defer fslArr.Release()
+	rec := array.NewRecordBatch(arrowSchema, []arrow.Array{fslArr}, numRows)
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(arrowSchema, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	var buf bytes.Buffer
+	props := parquet.NewWriterProperties(
+		parquet.WithAllocator(mem),
+		parquet.WithDictionaryDefault(false),
+		parquet.WithDataPageSize(64),
+		parquet.WithBatchSize(30),
+		parquet.WithPageIndexEnabled(true),
+	)
+	arrProps := pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem), pqarrow.WithVectorEncoding())
+	require.NoError(t, pqarrow.WriteTable(tbl, &buf, numRows, props, arrProps))
+
+	pr, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()), file.WithReadProps(parquet.NewReaderProperties(mem)))
+	require.NoError(t, err)
+	defer pr.Close()
+
+	rgPageIndex, err := pr.GetPageIndexReader().RowGroup(0)
+	require.NoError(t, err)
+	offsetIndex, err := rgPageIndex.GetOffsetIndex(0)
+	require.NoError(t, err)
+	require.NotNil(t, offsetIndex)
+	require.Greater(t, len(offsetIndex.GetPageLocations()), 1, "test must exercise offset-index page selection")
+
+	cr, err := pr.RowGroup(0).Column(0)
+	require.NoError(t, err)
+	defer cr.Close()
+	rdr := cr.(*file.Int32ColumnChunkReader)
+	for _, row := range []int64{0, 1, 11, 97, int64(numRows - 1)} {
+		require.NoError(t, rdr.SeekToRow(row), "seek row %d", row)
+		out := make([]int32, listSize)
+		_, read, err := rdr.ReadBatch(int64(listSize), out, nil, nil)
+		require.NoError(t, err)
+		require.EqualValues(t, listSize, read)
+		for j := int32(0); j < listSize; j++ {
+			assert.Equal(t, int32(row*10+int64(j)), out[j], "row %d element %d", row, j)
+		}
+	}
+	assert.Error(t, rdr.SeekToRow(numRows))
+}
+
+// assertColumnIsVector opens the written parquet bytes and asserts the single
+// top-level column was actually encoded as a VECTOR leaf (Option B), not as a
+// LIST fallback, so the round-trip really exercises the VECTOR write/read path.
+func assertColumnIsVector(t *testing.T, b []byte, vectorLen int32) {
+	t.Helper()
+	rdr, err := file.NewParquetReader(bytes.NewReader(b))
+	require.NoError(t, err)
+	defer rdr.Close()
+	col := rdr.MetaData().Schema.Column(0)
+	assert.True(t, col.InVectorColumn(), "expected a VECTOR-encoded column, got rep %s", col.SchemaNode().RepetitionType())
+	assert.EqualValues(t, vectorLen, col.EffectiveVectorLength())
+}
+
+// storeSchemaRoundTrip writes a non-nullable FixedSizeList<timestamp[us, tz],2>
+// carrying user field metadata, with WithStoreSchema() and optionally
+// WithVectorEncoding(), then reads it back and returns the reconstructed field.
+func storeSchemaRoundTrip(t *testing.T, vector bool) arrow.Field {
+	t.Helper()
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	tsType := &arrow.TimestampType{Unit: arrow.Microsecond, TimeZone: "America/New_York"}
+	elem := arrow.Field{Name: "element", Type: tsType, Nullable: false}
+	fsl := arrow.FixedSizeListOfField(2, elem)
+	colMeta := arrow.NewMetadata([]string{"unit", "model"}, []string{"meters", "abc"})
+	field := arrow.Field{Name: "v", Type: fsl, Nullable: false, Metadata: colMeta}
+	sc := arrow.NewSchema([]arrow.Field{field}, nil)
+
+	b := array.NewFixedSizeListBuilderWithField(mem, 2, elem)
+	defer b.Release()
+	vb := b.ValueBuilder().(*array.TimestampBuilder)
+	for i := 0; i < 4; i++ {
+		b.Append(true)
+		vb.Append(arrow.Timestamp(int64(i)))
+		vb.Append(arrow.Timestamp(int64(i) + 100))
+	}
+	arr := b.NewArray()
+	defer arr.Release()
+	rec := array.NewRecordBatch(sc, []arrow.Array{arr}, 4)
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(sc, []arrow.RecordBatch{rec})
+	defer tbl.Release()
+
+	var buf bytes.Buffer
+	awopts := []pqarrow.WriterOption{pqarrow.WithAllocator(mem), pqarrow.WithStoreSchema()}
+	if vector {
+		awopts = append(awopts, pqarrow.WithVectorEncoding())
+	}
+	require.NoError(t, pqarrow.WriteTable(tbl, &buf, 4,
+		parquet.NewWriterProperties(parquet.WithAllocator(mem)),
+		pqarrow.NewArrowWriterProperties(awopts...)))
+
+	got, err := pqarrow.ReadTable(context.Background(), bytes.NewReader(buf.Bytes()),
+		parquet.NewReaderProperties(mem), pqarrow.ArrowReadProperties{}, mem)
+	require.NoError(t, err)
+	defer got.Release()
+	return got.Schema().Field(0)
+}
+
+// With WithStoreSchema(), the reader restores element-type refinements that
+// Parquet cannot carry (here, a timestamp timezone) and user field metadata from
+// the embedded Arrow schema. Regression test for the bug where a VECTOR column,
+// reconstructed directly as a FixedSizeList, took an early return in
+// applyOriginalStorageMetadata (getNestedFactory had no inferred FIXED_SIZE_LIST
+// case) and silently dropped both. The standard LIST-encoded path is the control.
+func TestVectorStoreSchemaRestoresElementMetadata(t *testing.T) {
+	listF := storeSchemaRoundTrip(t, false)
+	vecF := storeSchemaRoundTrip(t, true)
+
+	listElem := listF.Type.(*arrow.FixedSizeListType).Elem().(*arrow.TimestampType)
+	vecElem := vecF.Type.(*arrow.FixedSizeListType).Elem().(*arrow.TimestampType)
+
+	// Control: the standard LIST path restores the original timezone + metadata.
+	require.Equal(t, "America/New_York", listElem.TimeZone)
+	require.ElementsMatch(t, []string{"PARQUET:field_id", "unit", "model"}, listF.Metadata.Keys())
+
+	// The VECTOR path must now match the LIST control.
+	assert.Equal(t, listElem.TimeZone, vecElem.TimeZone, "VECTOR store-schema must restore element timezone")
+	assert.ElementsMatch(t, listF.Metadata.Keys(), vecF.Metadata.Keys(), "VECTOR store-schema must preserve field metadata")
+	assert.Equal(t, "meters", metaValue(vecF.Metadata, "unit"))
+	assert.Equal(t, "abc", metaValue(vecF.Metadata, "model"))
+}
+
+func metaValue(m arrow.Metadata, key string) string {
+	if i := m.FindKey(key); i >= 0 {
+		return m.Values()[i]
+	}
+	return ""
+}

--- a/parquet/pqarrow/write_vector_test.go
+++ b/parquet/pqarrow/write_vector_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 // End-to-end WRITE path: a non-nullable FixedSizeList<float32, N> written
-// with WithVectorEncoding produces a VECTOR primitive leaf on disk that
+// with WithVectorEncoding produces a VECTOR logical group on disk whose leaf
 // holds the flattened values with no inner levels, and the row count is the
 // number of vectors (not leaf slots).
 func TestWriteFixedSizeListAsVector(t *testing.T) {
@@ -88,7 +88,7 @@ func TestWriteFixedSizeListAsVector(t *testing.T) {
 	assert.EqualValues(t, listSize, descr.EffectiveVectorLength())
 	assert.EqualValues(t, 0, descr.MaxDefinitionLevel())
 	assert.EqualValues(t, 0, descr.MaxRepetitionLevel())
-	assert.Equal(t, "emb", descr.Path())
+	assert.Equal(t, "emb.list.element", descr.Path())
 	assert.Equal(t, parquet.Types.Float, descr.PhysicalType())
 
 	rgr := rdr.RowGroup(0)
@@ -534,8 +534,8 @@ func TestVectorColumnReaderSeekToRowWithOffsetIndex(t *testing.T) {
 }
 
 // assertColumnIsVector opens the written parquet bytes and asserts the single
-// top-level column was actually encoded as a VECTOR leaf, not as a LIST
-// fallback, so the round-trip really exercises the VECTOR write/read path.
+// top-level column was actually encoded as VECTOR, not as a LIST fallback, so
+// the round-trip really exercises the VECTOR write/read path.
 func assertColumnIsVector(t *testing.T, b []byte, vectorLen int32) {
 	t.Helper()
 	rdr, err := file.NewParquetReader(bytes.NewReader(b))

--- a/parquet/schema/column.go
+++ b/parquet/schema/column.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/apache/arrow-go/v18/parquet"
@@ -41,17 +42,65 @@ type Column struct {
 	maxRepLvl int16
 	// cached path string to avoid repeated string building
 	path string
+	// effectiveVectorLength is the fixed number of leaf values contributed per
+	// parent record when this column is part of a VECTOR-repeated subtree
+	// (Option B), and -1 otherwise. See effectiveVectorLength.
+	effectiveVectorLength int32
+}
+
+// effectiveVectorLength returns the product of vector_length over the leaf node
+// and any ancestors that are VECTOR-repeated, which is the number of physical
+// leaf values contributed per parent record. It returns -1 when the leaf is not
+// part of a VECTOR-repeated subtree. The product is accumulated in int64 so a
+// pathological nested-vector schema that would overflow int32 returns an error
+// rather than silently wrapping.
+func effectiveVectorLength(n Node) (int32, error) {
+	eff := int64(-1)
+	for cursor := n; cursor != nil; cursor = cursor.Parent() {
+		if cursor.RepetitionType() != parquet.Repetitions.Vector {
+			continue
+		}
+		vl := int64(nodeVectorLength(cursor))
+		if eff < 0 {
+			eff = vl
+			continue
+		}
+		eff *= vl
+		if eff > math.MaxInt32 {
+			return 0, fmt.Errorf("parquet: nested VECTOR effective vector_length overflows int32 for column %q", n.Path())
+		}
+	}
+	return int32(eff), nil
 }
 
 // NewColumn returns a new column object for the given node with the provided
-// maximum definition and repetition levels.
+// maximum definition and repetition levels. It panics if the schema is invalid
+// (for example a nested-VECTOR effective vector_length that overflows int32);
+// use NewColumnChecked to receive that as an error instead.
 func NewColumn(n *PrimitiveNode, maxDefinitionLvl, maxRepetitionLvl int16) *Column {
-	return &Column{
-		pnode:     n,
-		maxDefLvl: maxDefinitionLvl,
-		maxRepLvl: maxRepetitionLvl,
-		path:      n.Path(),
+	c, err := NewColumnChecked(n, maxDefinitionLvl, maxRepetitionLvl)
+	if err != nil {
+		panic(err)
 	}
+	return c
+}
+
+// NewColumnChecked is like NewColumn but returns an error instead of panicking
+// when the schema is invalid, so it can be used on paths (such as
+// NewSchemaChecked) that read untrusted files and must fail loudly rather than
+// panic.
+func NewColumnChecked(n *PrimitiveNode, maxDefinitionLvl, maxRepetitionLvl int16) (*Column, error) {
+	eff, err := effectiveVectorLength(n)
+	if err != nil {
+		return nil, err
+	}
+	return &Column{
+		pnode:                 n,
+		maxDefLvl:             maxDefinitionLvl,
+		maxRepLvl:             maxRepetitionLvl,
+		path:                  n.Path(),
+		effectiveVectorLength: eff,
+	}, nil
 }
 
 // Name is the column's name
@@ -66,8 +115,20 @@ func (c *Column) Path() string { return c.path }
 // TypeLength is -1 if not a FixedLenByteArray, otherwise it is the length of elements in the column
 func (c *Column) TypeLength() int { return c.pnode.TypeLength() }
 
-func (c *Column) MaxDefinitionLevel() int16        { return c.maxDefLvl }
-func (c *Column) MaxRepetitionLevel() int16        { return c.maxRepLvl }
+func (c *Column) MaxDefinitionLevel() int16 { return c.maxDefLvl }
+func (c *Column) MaxRepetitionLevel() int16 { return c.maxRepLvl }
+
+// EffectiveVectorLength returns the fixed number of leaf values per parent
+// record contributed by this column when it belongs to a VECTOR-repeated
+// subtree (the product of all VECTOR-repeated nodes on the path), or -1
+// otherwise.
+func (c *Column) EffectiveVectorLength() int32 { return c.effectiveVectorLength }
+
+// InVectorColumn reports whether this column belongs to a VECTOR-repeated
+// subtree (Option B), in which case leaf values are written without per-element
+// repetition levels.
+func (c *Column) InVectorColumn() bool { return c.effectiveVectorLength > 0 }
+
 func (c *Column) PhysicalType() parquet.Type       { return c.pnode.PhysicalType() }
 func (c *Column) ConvertedType() ConvertedType     { return c.pnode.convertedType }
 func (c *Column) LogicalType() LogicalType         { return c.pnode.logicalType }
@@ -80,6 +141,9 @@ func (c *Column) String() string {
 	fmt.Fprintf(&bld, "  physical_type: %s,\n", c.PhysicalType())
 	fmt.Fprintf(&bld, "  converted_type: %s,\n", c.ConvertedType())
 	fmt.Fprintf(&bld, "  logical_type: %s,\n", c.LogicalType())
+	if c.InVectorColumn() {
+		fmt.Fprintf(&bld, "  vector_length: %d,\n", c.EffectiveVectorLength())
+	}
 	fmt.Fprintf(&bld, "  max_definition_level: %d,\n", c.MaxDefinitionLevel())
 	fmt.Fprintf(&bld, "  max_repetition_level: %d,\n", c.MaxRepetitionLevel())
 	if c.PhysicalType() == parquet.Types.FixedLenByteArray {
@@ -97,7 +161,8 @@ func (c *Column) String() string {
 func (c *Column) Equals(rhs *Column) bool {
 	return c.pnode.Equals(rhs.pnode) &&
 		c.MaxRepetitionLevel() == rhs.MaxRepetitionLevel() &&
-		c.MaxDefinitionLevel() == rhs.MaxDefinitionLevel()
+		c.MaxDefinitionLevel() == rhs.MaxDefinitionLevel() &&
+		c.EffectiveVectorLength() == rhs.EffectiveVectorLength()
 }
 
 // SchemaNode returns the underlying Node in the schema tree for this column.

--- a/parquet/schema/column.go
+++ b/parquet/schema/column.go
@@ -43,8 +43,8 @@ type Column struct {
 	// cached path string to avoid repeated string building
 	path string
 	// effectiveVectorLength is the fixed number of leaf values contributed per
-	// parent record when this column is part of a VECTOR-repeated subtree
-	// (Option B), and -1 otherwise. See effectiveVectorLength.
+	// parent record when this column is part of a VECTOR-repeated subtree,
+	// and -1 otherwise. See effectiveVectorLength.
 	effectiveVectorLength int32
 }
 
@@ -125,7 +125,7 @@ func (c *Column) MaxRepetitionLevel() int16 { return c.maxRepLvl }
 func (c *Column) EffectiveVectorLength() int32 { return c.effectiveVectorLength }
 
 // InVectorColumn reports whether this column belongs to a VECTOR-repeated
-// subtree (Option B), in which case leaf values are written without per-element
+// subtree, in which case leaf values are written without per-element
 // repetition levels.
 func (c *Column) InVectorColumn() bool { return c.effectiveVectorLength > 0 }
 

--- a/parquet/schema/logical_types.go
+++ b/parquet/schema/logical_types.go
@@ -73,6 +73,8 @@ func getLogicalType(l *format.LogicalType) LogicalType {
 		return Float16LogicalType{}
 	case l.IsSetVARIANT():
 		return VariantLogicalType{}
+	case l.IsSetVECTOR():
+		return VectorLogicalType{}
 	case l == nil:
 		return NoLogicalType{}
 	default:
@@ -297,6 +299,41 @@ func (ListLogicalType) toThrift() *format.LogicalType {
 
 func (ListLogicalType) Equals(rhs LogicalType) bool {
 	_, ok := rhs.(ListLogicalType)
+	return ok
+}
+
+// VectorLogicalType annotates the outer group of a fixed-size vector field.
+// The annotated group contains one VECTOR-repeated child group carrying the
+// vector_length and exactly one element child, mirroring the canonical LIST
+// structure.
+type VectorLogicalType struct{ baseLogicalType }
+
+func (VectorLogicalType) SortOrder() SortOrder { return SortUNKNOWN }
+
+func (VectorLogicalType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{"Type": VectorLogicalType{}.String()})
+}
+
+func (VectorLogicalType) String() string { return "Vector" }
+
+func (VectorLogicalType) IsNested() bool { return true }
+
+func (VectorLogicalType) ToConvertedType() (ConvertedType, DecimalMetadata) {
+	return ConvertedTypes.None, DecimalMetadata{}
+}
+
+func (VectorLogicalType) IsCompatible(t ConvertedType, dec DecimalMetadata) bool {
+	return t == ConvertedTypes.None && !dec.IsSet
+}
+
+func (VectorLogicalType) IsApplicable(parquet.Type, int32) bool { return false }
+
+func (VectorLogicalType) toThrift() *format.LogicalType {
+	return &format.LogicalType{VECTOR: format.NewVectorType()}
+}
+
+func (VectorLogicalType) Equals(rhs LogicalType) bool {
+	_, ok := rhs.(VectorLogicalType)
 	return ok
 }
 

--- a/parquet/schema/node.go
+++ b/parquet/schema/node.go
@@ -103,6 +103,9 @@ type node struct {
 	logicalType   LogicalType
 	convertedType ConvertedType
 	colPath       parquet.ColumnPath
+	// vectorLength is the fixed multiplicity for VECTOR-repeated nodes and -1
+	// for all other nodes. See parquet.Repetitions.Vector.
+	vectorLength int32
 }
 
 func (n *node) toThrift() *format.SchemaElement    { return nil }
@@ -112,6 +115,7 @@ func (n *node) RepetitionType() parquet.Repetition { return n.repetition }
 func (n *node) ConvertedType() ConvertedType       { return n.convertedType }
 func (n *node) LogicalType() LogicalType           { return n.logicalType }
 func (n *node) FieldID() int32                     { return n.fieldID }
+func (n *node) VectorLength() int32                { return n.vectorLength }
 func (n *node) Parent() Node                       { return n.parent }
 func (n *node) SetParent(p Node)                   { n.parent = p }
 func (n *node) Path() string {
@@ -124,13 +128,42 @@ func (n *node) columnPath() parquet.ColumnPath {
 	return n.colPath
 }
 
+func nodeVectorLength(n Node) int32 {
+	if v, ok := n.(interface{ VectorLength() int32 }); ok {
+		return v.VectorLength()
+	}
+	return -1
+}
+
 func (n *node) Equals(rhs Node) bool {
 	return n.typ == rhs.Type() &&
 		n.Name() == rhs.Name() &&
 		n.RepetitionType() == rhs.RepetitionType() &&
 		n.ConvertedType() == rhs.ConvertedType() &&
 		n.FieldID() == rhs.FieldID() &&
+		n.VectorLength() == nodeVectorLength(rhs) &&
 		n.LogicalType().Equals(rhs.LogicalType())
+}
+
+// validateVectorProperties enforces the VECTOR repetition invariants shared by
+// all node constructors: in this reduced Option B implementation VECTOR
+// repetition is only valid on primitive leaf nodes and requires a positive
+// vector_length, and no other node may carry a vector_length (its sentinel is
+// -1).
+func validateVectorProperties(typ NodeType, repetition parquet.Repetition, vectorLength int32) error {
+	if repetition == parquet.Repetitions.Vector {
+		if typ != Primitive {
+			return errors.New("parquet: VECTOR repetition is only allowed on primitive leaf nodes")
+		}
+		if vectorLength <= 0 {
+			return errors.New("parquet: VECTOR nodes must specify a positive vector_length")
+		}
+		return nil
+	}
+	if vectorLength != -1 {
+		return errors.New("parquet: only VECTOR nodes may specify vector_length")
+	}
+	return nil
 }
 
 func (n *node) Visit(v Visitor) {}
@@ -151,10 +184,28 @@ type PrimitiveNode struct {
 // NewPrimitiveNodeLogical constructs a Primitive node using the provided logical type for a given
 // physical type and typelength.
 func NewPrimitiveNodeLogical(name string, repetition parquet.Repetition, logicalType LogicalType, physicalType parquet.Type, typeLen int, id int32) (*PrimitiveNode, error) {
+	return newPrimitiveNodeLogical(name, repetition, logicalType, physicalType, typeLen, id, -1)
+}
+
+// NewPrimitiveNodeLogicalVector constructs a primitive VECTOR leaf node using
+// the provided logical type for a given physical type and typelength.
+// vectorLength must be positive.
+func NewPrimitiveNodeLogicalVector(name string, logicalType LogicalType, physicalType parquet.Type, typeLen int, vectorLength int32, id int32) (*PrimitiveNode, error) {
+	return newPrimitiveNodeLogical(name, parquet.Repetitions.Vector, logicalType, physicalType, typeLen, id, vectorLength)
+}
+
+func newPrimitiveNodeLogical(name string, repetition parquet.Repetition, logicalType LogicalType, physicalType parquet.Type, typeLen int, id int32, vectorLength int32) (*PrimitiveNode, error) {
 	n := &PrimitiveNode{
-		node:         node{typ: Primitive, name: name, repetition: repetition, logicalType: logicalType, fieldID: id},
+		node:         node{typ: Primitive, name: name, repetition: repetition, logicalType: logicalType, fieldID: id, vectorLength: vectorLength},
 		physicalType: physicalType,
 		typeLen:      typeLen,
+	}
+
+	if err := validateVectorProperties(Primitive, repetition, n.vectorLength); err != nil {
+		return nil, err
+	}
+	if repetition == parquet.Repetitions.Vector && physicalType == parquet.Types.ByteArray {
+		return nil, errors.New("parquet: VECTOR primitive nodes do not support variable-width BYTE_ARRAY elements")
 	}
 
 	if logicalType != nil {
@@ -185,10 +236,21 @@ func NewPrimitiveNodeLogical(name string, repetition parquet.Repetition, logical
 // NewPrimitiveNodeConverted constructs a primitive node from the given physical type and converted type,
 // determining the logical type from the converted type.
 func NewPrimitiveNodeConverted(name string, repetition parquet.Repetition, typ parquet.Type, converted ConvertedType, typeLen, precision, scale int, id int32) (*PrimitiveNode, error) {
+	return newPrimitiveNodeConverted(name, repetition, typ, converted, typeLen, precision, scale, id, -1)
+}
+
+func newPrimitiveNodeConverted(name string, repetition parquet.Repetition, typ parquet.Type, converted ConvertedType, typeLen, precision, scale int, id int32, vectorLength int32) (*PrimitiveNode, error) {
 	n := &PrimitiveNode{
-		node:         node{typ: Primitive, name: name, repetition: repetition, convertedType: converted, fieldID: id},
+		node:         node{typ: Primitive, name: name, repetition: repetition, convertedType: converted, fieldID: id, vectorLength: vectorLength},
 		physicalType: typ,
 		typeLen:      -1,
+	}
+
+	if err := validateVectorProperties(Primitive, repetition, n.vectorLength); err != nil {
+		return nil, err
+	}
+	if repetition == parquet.Repetitions.Vector && typ == parquet.Types.ByteArray {
+		return nil, errors.New("parquet: VECTOR primitive nodes do not support variable-width BYTE_ARRAY elements")
 	}
 
 	switch converted {
@@ -268,16 +330,27 @@ func PrimitiveNodeFromThrift(elem *format.SchemaElement) (*PrimitiveNode, error)
 		fieldID = elem.GetFieldID()
 	}
 
-	if elem.IsSetLogicalType() {
-		return NewPrimitiveNodeLogical(elem.GetName(), parquet.Repetition(elem.GetRepetitionType()),
-			getLogicalType(elem.GetLogicalType()), parquet.Type(elem.GetType()), int(elem.GetTypeLength()),
-			fieldID)
-	} else if elem.IsSetConvertedType() {
-		return NewPrimitiveNodeConverted(elem.GetName(), parquet.Repetition(elem.GetRepetitionType()),
-			parquet.Type(elem.GetType()), ConvertedType(elem.GetConvertedType()),
-			int(elem.GetTypeLength()), int(elem.GetPrecision()), int(elem.GetScale()), fieldID)
+	repetition := parquet.Repetition(elem.GetRepetitionType())
+	vectorLength := int32(-1)
+	if repetition == parquet.Repetitions.Vector {
+		if !elem.IsSetVectorLength() {
+			return nil, errors.New("parquet: VECTOR primitive nodes must specify vector_length")
+		}
+		vectorLength = elem.GetVectorLength()
+	} else if elem.IsSetVectorLength() {
+		return nil, errors.New("parquet: only VECTOR nodes may specify vector_length")
 	}
-	return NewPrimitiveNodeLogical(elem.GetName(), parquet.Repetition(elem.GetRepetitionType()), NoLogicalType{}, parquet.Type(elem.GetType()), int(elem.GetTypeLength()), fieldID)
+
+	if elem.IsSetLogicalType() {
+		return newPrimitiveNodeLogical(elem.GetName(), repetition,
+			getLogicalType(elem.GetLogicalType()), parquet.Type(elem.GetType()), int(elem.GetTypeLength()),
+			fieldID, vectorLength)
+	} else if elem.IsSetConvertedType() {
+		return newPrimitiveNodeConverted(elem.GetName(), repetition,
+			parquet.Type(elem.GetType()), ConvertedType(elem.GetConvertedType()),
+			int(elem.GetTypeLength()), int(elem.GetPrecision()), int(elem.GetScale()), fieldID, vectorLength)
+	}
+	return newPrimitiveNodeLogical(elem.GetName(), repetition, NoLogicalType{}, parquet.Type(elem.GetType()), int(elem.GetTypeLength()), fieldID, vectorLength)
 }
 
 // NewPrimitiveNode constructs a primitive node with the ConvertedType of None and no logical type.
@@ -360,6 +433,9 @@ func (p *PrimitiveNode) toThrift() *format.SchemaElement {
 	if p.physicalType == parquet.Types.FixedLenByteArray {
 		elem.TypeLength = thrift.Int32Ptr(int32(p.typeLen))
 	}
+	if p.RepetitionType() == parquet.Repetitions.Vector {
+		elem.VectorLength = thrift.Int32Ptr(p.vectorLength)
+	}
 	if p.decimalMetaData.IsSet {
 		elem.Precision = &p.decimalMetaData.Precision
 		elem.Scale = &p.decimalMetaData.Scale
@@ -384,8 +460,11 @@ type GroupNode struct {
 // determining the logical type from that converted type.
 func NewGroupNodeConverted(name string, repetition parquet.Repetition, fields FieldList, converted ConvertedType, id int32) (n *GroupNode, err error) {
 	n = &GroupNode{
-		node:   node{typ: Group, name: name, repetition: repetition, convertedType: converted, fieldID: id},
+		node:   node{typ: Group, name: name, repetition: repetition, convertedType: converted, fieldID: id, vectorLength: -1},
 		fields: fields,
+	}
+	if err = validateVectorProperties(Group, repetition, n.vectorLength); err != nil {
+		return
 	}
 	n.logicalType = n.convertedType.ToLogicalType(DecimalMetadata{})
 	if !(n.logicalType != nil && (n.logicalType.IsNested() || n.logicalType.IsNone()) && n.logicalType.IsCompatible(n.convertedType, DecimalMetadata{})) {
@@ -405,8 +484,12 @@ func NewGroupNodeConverted(name string, repetition parquet.Repetition, fields Fi
 // determining the converted type from the provided logical type.
 func NewGroupNodeLogical(name string, repetition parquet.Repetition, fields FieldList, logical LogicalType, id int32) (n *GroupNode, err error) {
 	n = &GroupNode{
-		node:   node{typ: Group, name: name, repetition: repetition, logicalType: logical, fieldID: id},
+		node:   node{typ: Group, name: name, repetition: repetition, logicalType: logical, fieldID: id, vectorLength: -1},
 		fields: fields,
+	}
+
+	if err = validateVectorProperties(Group, repetition, n.vectorLength); err != nil {
+		return
 	}
 
 	if logical != nil {
@@ -471,6 +554,13 @@ func GroupNodeFromThrift(elem *format.SchemaElement, fields FieldList) (*GroupNo
 	id := int32(-1)
 	if elem.IsSetFieldID() {
 		id = elem.GetFieldID()
+	}
+
+	if parquet.Repetition(elem.GetRepetitionType()) == parquet.Repetitions.Vector {
+		return nil, errors.New("parquet: VECTOR repetition is only allowed on primitive leaf nodes")
+	}
+	if elem.IsSetVectorLength() {
+		return nil, errors.New("parquet: only VECTOR nodes may specify vector_length")
 	}
 
 	if elem.IsSetLogicalType() {

--- a/parquet/schema/node.go
+++ b/parquet/schema/node.go
@@ -146,13 +146,13 @@ func (n *node) Equals(rhs Node) bool {
 }
 
 // validateVectorProperties enforces the VECTOR repetition invariants shared by
-// all node constructors: in this reduced implementation VECTOR repetition is only
-// valid on primitive leaf nodes and requires a positive vector_length, and no
-// other node may carry a vector_length (its sentinel is -1).
+// all node constructors: VECTOR repetition is only valid on group nodes and
+// requires a positive vector_length, and no other node may carry a vector_length
+// (its sentinel is -1).
 func validateVectorProperties(typ NodeType, repetition parquet.Repetition, vectorLength int32) error {
 	if repetition == parquet.Repetitions.Vector {
-		if typ != Primitive {
-			return errors.New("parquet: VECTOR repetition is only allowed on primitive leaf nodes")
+		if typ != Group {
+			return errors.New("parquet: VECTOR repetition is only allowed on group nodes")
 		}
 		if vectorLength <= 0 {
 			return errors.New("parquet: VECTOR nodes must specify a positive vector_length")
@@ -186,13 +186,6 @@ func NewPrimitiveNodeLogical(name string, repetition parquet.Repetition, logical
 	return newPrimitiveNodeLogical(name, repetition, logicalType, physicalType, typeLen, id, -1)
 }
 
-// NewPrimitiveNodeLogicalVector constructs a primitive VECTOR leaf node using
-// the provided logical type for a given physical type and typelength.
-// vectorLength must be positive.
-func NewPrimitiveNodeLogicalVector(name string, logicalType LogicalType, physicalType parquet.Type, typeLen int, vectorLength int32, id int32) (*PrimitiveNode, error) {
-	return newPrimitiveNodeLogical(name, parquet.Repetitions.Vector, logicalType, physicalType, typeLen, id, vectorLength)
-}
-
 func newPrimitiveNodeLogical(name string, repetition parquet.Repetition, logicalType LogicalType, physicalType parquet.Type, typeLen int, id int32, vectorLength int32) (*PrimitiveNode, error) {
 	n := &PrimitiveNode{
 		node:         node{typ: Primitive, name: name, repetition: repetition, logicalType: logicalType, fieldID: id, vectorLength: vectorLength},
@@ -202,9 +195,6 @@ func newPrimitiveNodeLogical(name string, repetition parquet.Repetition, logical
 
 	if err := validateVectorProperties(Primitive, repetition, n.vectorLength); err != nil {
 		return nil, err
-	}
-	if repetition == parquet.Repetitions.Vector && physicalType == parquet.Types.ByteArray {
-		return nil, errors.New("parquet: VECTOR primitive nodes do not support variable-width BYTE_ARRAY elements")
 	}
 
 	if logicalType != nil {
@@ -247,9 +237,6 @@ func newPrimitiveNodeConverted(name string, repetition parquet.Repetition, typ p
 
 	if err := validateVectorProperties(Primitive, repetition, n.vectorLength); err != nil {
 		return nil, err
-	}
-	if repetition == parquet.Repetitions.Vector && typ == parquet.Types.ByteArray {
-		return nil, errors.New("parquet: VECTOR primitive nodes do not support variable-width BYTE_ARRAY elements")
 	}
 
 	switch converted {
@@ -332,10 +319,7 @@ func PrimitiveNodeFromThrift(elem *format.SchemaElement) (*PrimitiveNode, error)
 	repetition := parquet.Repetition(elem.GetRepetitionType())
 	vectorLength := int32(-1)
 	if repetition == parquet.Repetitions.Vector {
-		if !elem.IsSetVectorLength() {
-			return nil, errors.New("parquet: VECTOR primitive nodes must specify vector_length")
-		}
-		vectorLength = elem.GetVectorLength()
+		return nil, errors.New("parquet: VECTOR repetition is only allowed on group nodes")
 	} else if elem.IsSetVectorLength() {
 		return nil, errors.New("parquet: only VECTOR nodes may specify vector_length")
 	}
@@ -458,11 +442,19 @@ type GroupNode struct {
 // NewGroupNodeConverted constructs a group node with the provided fields and converted type,
 // determining the logical type from that converted type.
 func NewGroupNodeConverted(name string, repetition parquet.Repetition, fields FieldList, converted ConvertedType, id int32) (n *GroupNode, err error) {
+	return newGroupNodeConverted(name, repetition, fields, converted, id, -1)
+}
+
+func newGroupNodeConverted(name string, repetition parquet.Repetition, fields FieldList, converted ConvertedType, id int32, vectorLength int32) (n *GroupNode, err error) {
 	n = &GroupNode{
-		node:   node{typ: Group, name: name, repetition: repetition, convertedType: converted, fieldID: id, vectorLength: -1},
+		node:   node{typ: Group, name: name, repetition: repetition, convertedType: converted, fieldID: id, vectorLength: vectorLength},
 		fields: fields,
 	}
 	if err = validateVectorProperties(Group, repetition, n.vectorLength); err != nil {
+		return
+	}
+	if repetition == parquet.Repetitions.Vector && converted != ConvertedTypes.None {
+		err = errors.New("parquet: VECTOR-repeated groups must not have a converted type")
 		return
 	}
 	n.logicalType = n.convertedType.ToLogicalType(DecimalMetadata{})
@@ -482,12 +474,28 @@ func NewGroupNodeConverted(name string, repetition parquet.Repetition, fields Fi
 // NewGroupNodeLogical constructs a group node with the provided fields and logical type,
 // determining the converted type from the provided logical type.
 func NewGroupNodeLogical(name string, repetition parquet.Repetition, fields FieldList, logical LogicalType, id int32) (n *GroupNode, err error) {
+	return newGroupNodeLogical(name, repetition, fields, logical, id, -1)
+}
+
+// NewGroupNodeVector constructs a VECTOR-repeated group node carrying
+// the fixed vectorLength multiplicity. The group should be the single child of
+// an outer group annotated with VectorLogicalType and must not have its own
+// logical type.
+func NewGroupNodeVector(name string, fields FieldList, vectorLength int32, id int32) (n *GroupNode, err error) {
+	return newGroupNodeLogical(name, parquet.Repetitions.Vector, fields, nil, id, vectorLength)
+}
+
+func newGroupNodeLogical(name string, repetition parquet.Repetition, fields FieldList, logical LogicalType, id int32, vectorLength int32) (n *GroupNode, err error) {
 	n = &GroupNode{
-		node:   node{typ: Group, name: name, repetition: repetition, logicalType: logical, fieldID: id, vectorLength: -1},
+		node:   node{typ: Group, name: name, repetition: repetition, logicalType: logical, fieldID: id, vectorLength: vectorLength},
 		fields: fields,
 	}
 
 	if err = validateVectorProperties(Group, repetition, n.vectorLength); err != nil {
+		return
+	}
+	if repetition == parquet.Repetitions.Vector && logical != nil && !logical.IsNone() {
+		err = errors.New("parquet: VECTOR-repeated groups must not have a logical type")
 		return
 	}
 
@@ -555,22 +563,26 @@ func GroupNodeFromThrift(elem *format.SchemaElement, fields FieldList) (*GroupNo
 		id = elem.GetFieldID()
 	}
 
-	if parquet.Repetition(elem.GetRepetitionType()) == parquet.Repetitions.Vector {
-		return nil, errors.New("parquet: VECTOR repetition is only allowed on primitive leaf nodes")
-	}
-	if elem.IsSetVectorLength() {
+	repetition := parquet.Repetition(elem.GetRepetitionType())
+	vectorLength := int32(-1)
+	if repetition == parquet.Repetitions.Vector {
+		if !elem.IsSetVectorLength() {
+			return nil, errors.New("parquet: VECTOR group nodes must specify vector_length")
+		}
+		vectorLength = elem.GetVectorLength()
+	} else if elem.IsSetVectorLength() {
 		return nil, errors.New("parquet: only VECTOR nodes may specify vector_length")
 	}
 
 	if elem.IsSetLogicalType() {
-		return NewGroupNodeLogical(elem.GetName(), parquet.Repetition(elem.GetRepetitionType()), fields, getLogicalType(elem.GetLogicalType()), id)
+		return newGroupNodeLogical(elem.GetName(), repetition, fields, getLogicalType(elem.GetLogicalType()), id, vectorLength)
 	}
 
 	converted := ConvertedTypes.None
 	if elem.IsSetConvertedType() {
 		converted = ConvertedType(elem.GetConvertedType())
 	}
-	return NewGroupNodeConverted(elem.GetName(), parquet.Repetition(elem.GetRepetitionType()), fields, converted, id)
+	return newGroupNodeConverted(elem.GetName(), repetition, fields, converted, id, vectorLength)
 }
 
 func (g *GroupNode) toThrift() *format.SchemaElement {
@@ -584,6 +596,9 @@ func (g *GroupNode) toThrift() *format.SchemaElement {
 	}
 	if g.fieldID >= 0 {
 		elem.FieldID = &g.fieldID
+	}
+	if g.RepetitionType() == parquet.Repetitions.Vector {
+		elem.VectorLength = thrift.Int32Ptr(g.vectorLength)
 	}
 	if g.logicalType != nil && g.logicalType.IsSerialized() {
 		elem.LogicalType = g.logicalType.toThrift()

--- a/parquet/schema/node.go
+++ b/parquet/schema/node.go
@@ -146,10 +146,9 @@ func (n *node) Equals(rhs Node) bool {
 }
 
 // validateVectorProperties enforces the VECTOR repetition invariants shared by
-// all node constructors: in this reduced Option B implementation VECTOR
-// repetition is only valid on primitive leaf nodes and requires a positive
-// vector_length, and no other node may carry a vector_length (its sentinel is
-// -1).
+// all node constructors: in this reduced implementation VECTOR repetition is only
+// valid on primitive leaf nodes and requires a positive vector_length, and no
+// other node may carry a vector_length (its sentinel is -1).
 func validateVectorProperties(typ NodeType, repetition parquet.Repetition, vectorLength int32) error {
 	if repetition == parquet.Repetitions.Vector {
 		if typ != Primitive {

--- a/parquet/schema/node_vector_internal_test.go
+++ b/parquet/schema/node_vector_internal_test.go
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/parquet"
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPrimitiveNodeVector(t *testing.T) {
+	leaf, err := NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, 768, -1)
+	require.NoError(t, err)
+
+	assert.Equal(t, parquet.Repetitions.Vector, leaf.RepetitionType())
+	assert.EqualValues(t, 768, leaf.VectorLength())
+	assert.True(t, leaf.LogicalType().IsNone())
+
+	// toThrift emits repetition VECTOR and vector_length on the primitive leaf.
+	se := leaf.toThrift()
+	assert.Equal(t, format.FieldRepetitionType_VECTOR, se.GetRepetitionType())
+	require.True(t, se.IsSetVectorLength())
+	assert.EqualValues(t, 768, se.GetVectorLength())
+
+	// Round-trip the vector leaf node through thrift.
+	leaf2, err := PrimitiveNodeFromThrift(se)
+	require.NoError(t, err)
+	assert.True(t, leaf.Equals(leaf2))
+	assert.EqualValues(t, 768, leaf2.VectorLength())
+}
+
+func TestVectorLengthDefaultIsNegativeOne(t *testing.T) {
+	prim := MustPrimitive(NewPrimitiveNode("x", parquet.Repetitions.Optional, parquet.Types.Int32, -1, -1))
+	assert.EqualValues(t, -1, prim.VectorLength())
+
+	grp := MustGroup(NewGroupNode("g", parquet.Repetitions.Optional, FieldList{prim}, -1))
+	assert.EqualValues(t, -1, grp.VectorLength())
+}
+
+func TestVectorValidationErrors(t *testing.T) {
+	elem := MustPrimitive(NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+
+	t.Run("non-positive vector_length", func(t *testing.T) {
+		_, err := NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, 0, -1)
+		assert.Error(t, err)
+		_, err = NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, -3, -1)
+		assert.Error(t, err)
+	})
+
+	t.Run("VECTOR repetition on a primitive without vector_length", func(t *testing.T) {
+		_, err := NewPrimitiveNode("p", parquet.Repetitions.Vector, parquet.Types.Float, -1, -1)
+		assert.Error(t, err)
+	})
+
+	t.Run("VECTOR repetition on a group", func(t *testing.T) {
+		_, err := NewGroupNode("g", parquet.Repetitions.Vector, FieldList{elem}, -1)
+		assert.Error(t, err)
+	})
+
+	t.Run("VECTOR primitive with variable-width BYTE_ARRAY", func(t *testing.T) {
+		_, err := NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.ByteArray, -1, 8, -1)
+		assert.Error(t, err)
+	})
+
+	t.Run("vector_length set on non-VECTOR group thrift", func(t *testing.T) {
+		rep := format.FieldRepetitionType_OPTIONAL
+		vlen := int32(8)
+		se := &format.SchemaElement{Name: "g", RepetitionType: &rep, VectorLength: &vlen}
+		_, err := GroupNodeFromThrift(se, FieldList{})
+		assert.Error(t, err)
+	})
+
+	t.Run("vector_length set on non-VECTOR primitive thrift", func(t *testing.T) {
+		rep := format.FieldRepetitionType_OPTIONAL
+		typ := format.Type_FLOAT
+		vlen := int32(8)
+		se := &format.SchemaElement{Name: "p", RepetitionType: &rep, Type: &typ, VectorLength: &vlen}
+		_, err := PrimitiveNodeFromThrift(se)
+		assert.Error(t, err)
+	})
+
+	t.Run("VECTOR group thrift", func(t *testing.T) {
+		rep := format.FieldRepetitionType_VECTOR
+		vlen := int32(8)
+		se := &format.SchemaElement{Name: "list", RepetitionType: &rep, VectorLength: &vlen}
+		_, err := GroupNodeFromThrift(se, FieldList{elem})
+		assert.Error(t, err)
+	})
+
+	t.Run("VECTOR primitive thrift without vector_length", func(t *testing.T) {
+		rep := format.FieldRepetitionType_VECTOR
+		typ := format.Type_FLOAT
+		se := &format.SchemaElement{Name: "embedding", RepetitionType: &rep, Type: &typ}
+		_, err := PrimitiveNodeFromThrift(se)
+		assert.Error(t, err)
+	})
+}
+
+// Full reduced Option B vector leaf round-trips through thrift:
+//
+//	vector float embedding [768];
+func TestVectorLeafRoundTrip(t *testing.T) {
+	leaf := MustPrimitive(NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, 768, -1))
+
+	leafSE := leaf.toThrift()
+	assert.Equal(t, format.FieldRepetitionType_VECTOR, leafSE.GetRepetitionType())
+	assert.True(t, leafSE.IsSetVectorLength())
+	assert.EqualValues(t, 768, leafSE.GetVectorLength())
+
+	leaf2, err := PrimitiveNodeFromThrift(leafSE)
+	require.NoError(t, err)
+
+	assert.True(t, leaf.Equals(leaf2))
+	assert.EqualValues(t, 768, leaf2.VectorLength())
+}

--- a/parquet/schema/node_vector_internal_test.go
+++ b/parquet/schema/node_vector_internal_test.go
@@ -25,25 +25,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewPrimitiveNodeVector(t *testing.T) {
-	leaf, err := NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, 768, -1)
-	require.NoError(t, err)
+func vectorGroupNode(t *testing.T, vectorLen int32) (*GroupNode, *PrimitiveNode) {
+	t.Helper()
+	elem := MustPrimitive(NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+	vec := MustGroup(NewGroupNodeVector("list", FieldList{elem}, vectorLen, -1))
+	return vec, elem
+}
 
-	assert.Equal(t, parquet.Repetitions.Vector, leaf.RepetitionType())
-	assert.EqualValues(t, 768, leaf.VectorLength())
-	assert.True(t, leaf.LogicalType().IsNone())
+func TestNewGroupNodeVector(t *testing.T) {
+	vec, _ := vectorGroupNode(t, 768)
 
-	// toThrift emits repetition VECTOR and vector_length on the primitive leaf.
-	se := leaf.toThrift()
+	assert.Equal(t, parquet.Repetitions.Vector, vec.RepetitionType())
+	assert.EqualValues(t, 768, vec.VectorLength())
+	assert.True(t, vec.LogicalType().IsNone())
+
+	// toThrift emits repetition VECTOR and vector_length on the middle group.
+	se := vec.toThrift()
 	assert.Equal(t, format.FieldRepetitionType_VECTOR, se.GetRepetitionType())
 	require.True(t, se.IsSetVectorLength())
 	assert.EqualValues(t, 768, se.GetVectorLength())
 
-	// Round-trip the vector leaf node through thrift.
-	leaf2, err := PrimitiveNodeFromThrift(se)
+	// Round-trip the vector group node through thrift.
+	vec2, err := GroupNodeFromThrift(se, FieldList{vec.Field(0)})
 	require.NoError(t, err)
-	assert.True(t, leaf.Equals(leaf2))
-	assert.EqualValues(t, 768, leaf2.VectorLength())
+	assert.True(t, vec.Equals(vec2))
+	assert.EqualValues(t, 768, vec2.VectorLength())
+}
+
+func TestVectorLogicalTypeRoundTrip(t *testing.T) {
+	vec, _ := vectorGroupNode(t, 3)
+	outer := MustGroup(NewGroupNodeLogical("embedding", parquet.Repetitions.Optional, FieldList{vec}, VectorLogicalType{}, -1))
+
+	se := outer.toThrift()
+	require.True(t, se.IsSetLogicalType())
+	require.True(t, se.GetLogicalType().IsSetVECTOR())
+
+	roundtripped, err := GroupNodeFromThrift(se, FieldList{vec})
+	require.NoError(t, err)
+	assert.True(t, roundtripped.LogicalType().Equals(VectorLogicalType{}))
+	assert.True(t, outer.Equals(roundtripped))
 }
 
 func TestVectorLengthDefaultIsNegativeOne(t *testing.T) {
@@ -58,24 +78,19 @@ func TestVectorValidationErrors(t *testing.T) {
 	elem := MustPrimitive(NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
 
 	t.Run("non-positive vector_length", func(t *testing.T) {
-		_, err := NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, 0, -1)
+		_, err := NewGroupNodeVector("list", FieldList{elem}, 0, -1)
 		assert.Error(t, err)
-		_, err = NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, -3, -1)
+		_, err = NewGroupNodeVector("list", FieldList{elem}, -3, -1)
 		assert.Error(t, err)
 	})
 
-	t.Run("VECTOR repetition on a primitive without vector_length", func(t *testing.T) {
+	t.Run("VECTOR repetition on a primitive", func(t *testing.T) {
 		_, err := NewPrimitiveNode("p", parquet.Repetitions.Vector, parquet.Types.Float, -1, -1)
 		assert.Error(t, err)
 	})
 
-	t.Run("VECTOR repetition on a group", func(t *testing.T) {
+	t.Run("VECTOR repetition on a group without vector_length", func(t *testing.T) {
 		_, err := NewGroupNode("g", parquet.Repetitions.Vector, FieldList{elem}, -1)
-		assert.Error(t, err)
-	})
-
-	t.Run("VECTOR primitive with variable-width BYTE_ARRAY", func(t *testing.T) {
-		_, err := NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.ByteArray, -1, 8, -1)
 		assert.Error(t, err)
 	})
 
@@ -96,37 +111,32 @@ func TestVectorValidationErrors(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("VECTOR group thrift", func(t *testing.T) {
+	t.Run("VECTOR group with logical type", func(t *testing.T) {
+		_, err := newGroupNodeLogical("list", parquet.Repetitions.Vector, FieldList{elem}, NewListLogicalType(), -1, 8)
+		assert.Error(t, err)
+	})
+
+	t.Run("VECTOR group thrift without vector_length", func(t *testing.T) {
 		rep := format.FieldRepetitionType_VECTOR
-		vlen := int32(8)
-		se := &format.SchemaElement{Name: "list", RepetitionType: &rep, VectorLength: &vlen}
+		se := &format.SchemaElement{Name: "list", RepetitionType: &rep}
 		_, err := GroupNodeFromThrift(se, FieldList{elem})
 		assert.Error(t, err)
 	})
 
-	t.Run("VECTOR primitive thrift without vector_length", func(t *testing.T) {
+	t.Run("VECTOR group thrift with logical type", func(t *testing.T) {
+		rep := format.FieldRepetitionType_VECTOR
+		vlen := int32(8)
+		se := &format.SchemaElement{Name: "list", RepetitionType: &rep, VectorLength: &vlen, LogicalType: &format.LogicalType{LIST: format.NewListType()}}
+		_, err := GroupNodeFromThrift(se, FieldList{elem})
+		assert.Error(t, err)
+	})
+
+	t.Run("VECTOR primitive thrift", func(t *testing.T) {
 		rep := format.FieldRepetitionType_VECTOR
 		typ := format.Type_FLOAT
-		se := &format.SchemaElement{Name: "embedding", RepetitionType: &rep, Type: &typ}
+		vlen := int32(8)
+		se := &format.SchemaElement{Name: "embedding", RepetitionType: &rep, Type: &typ, VectorLength: &vlen}
 		_, err := PrimitiveNodeFromThrift(se)
 		assert.Error(t, err)
 	})
-}
-
-// Full vector leaf round-trips through thrift:
-//
-//	vector float embedding [768];
-func TestVectorLeafRoundTrip(t *testing.T) {
-	leaf := MustPrimitive(NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, 768, -1))
-
-	leafSE := leaf.toThrift()
-	assert.Equal(t, format.FieldRepetitionType_VECTOR, leafSE.GetRepetitionType())
-	assert.True(t, leafSE.IsSetVectorLength())
-	assert.EqualValues(t, 768, leafSE.GetVectorLength())
-
-	leaf2, err := PrimitiveNodeFromThrift(leafSE)
-	require.NoError(t, err)
-
-	assert.True(t, leaf.Equals(leaf2))
-	assert.EqualValues(t, 768, leaf2.VectorLength())
 }

--- a/parquet/schema/node_vector_internal_test.go
+++ b/parquet/schema/node_vector_internal_test.go
@@ -113,7 +113,7 @@ func TestVectorValidationErrors(t *testing.T) {
 	})
 }
 
-// Full reduced Option B vector leaf round-trips through thrift:
+// Full vector leaf round-trips through thrift:
 //
 //	vector float embedding [768];
 func TestVectorLeafRoundTrip(t *testing.T) {

--- a/parquet/schema/schema.go
+++ b/parquet/schema/schema.go
@@ -76,27 +76,48 @@ func FromParquet(elems []*format.SchemaElement) (Node, error) {
 	}
 
 	// We don't check that the root node is repeated since this is not
-	// consistently set by implementations
+	// consistently set by implementations. The root repetition also does not
+	// contribute levels, matching NewSchema/buildTree.
 	var (
 		pos      = 0
-		nextNode func() (Node, error)
+		nextNode func(isRoot bool, maxDefLvl, maxRepLvl int16) (Node, error)
 	)
 
-	nextNode = func() (Node, error) {
+	nextNode = func(isRoot bool, maxDefLvl, maxRepLvl int16) (Node, error) {
 		if pos == len(elems) {
 			return nil, errors.New("parquet: malformed schema: not enough elements")
 		}
 
 		elem := elems[pos]
 		pos++
+		repetition := parquet.Repetition(elem.GetRepetitionType())
 
 		if elem.GetNumChildren() == 0 {
+			if repetition == parquet.Repetitions.Vector {
+				if err := validateVectorColumnLevels(maxDefLvl, maxRepLvl); err != nil {
+					return nil, err
+				}
+			}
 			return PrimitiveNodeFromThrift(elem)
+		}
+
+		childMaxDefLvl, childMaxRepLvl := maxDefLvl, maxRepLvl
+		if !isRoot {
+			switch repetition {
+			case parquet.Repetitions.Repeated:
+				childMaxRepLvl++
+				fallthrough
+			case parquet.Repetitions.Optional:
+				childMaxDefLvl++
+			case parquet.Repetitions.Vector:
+				// GroupNodeFromThrift rejects VECTOR groups; keep level accounting a
+				// no-op here to mirror buildTree until that error is returned below.
+			}
 		}
 
 		fields := make([]Node, 0, elem.GetNumChildren())
 		for i := 0; i < int(elem.GetNumChildren()); i++ {
-			n, err := nextNode()
+			n, err := nextNode(false, childMaxDefLvl, childMaxRepLvl)
 			if err != nil {
 				return nil, err
 			}
@@ -106,7 +127,7 @@ func FromParquet(elems []*format.SchemaElement) (Node, error) {
 		return GroupNodeFromThrift(elem, fields)
 	}
 
-	return nextNode()
+	return nextNode(true, 0, 0)
 }
 
 // Root returns the group node that is the root of this schema
@@ -136,26 +157,48 @@ func (s *Schema) Equals(rhs *Schema) bool {
 	return true
 }
 
-func (s *Schema) buildTree(n Node, maxDefLvl, maxRepLvl int16, base Node) {
+func validateVectorColumnLevels(maxDefLvl, maxRepLvl int16) error {
+	if maxDefLvl != 0 || maxRepLvl != 0 {
+		return errors.New("parquet: VECTOR columns must be non-nullable and must not have repeated ancestors")
+	}
+	return nil
+}
+
+func (s *Schema) buildTree(n Node, maxDefLvl, maxRepLvl int16, base Node) error {
 	switch n.RepetitionType() {
 	case parquet.Repetitions.Repeated:
 		maxRepLvl++
 		fallthrough
 	case parquet.Repetitions.Optional:
 		maxDefLvl++
+	case parquet.Repetitions.Vector:
+		if err := validateVectorColumnLevels(maxDefLvl, maxRepLvl); err != nil {
+			return err
+		}
+		// VECTOR fields (Option B) repeat a fixed number of times per parent
+		// value without increasing the maximum definition or repetition level:
+		// the fixed multiplicity is recovered from the schema's vector_length,
+		// so no per-element levels are written. Intentionally a no-op.
 	}
 
 	switch n := n.(type) {
 	case *GroupNode:
 		for _, f := range n.fields {
-			s.buildTree(f, maxDefLvl, maxRepLvl, base)
+			if err := s.buildTree(f, maxDefLvl, maxRepLvl, base); err != nil {
+				return err
+			}
 		}
 	case *PrimitiveNode:
+		col, err := NewColumnChecked(n, maxDefLvl, maxRepLvl)
+		if err != nil {
+			return err
+		}
 		s.nodeToLeaf[n] = len(s.leaves)
-		s.leaves = append(s.leaves, NewColumn(n, maxDefLvl, maxRepLvl))
+		s.leaves = append(s.leaves, col)
 		s.leafToBase[len(s.leaves)-1] = base
 		s.leafToIndex.Add(n.Path(), len(s.leaves)-1)
 	}
+	return nil
 }
 
 // Column returns the (0-indexed) column of the provided index.
@@ -226,6 +269,16 @@ func (s *Schema) String() string {
 //
 // Any fields with a field-id of -1 will be given an appropriate field number based on their order.
 func NewSchema(root *GroupNode) *Schema {
+	s, err := NewSchemaChecked(root)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// NewSchemaChecked is like NewSchema, but returns an error instead of panicking
+// when schema invariants are violated.
+func NewSchemaChecked(root *GroupNode) (*Schema, error) {
 	s := &Schema{
 		root,
 		make([]*Column, 0),
@@ -235,9 +288,11 @@ func NewSchema(root *GroupNode) *Schema {
 	}
 
 	for _, f := range root.fields {
-		s.buildTree(f, 0, 0, f)
+		if err := s.buildTree(f, 0, 0, f); err != nil {
+			return nil, err
+		}
 	}
-	return s
+	return s, nil
 }
 
 type schemaColumnOrderUpdater struct {

--- a/parquet/schema/schema.go
+++ b/parquet/schema/schema.go
@@ -93,12 +93,13 @@ func FromParquet(elems []*format.SchemaElement) (Node, error) {
 		repetition := parquet.Repetition(elem.GetRepetitionType())
 
 		if elem.GetNumChildren() == 0 {
-			if repetition == parquet.Repetitions.Vector {
-				if err := validateVectorColumnLevels(maxDefLvl, maxRepLvl); err != nil {
-					return nil, err
-				}
-			}
 			return PrimitiveNodeFromThrift(elem)
+		}
+
+		if repetition == parquet.Repetitions.Vector {
+			if err := validateVectorColumnLevels(maxDefLvl, maxRepLvl); err != nil {
+				return nil, err
+			}
 		}
 
 		childMaxDefLvl, childMaxRepLvl := maxDefLvl, maxRepLvl
@@ -110,8 +111,8 @@ func FromParquet(elems []*format.SchemaElement) (Node, error) {
 			case parquet.Repetitions.Optional:
 				childMaxDefLvl++
 			case parquet.Repetitions.Vector:
-				// GroupNodeFromThrift rejects VECTOR groups; keep level accounting a
-				// no-op here to mirror buildTree until that error is returned below.
+				// VECTOR groups repeat a fixed number of values per parent but do not
+				// contribute definition or repetition levels.
 			}
 		}
 
@@ -127,7 +128,16 @@ func FromParquet(elems []*format.SchemaElement) (Node, error) {
 		return GroupNodeFromThrift(elem, fields)
 	}
 
-	return nextNode(true, 0, 0)
+	root, err := nextNode(true, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	if g, ok := root.(*GroupNode); ok {
+		if _, err := NewSchemaChecked(g); err != nil {
+			return nil, err
+		}
+	}
+	return root, nil
 }
 
 // Root returns the group node that is the root of this schema
@@ -159,7 +169,85 @@ func (s *Schema) Equals(rhs *Schema) bool {
 
 func validateVectorColumnLevels(maxDefLvl, maxRepLvl int16) error {
 	if maxDefLvl != 0 || maxRepLvl != 0 {
-		return errors.New("parquet: VECTOR columns must be non-nullable and must not have repeated ancestors")
+		return errors.New("parquet: nullable VECTOR columns and VECTOR columns with repeated ancestors are not supported")
+	}
+	return nil
+}
+
+func isVectorLogicalNode(n Node) bool {
+	g, ok := n.(*GroupNode)
+	return ok && g.LogicalType().Equals(VectorLogicalType{})
+}
+
+func validateVectorElement(n Node) error {
+	if n.Name() != "element" {
+		return errors.New("parquet: VECTOR element child must be named element")
+	}
+	switch n.RepetitionType() {
+	case parquet.Repetitions.Required:
+	case parquet.Repetitions.Optional:
+		return errors.New("parquet: nullable VECTOR elements are not supported")
+	case parquet.Repetitions.Repeated:
+		return errors.New("parquet: repeated fields inside VECTOR columns are not supported")
+	case parquet.Repetitions.Vector:
+		return errors.New("parquet: nested VECTOR columns are not supported")
+	}
+
+	primitive, ok := n.(*PrimitiveNode)
+	if !ok {
+		return errors.New("parquet: VECTOR elements must be primitive")
+	}
+	if primitive.PhysicalType() == parquet.Types.ByteArray {
+		return errors.New("parquet: VECTOR elements must be fixed-width primitive types")
+	}
+	return nil
+}
+
+func validateVectorStructure(n Node) error {
+	return validateVectorStructureAt(n, true, false)
+}
+
+func validateVectorStructureAt(n Node, isRoot, topLevel bool) error {
+	if isVectorLogicalNode(n) {
+		if !topLevel {
+			return errors.New("parquet: VECTOR logical groups must be top-level fields")
+		}
+		g := n.(*GroupNode)
+		if g.RepetitionType() != parquet.Repetitions.Required {
+			return errors.New("parquet: nullable VECTOR columns are not supported")
+		}
+		if g.NumFields() != 1 {
+			return errors.New("parquet: VECTOR logical groups must have a single VECTOR-repeated child")
+		}
+		child := g.Field(0)
+		vectorGroup, ok := child.(*GroupNode)
+		if !ok || child.RepetitionType() != parquet.Repetitions.Vector {
+			return errors.New("parquet: VECTOR logical groups must contain a VECTOR-repeated group child")
+		}
+		if vectorGroup.Name() != "list" {
+			return errors.New("parquet: VECTOR-repeated group must be named list")
+		}
+		if !vectorGroup.LogicalType().IsNone() || vectorGroup.ConvertedType() != ConvertedTypes.None {
+			return errors.New("parquet: VECTOR-repeated groups must not have a logical or converted type")
+		}
+		if vectorGroup.NumFields() != 1 {
+			return errors.New("parquet: VECTOR-repeated groups must have a single element child")
+		}
+		return validateVectorElement(vectorGroup.Field(0))
+	}
+
+	if n.RepetitionType() == parquet.Repetitions.Vector {
+		return errors.New("parquet: VECTOR-repeated groups must be the single child of a group annotated with the VECTOR logical type")
+	}
+
+	g, ok := n.(*GroupNode)
+	if !ok {
+		return nil
+	}
+	for _, f := range g.fields {
+		if err := validateVectorStructureAt(f, false, isRoot); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -279,6 +367,10 @@ func NewSchema(root *GroupNode) *Schema {
 // NewSchemaChecked is like NewSchema, but returns an error instead of panicking
 // when schema invariants are violated.
 func NewSchemaChecked(root *GroupNode) (*Schema, error) {
+	if err := validateVectorStructure(root); err != nil {
+		return nil, err
+	}
+
 	s := &Schema{
 		root,
 		make([]*Column, 0),

--- a/parquet/schema/schema.go
+++ b/parquet/schema/schema.go
@@ -175,10 +175,10 @@ func (s *Schema) buildTree(n Node, maxDefLvl, maxRepLvl int16, base Node) error 
 		if err := validateVectorColumnLevels(maxDefLvl, maxRepLvl); err != nil {
 			return err
 		}
-		// VECTOR fields (Option B) repeat a fixed number of times per parent
-		// value without increasing the maximum definition or repetition level:
-		// the fixed multiplicity is recovered from the schema's vector_length,
-		// so no per-element levels are written. Intentionally a no-op.
+		// VECTOR fields repeat a fixed number of times per parent value without
+		// increasing the maximum definition or repetition level: the fixed
+		// multiplicity is recovered from the schema's vector_length, so no
+		// per-element levels are written. Intentionally a no-op.
 	}
 
 	switch n := n.(type) {

--- a/parquet/schema/schema_vector_test.go
+++ b/parquet/schema/schema_vector_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// vectorRoot builds a root group containing the reduced Option B vector leaf:
+// vectorRoot builds a root group containing vector leaf:
 //
 //	vector float embedding [listSize];
 func vectorRoot(t *testing.T, listSize int32) *schema.GroupNode {

--- a/parquet/schema/schema_vector_test.go
+++ b/parquet/schema/schema_vector_test.go
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/parquet"
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
+	"github.com/apache/arrow-go/v18/parquet/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vectorRoot builds a root group containing the reduced Option B vector leaf:
+//
+//	vector float embedding [listSize];
+func vectorRoot(t *testing.T, listSize int32) *schema.GroupNode {
+	t.Helper()
+	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, listSize, -1))
+	return schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{leaf}, -1))
+}
+
+// VECTOR repetition must not increase the leaf's max definition or repetition
+// level; the fixed multiplicity is carried by vector_length on the leaf.
+func TestVectorBuildTreeLevels(t *testing.T) {
+	sc := schema.NewSchema(vectorRoot(t, 128))
+	require.Equal(t, 1, sc.NumColumns())
+	col := sc.Column(0)
+	assert.Equal(t, "embedding", col.Name())
+	assert.Equal(t, "embedding", col.Path())
+	assert.Equal(t, parquet.Types.Float, col.PhysicalType())
+	assert.EqualValues(t, 0, col.MaxDefinitionLevel(), "max definition level")
+	assert.EqualValues(t, 0, col.MaxRepetitionLevel(), "max repetition level")
+	assert.True(t, col.InVectorColumn())
+	assert.EqualValues(t, 128, col.EffectiveVectorLength())
+}
+
+// The flattened schema must carry VECTOR repetition and vector_length directly
+// on the primitive leaf, and reconstruct losslessly via FromParquet.
+func TestVectorSchemaThriftRoundTrip(t *testing.T) {
+	root := vectorRoot(t, 128)
+	sc := schema.NewSchema(root)
+
+	elems := schema.ToThrift(root)
+
+	var sawVectorRep bool
+	for _, e := range elems {
+		if e.GetRepetitionType() == format.FieldRepetitionType_VECTOR {
+			sawVectorRep = true
+			require.True(t, e.IsSetVectorLength(), "VECTOR leaf must carry vector_length")
+			assert.EqualValues(t, 128, e.GetVectorLength())
+			assert.False(t, e.IsSetLogicalType(), "VECTOR leaf must not carry a VECTOR logical type")
+			assert.True(t, e.IsSetType(), "VECTOR leaf must be primitive")
+		}
+	}
+	assert.True(t, sawVectorRep, "expected a VECTOR-repeated primitive leaf")
+
+	recon, err := schema.FromParquet(elems)
+	require.NoError(t, err)
+	reconSchema := schema.NewSchema(recon.(*schema.GroupNode))
+
+	assert.True(t, sc.Equals(reconSchema), "schema must round-trip through ToThrift/FromParquet")
+	assert.EqualValues(t, 128, reconSchema.Column(0).EffectiveVectorLength())
+	assert.True(t, reconSchema.Column(0).InVectorColumn())
+}
+
+func TestVectorRejectsNullableOrRepeatedAncestors(t *testing.T) {
+	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, 8, -1))
+
+	t.Run("optional ancestor", func(t *testing.T) {
+		opt := schema.MustGroup(schema.NewGroupNode("opt", parquet.Repetitions.Optional, schema.FieldList{leaf}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{opt}, -1))
+		_, err := schema.NewSchemaChecked(root)
+		assert.Error(t, err)
+		assert.Panics(t, func() { schema.NewSchema(root) })
+		_, err = schema.FromParquet(schema.ToThrift(root))
+		assert.Error(t, err)
+	})
+
+	t.Run("repeated ancestor", func(t *testing.T) {
+		rep := schema.MustGroup(schema.NewGroupNode("rep", parquet.Repetitions.Repeated, schema.FieldList{leaf}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{rep}, -1))
+		_, err := schema.NewSchemaChecked(root)
+		assert.Error(t, err)
+		assert.Panics(t, func() { schema.NewSchema(root) })
+		_, err = schema.FromParquet(schema.ToThrift(root))
+		assert.Error(t, err)
+	})
+}
+
+func TestVectorEffectiveLength(t *testing.T) {
+	sc := schema.NewSchema(vectorRoot(t, 128))
+	col := sc.Column(0)
+	assert.True(t, col.InVectorColumn())
+	assert.EqualValues(t, 128, col.EffectiveVectorLength())
+
+	// A non-VECTOR column reports -1 / false.
+	plain := schema.MustPrimitive(schema.NewPrimitiveNode("x", parquet.Repetitions.Optional, parquet.Types.Int32, -1, -1))
+	psc := schema.NewSchema(schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{plain}, -1)))
+	assert.False(t, psc.Column(0).InVectorColumn())
+	assert.EqualValues(t, -1, psc.Column(0).EffectiveVectorLength())
+
+	// Survives the thrift round-trip.
+	recon, err := schema.FromParquet(schema.ToThrift(vectorRoot(t, 128)))
+	require.NoError(t, err)
+	rsc := schema.NewSchema(recon.(*schema.GroupNode))
+	assert.EqualValues(t, 128, rsc.Column(0).EffectiveVectorLength())
+	assert.True(t, rsc.Column(0).InVectorColumn())
+}

--- a/parquet/schema/schema_vector_test.go
+++ b/parquet/schema/schema_vector_test.go
@@ -26,23 +26,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// vectorRoot builds a root group containing vector leaf:
+// vectorRoot builds a root group containing the canonical 3-level vector form:
 //
-//	vector float embedding [listSize];
+//	required group embedding (VECTOR) {
+//	  vector group list [listSize] {
+//	    required float element;
+//	  }
+//	}
 func vectorRoot(t *testing.T, listSize int32) *schema.GroupNode {
 	t.Helper()
-	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, listSize, -1))
-	return schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{leaf}, -1))
+	element := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+	list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{element}, listSize, -1))
+	embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+	return schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
 }
 
 // VECTOR repetition must not increase the leaf's max definition or repetition
-// level; the fixed multiplicity is carried by vector_length on the leaf.
+// level; the fixed multiplicity is carried by vector_length on the middle group.
 func TestVectorBuildTreeLevels(t *testing.T) {
 	sc := schema.NewSchema(vectorRoot(t, 128))
 	require.Equal(t, 1, sc.NumColumns())
 	col := sc.Column(0)
-	assert.Equal(t, "embedding", col.Name())
-	assert.Equal(t, "embedding", col.Path())
+	assert.Equal(t, "element", col.Name())
+	assert.Equal(t, "embedding.list.element", col.Path())
 	assert.Equal(t, parquet.Types.Float, col.PhysicalType())
 	assert.EqualValues(t, 0, col.MaxDefinitionLevel(), "max definition level")
 	assert.EqualValues(t, 0, col.MaxRepetitionLevel(), "max repetition level")
@@ -50,25 +56,55 @@ func TestVectorBuildTreeLevels(t *testing.T) {
 	assert.EqualValues(t, 128, col.EffectiveVectorLength())
 }
 
-// The flattened schema must carry VECTOR repetition and vector_length directly
-// on the primitive leaf, and reconstruct losslessly via FromParquet.
+func TestVectorRejectsNullableOuterLevel(t *testing.T) {
+	element := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+	list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{element}, 8, -1))
+	embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Optional, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
+	_, err := schema.NewSchemaChecked(root)
+	assert.ErrorContains(t, err, "nullable VECTOR columns")
+	assert.Panics(t, func() { schema.NewSchema(root) })
+	_, err = schema.FromParquet(schema.ToThrift(root))
+	assert.ErrorContains(t, err, "nullable VECTOR columns")
+}
+
+func TestVectorRejectsNullableElement(t *testing.T) {
+	element := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Optional, parquet.Types.Float, -1, -1))
+	list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{element}, 8, -1))
+	embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
+	_, err := schema.NewSchemaChecked(root)
+	assert.ErrorContains(t, err, "nullable VECTOR elements")
+	assert.Panics(t, func() { schema.NewSchema(root) })
+	_, err = schema.FromParquet(schema.ToThrift(root))
+	assert.ErrorContains(t, err, "nullable VECTOR elements")
+}
+
+// The flattened schema must carry VECTOR logical type on the outer group and
+// VECTOR repetition/vector_length on the middle group, and reconstruct
+// losslessly via FromParquet.
 func TestVectorSchemaThriftRoundTrip(t *testing.T) {
 	root := vectorRoot(t, 128)
 	sc := schema.NewSchema(root)
 
 	elems := schema.ToThrift(root)
 
-	var sawVectorRep bool
+	var sawVectorLogical, sawVectorRep bool
 	for _, e := range elems {
+		if e.IsSetLogicalType() && e.GetLogicalType().IsSetVECTOR() {
+			sawVectorLogical = true
+			assert.Equal(t, format.FieldRepetitionType_REQUIRED, e.GetRepetitionType())
+		}
 		if e.GetRepetitionType() == format.FieldRepetitionType_VECTOR {
 			sawVectorRep = true
-			require.True(t, e.IsSetVectorLength(), "VECTOR leaf must carry vector_length")
+			require.True(t, e.IsSetVectorLength(), "VECTOR group must carry vector_length")
 			assert.EqualValues(t, 128, e.GetVectorLength())
-			assert.False(t, e.IsSetLogicalType(), "VECTOR leaf must not carry a VECTOR logical type")
-			assert.True(t, e.IsSetType(), "VECTOR leaf must be primitive")
+			assert.False(t, e.IsSetLogicalType(), "VECTOR-repeated middle group must not carry a logical type")
+			assert.False(t, e.IsSetType(), "VECTOR-repeated middle group must be a group")
 		}
 	}
-	assert.True(t, sawVectorRep, "expected a VECTOR-repeated primitive leaf")
+	assert.True(t, sawVectorLogical, "expected a VECTOR logical outer group")
+	assert.True(t, sawVectorRep, "expected a VECTOR-repeated middle group")
 
 	recon, err := schema.FromParquet(elems)
 	require.NoError(t, err)
@@ -79,27 +115,104 @@ func TestVectorSchemaThriftRoundTrip(t *testing.T) {
 	assert.True(t, reconSchema.Column(0).InVectorColumn())
 }
 
-func TestVectorRejectsNullableOrRepeatedAncestors(t *testing.T) {
-	leaf := schema.MustPrimitive(schema.NewPrimitiveNodeLogicalVector("embedding", nil, parquet.Types.Float, -1, 8, -1))
+func TestVectorRejectsRepeatedAncestors(t *testing.T) {
+	element := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+	list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{element}, 8, -1))
+	embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+	rep := schema.MustGroup(schema.NewGroupNode("rep", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
+	root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{rep}, -1))
+	_, err := schema.NewSchemaChecked(root)
+	assert.Error(t, err)
+	assert.Panics(t, func() { schema.NewSchema(root) })
+	_, err = schema.FromParquet(schema.ToThrift(root))
+	assert.Error(t, err)
+}
 
-	t.Run("optional ancestor", func(t *testing.T) {
-		opt := schema.MustGroup(schema.NewGroupNode("opt", parquet.Repetitions.Optional, schema.FieldList{leaf}, -1))
-		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{opt}, -1))
+func TestVectorRejectsMalformedCanonicalShape(t *testing.T) {
+	element := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+
+	t.Run("bare VECTOR-repeated group", func(t *testing.T) {
+		list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{element}, 8, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{list}, -1))
 		_, err := schema.NewSchemaChecked(root)
-		assert.Error(t, err)
-		assert.Panics(t, func() { schema.NewSchema(root) })
+		assert.ErrorContains(t, err, "single child of a group annotated")
 		_, err = schema.FromParquet(schema.ToThrift(root))
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "single child of a group annotated")
 	})
 
-	t.Run("repeated ancestor", func(t *testing.T) {
-		rep := schema.MustGroup(schema.NewGroupNode("rep", parquet.Repetitions.Repeated, schema.FieldList{leaf}, -1))
-		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{rep}, -1))
+	t.Run("logical VECTOR without VECTOR child", func(t *testing.T) {
+		embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{element}, schema.VectorLogicalType{}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
 		_, err := schema.NewSchemaChecked(root)
-		assert.Error(t, err)
-		assert.Panics(t, func() { schema.NewSchema(root) })
+		assert.ErrorContains(t, err, "VECTOR-repeated group child")
 		_, err = schema.FromParquet(schema.ToThrift(root))
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "VECTOR-repeated group child")
+	})
+
+	t.Run("nested VECTOR logical group", func(t *testing.T) {
+		list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{element}, 8, -1))
+		embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+		wrapper := schema.MustGroup(schema.NewGroupNode("wrapper", parquet.Repetitions.Required, schema.FieldList{embedding}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{wrapper}, -1))
+		_, err := schema.NewSchemaChecked(root)
+		assert.ErrorContains(t, err, "top-level fields")
+		_, err = schema.FromParquet(schema.ToThrift(root))
+		assert.ErrorContains(t, err, "top-level fields")
+	})
+
+	t.Run("middle group name", func(t *testing.T) {
+		items := schema.MustGroup(schema.NewGroupNodeVector("items", schema.FieldList{element}, 8, -1))
+		embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{items}, schema.VectorLogicalType{}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
+		_, err := schema.NewSchemaChecked(root)
+		assert.ErrorContains(t, err, "must be named list")
+		_, err = schema.FromParquet(schema.ToThrift(root))
+		assert.ErrorContains(t, err, "must be named list")
+	})
+
+	t.Run("element name", func(t *testing.T) {
+		item := schema.MustPrimitive(schema.NewPrimitiveNode("item", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+		list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{item}, 8, -1))
+		embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
+		_, err := schema.NewSchemaChecked(root)
+		assert.ErrorContains(t, err, "must be named element")
+		_, err = schema.FromParquet(schema.ToThrift(root))
+		assert.ErrorContains(t, err, "must be named element")
+	})
+
+	t.Run("non-primitive element", func(t *testing.T) {
+		x := schema.MustPrimitive(schema.NewPrimitiveNode("x", parquet.Repetitions.Required, parquet.Types.Float, -1, -1))
+		groupElement := schema.MustGroup(schema.NewGroupNode("element", parquet.Repetitions.Required, schema.FieldList{x}, -1))
+		list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{groupElement}, 8, -1))
+		embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
+		_, err := schema.NewSchemaChecked(root)
+		assert.ErrorContains(t, err, "elements must be primitive")
+		_, err = schema.FromParquet(schema.ToThrift(root))
+		assert.ErrorContains(t, err, "elements must be primitive")
+	})
+
+	t.Run("variable-width element", func(t *testing.T) {
+		binary := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Required, parquet.Types.ByteArray, -1, -1))
+		list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{binary}, 8, -1))
+		embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
+		_, err := schema.NewSchemaChecked(root)
+		assert.ErrorContains(t, err, "fixed-width primitive")
+		_, err = schema.FromParquet(schema.ToThrift(root))
+		assert.ErrorContains(t, err, "fixed-width primitive")
+	})
+
+	t.Run("repeated descendant", func(t *testing.T) {
+		repeated := schema.MustPrimitive(schema.NewPrimitiveNode("element", parquet.Repetitions.Repeated, parquet.Types.Float, -1, -1))
+		list := schema.MustGroup(schema.NewGroupNodeVector("list", schema.FieldList{repeated}, 8, -1))
+		embedding := schema.MustGroup(schema.NewGroupNodeLogical("embedding", parquet.Repetitions.Required, schema.FieldList{list}, schema.VectorLogicalType{}, -1))
+		root := schema.MustGroup(schema.NewGroupNode("schema", parquet.Repetitions.Repeated, schema.FieldList{embedding}, -1))
+		_, err := schema.NewSchemaChecked(root)
+		assert.ErrorContains(t, err, "repeated fields inside VECTOR")
+		_, err = schema.FromParquet(schema.ToThrift(root))
+		assert.ErrorContains(t, err, "repeated fields inside VECTOR")
 	})
 }
 

--- a/parquet/types.go
+++ b/parquet/types.go
@@ -323,15 +323,23 @@ var (
 
 	// Repetitions contains the constants for Field Repetition Types
 	Repetitions = struct {
-		Required  Repetition
-		Optional  Repetition
-		Repeated  Repetition
-		Undefined Repetition // convenience value
+		Required Repetition
+		Optional Repetition
+		Repeated Repetition
+		// Vector is the EXPERIMENTAL fixed-size repetition: the field repeats
+		// exactly SchemaElement.vector_length times per parent value without
+		// increasing the maximum definition or repetition level. Used to encode
+		// Arrow FixedSizeList as Parquet VECTOR (Option B).
+		Vector Repetition
+		// Undefined is a convenience sentinel outside the parquet-format enum.
+		// It is intentionally greater than every known repetition value.
+		Undefined Repetition
 	}{
 		Required:  Repetition(format.FieldRepetitionType_REQUIRED),
 		Optional:  Repetition(format.FieldRepetitionType_OPTIONAL),
 		Repeated:  Repetition(format.FieldRepetitionType_REPEATED),
-		Undefined: Repetition(format.FieldRepetitionType_REPEATED + 1),
+		Vector:    Repetition(format.FieldRepetitionType_VECTOR),
+		Undefined: Repetition(format.FieldRepetitionType_VECTOR + 1),
 	}
 )
 

--- a/parquet/types.go
+++ b/parquet/types.go
@@ -326,10 +326,10 @@ var (
 		Required Repetition
 		Optional Repetition
 		Repeated Repetition
-		// Vector is the EXPERIMENTAL fixed-size repetition: the field repeats
+		// Vector is the EXPERIMENTAL fixed-size repetition: the group repeats
 		// exactly SchemaElement.vector_length times per parent value without
-		// increasing the maximum definition or repetition level. Used to encode
-		// Arrow FixedSizeList as Parquet VECTOR.
+		// increasing the maximum definition or repetition level. Used with
+		// LogicalType.VECTOR to encode Arrow FixedSizeList as Parquet VECTOR.
 		Vector Repetition
 		// Undefined is a convenience sentinel outside the parquet-format enum.
 		// It is intentionally greater than every known repetition value.

--- a/parquet/types.go
+++ b/parquet/types.go
@@ -329,7 +329,7 @@ var (
 		// Vector is the EXPERIMENTAL fixed-size repetition: the field repeats
 		// exactly SchemaElement.vector_length times per parent value without
 		// increasing the maximum definition or repetition level. Used to encode
-		// Arrow FixedSizeList as Parquet VECTOR (Option B).
+		// Arrow FixedSizeList as Parquet VECTOR.
 		Vector Repetition
 		// Undefined is a convenience sentinel outside the parquet-format enum.
 		// It is intentionally greater than every known repetition value.


### PR DESCRIPTION
DO NOT MERGE. At this point this is a proposal meant to support discussion about a change to parquet format.

### Rationale for this change

Arrow `FixedSizeList<T, N>` (embeddings, multidimensional array scientific data, etc) round-trips through Parquet today as a standard 3-level `LIST`, paying per-element repetition/definition levels for a shape that is fixed and known from the schema. [On C++ we showed ~2-10x read improved performance is possible](https://gist.github.com/rok/fe4785d4a74d2e080cbad73e88cc1bef) which motivates a denser encoding.

This adds an experimental Parquet `VECTOR` repetition type - the "Option B" design from the [*Fixed-size list type for Parquet* proposal](https://docs.google.com/document/d/1nf30OqK_UqxA4YTEZQszmOBEG56m9M5mp9rIYC2SUWc/edit?tab=t.0) - that stores fixed-shape data without those inner levels.

Closes #855.

### What changes are included in this PR?

- **Format:** `FieldRepetitionType.VECTOR = 3` and `SchemaElement.vector_length` (field id 11), hand-applied to the generated `parquet/internal/gen-go/parquet/parquet.go` in the existing Thrift 0.21.0 generator style; `parquet/parquet_vector.thrift` vendors the IDL fragment as the source of truth.
- **schema:** a primitive `VECTOR` leaf node (`NewPrimitiveNodeLogicalVector`), `vector_length` plumbing, level computation (`VECTOR` adds no def/rep level), and `NewSchemaChecked`, which returns an error instead of panicking on a malformed `VECTOR` schema.
- **file:** the column writer counts rows as `values / vector_length` and keeps every data page on a whole-vector boundary across all write paths (`WriteBatch`, `WriteBatchSpaced`, `WriteBitmapBatchSpaced`, dictionary indices, FLBA); the reader supports row-ordinal seeking by value stride and rejects malformed `VECTOR` chunks (`num_values` not a whole multiple of, or inconsistent with, the row count).
- **pqarrow:** opt-in encoding via `WithVectorEncoding()`; eligible top-level `FixedSizeList` columns are written as `VECTOR` and reconstructed on read without a stored Arrow schema, and ineligible ones fall back to `LIST`. Works alongside `WithStoreSchema` (element timezone / field metadata are restored).

A `VECTOR` column is a single primitive leaf (`vector <element-type> <name> [N]`), **not** a nested group — the leaf carries `vector_length` and adds no definition/repetition level, so a dense vector has no inner levels.

**Scope:** dense, non-nullable, top-level `FixedSizeList` with a fixed-width primitive element. Every other `FixedSizeList` transparently falls back to `LIST`; nothing that writes today changes unless the flag is set.

### Are these changes tested?

Yes. New tests cover:

- write/read round-trips across element types (bool, int32/64, float32/64, float16, fixed_size_binary, decimal128/256, date32, timestamp) and list sizes that don't divide the write batch size;
- whole-vector page boundaries and row accounting for every write path;
- row-ordinal seeking on DataPageV1, DataPageV2, and via offset index;
- compression (Snappy/Zstd) and dictionary-read;
- the `LIST` fallback for every ineligible case;
- rejection of nulls in non-nullable `VECTOR` data and of malformed `VECTOR` files;
- `WithStoreSchema` round-trip; and the schema/Thrift compact-protocol round-trip.

All new tests pass; the only failing tests in the suite are the pre-existing ones that need the `parquet-testing` data submodule / `PARQUET_TEST_DATA`.

### Are there any user-facing changes?

Yes:

- New writer option `pqarrow.WithVectorEncoding()` (default off) and new schema helpers `schema.NewPrimitiveNodeLogicalVector` / `schema.NewSchemaChecked` / `schema.NewColumnChecked`.
- New exported error `file.ErrVectorBatchMisaligned`, returned by the typed column writers when a VECTOR column is given a partial-vector batch.
- A new `parquet.Repetitions.Vector` value; `parquet.Repetitions.Undefined` shifts from `3` to `4`.

⚠️ **Compatibility:** files written with `VECTOR` are **not** readable by Parquet implementations that don't understand the `VECTOR` repetition type. This is the defining trade-off of VECTOR repetition type and the reason it is strictly opt-in and documented experimental, until `VECTOR` is standardized in apache/parquet-format.

**Potential follow-up:** nullable vectors (spaced leaf materialization + def-level→validity collapse), struct elements, and nested vectors.

