### PR TITLE
ci: pin Go to go.mod in RC verify so the matching toolchain is used

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -92,6 +92,10 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: archive
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.2.0
+        with:
+          go-version-file: go.mod
       - name: Verify
         run: |
           tar_gz=$(echo apache-arrow-go-*.tar.gz)


### PR DESCRIPTION
### Rationale for this change

The RC `Verify` job does not install Go via `actions/setup-go`. `dev/release/verify_rc.sh`'s `ensure_go()` reuses whatever Go is already on the runner and only downloads one when none is present — and it never checks the installed version against the module's required `go` directive.

On `macos-latest` there is no preinstalled Go, so the script downloaded the newest available release — a `go1.27` release candidate — which failed to build the `go 1.25.0` module's `arrow/compute` (`slices.Collect` / `maps.Keys` are gated to Go 1.23, reported as "file is go1.22"). `RC/Verify (ubuntu-latest)` passed because that runner had Go 1.24.x preinstalled and auto-fetched the matching toolchain.

### What changes are included in this PR?

Add `actions/setup-go` (pinned to the same version the other workflows use) with `go-version-file: go.mod` to the `Verify` job, so the Go version matching the module is installed on every runner before `verify_rc.sh` runs.

### Are these changes tested?

CI-only change, exercised by this PR's own `RC/Verify` jobs — `RC/Verify (macos-latest)` now passes. `actionlint` is clean for the modified workflow.

### Are there any user-facing changes?

No. CI-only change.
