### PR TITLE
fix(array): validate negative bounds in NewSliceData

### DIFF
--- a/arrow/array/data.go
+++ b/arrow/array/data.go
@@ -229,7 +229,7 @@ func (d *Data) SizeInBytes() uint64 {
 // NewSliceData panics if the slice is outside the valid range of the input Data.
 // NewSliceData panics if j < i.
 func NewSliceData(data arrow.ArrayData, i, j int64) arrow.ArrayData {
-	if j > int64(data.Len()) || i > j || data.Offset()+int(i) > data.Offset()+data.Len() {
+	if i < 0 || j < 0 || j > int64(data.Len()) || i > j || data.Offset()+int(i) > data.Offset()+data.Len() {
 		panic("arrow/array: index out of range")
 	}
 

--- a/arrow/array/data_test.go
+++ b/arrow/array/data_test.go
@@ -51,6 +51,29 @@ func TestDataReset(t *testing.T) {
 	}
 }
 
+func TestNewSliceDataInvalidBounds(t *testing.T) {
+	data := NewData(&arrow.Int64Type{}, 3, nil, nil, 0, 0)
+	defer data.Release()
+
+	tests := []struct {
+		name string
+		i, j int64
+	}{
+		{name: "negative start", i: -1, j: 0},
+		{name: "negative end", i: -2, j: -1},
+		{name: "end beyond length", i: 0, j: 4},
+		{name: "start after end", i: 2, j: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.PanicsWithValue(t, "arrow/array: index out of range", func() {
+				NewSliceData(data, tt.i, tt.j)
+			})
+		})
+	}
+}
+
 func TestSizeInBytes(t *testing.T) {
 	var buffers1 = make([]*memory.Buffer, 0, 3)
 


### PR DESCRIPTION
### What changed

NewSliceData now rejects negative start and end bounds before constructing sliced Data metadata.

### Why

The existing bounds check rejected end positions past the array length and start positions after the end, but it did not reject negative bounds. A call such as NewSliceData(data, -1, 0) could produce a Data value with a negative offset even though the function documents that out-of-range slices panic.

### Validation

- go test ./arrow/array -run TestNewSliceDataInvalidBounds -count=1
- go test ./arrow/array -count=1
- PARQUET_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/parquet-testing/data ARROW_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/arrow-testing/data go test ./... -count=1