### PR TITLE
fix(array): empty chunked approximate equality

### DIFF
--- a/arrow/array/compare.go
+++ b/arrow/array/compare.go
@@ -141,7 +141,7 @@ func ChunkedApproxEqual(left, right *arrow.Chunked, opts ...EqualOption) bool {
 		return false
 	}
 
-	var isequal bool
+	var isequal = true
 	chunkedBinaryApply(left, right, func(left arrow.Array, lbeg, lend int64, right arrow.Array, rbeg, rend int64) bool {
 		isequal = SliceApproxEqual(left, lbeg, lend, right, rbeg, rend, opts...)
 		return isequal

--- a/arrow/array/compare_test.go
+++ b/arrow/array/compare_test.go
@@ -822,6 +822,16 @@ func TestChunkedApproxEqual(t *testing.T) {
 	assert.True(t, array.ChunkedApproxEqual(c1, c2))
 }
 
+func TestChunkedApproxEqualEmpty(t *testing.T) {
+	c1 := arrow.NewChunked(arrow.PrimitiveTypes.Float64, nil)
+	defer c1.Release()
+	c2 := arrow.NewChunked(arrow.PrimitiveTypes.Float64, nil)
+	defer c2.Release()
+
+	assert.True(t, array.ChunkedEqual(c1, c2))
+	assert.True(t, array.ChunkedApproxEqual(c1, c2))
+}
+
 func TestTableEqual(t *testing.T) {
 	for name, recs := range arrdata.Records {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### What changed

ChunkedApproxEqual now initializes its result to true before iterating chunk pairs, matching ChunkedEqual.

### Why

For two empty same-typed chunked arrays, chunkedBinaryApply does not invoke the comparison callback. The previous zero-value false result made ChunkedApproxEqual return false for equal empty inputs.

### Validation

- go test ./arrow/array -run TestChunkedApproxEqualEmpty -count=1
- go test ./arrow/array -count=1
- go test ./arrow/flight/flightsql -run TestStatefulServerSessionCookies -count=1
- PARQUET_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/parquet-testing/data ARROW_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/arrow-testing/data go test ./... -count=1