### PR TITLE
fix(array): clear dictionary data on reset

### DIFF
--- a/arrow/array/data.go
+++ b/arrow/array/data.go
@@ -122,6 +122,11 @@ func (d *Data) Reset(dtype arrow.DataType, length int, buffers []*memory.Buffer,
 	}
 	d.childData = childData
 
+	if d.dictionary != nil {
+		d.dictionary.Release()
+		d.dictionary = nil
+	}
+
 	d.dtype = dtype
 	d.length = length
 	d.nulls = nulls

--- a/arrow/array/data_test.go
+++ b/arrow/array/data_test.go
@@ -74,6 +74,32 @@ func TestNewSliceDataInvalidBounds(t *testing.T) {
 	}
 }
 
+func TestDataResetClearsDictionary(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+
+	values := memory.NewResizableBuffer(mem)
+	values.Resize(16)
+
+	dictData := NewData(arrow.PrimitiveTypes.Int32, 4, []*memory.Buffer{nil, values}, nil, 0, 0)
+	values.Release()
+
+	dictType := &arrow.DictionaryType{
+		IndexType: arrow.PrimitiveTypes.Int8,
+		ValueType: arrow.PrimitiveTypes.Int32,
+	}
+	data := NewDataWithDictionary(dictType, 0, []*memory.Buffer{nil, nil}, 0, 0, dictData)
+	defer data.Release()
+
+	assert.NotNil(t, data.Dictionary())
+
+	data.Reset(arrow.PrimitiveTypes.Int8, 0, []*memory.Buffer{nil, nil}, nil, 0, 0)
+
+	assert.Nil(t, data.Dictionary())
+
+	dictData.Release()
+	mem.AssertSize(t, 0)
+}
+
 func TestSizeInBytes(t *testing.T) {
 	var buffers1 = make([]*memory.Buffer, 0, 3)
 


### PR DESCRIPTION
### What changed

Data.Reset now releases and clears any existing dictionary data when reusing an ArrayData value.

### Why

Reset replaces the buffers, children, type, length, null count, and offset, but previously left the old dictionary attached. Reusing dictionary-backed data as non-dictionary data could keep returning stale dictionary data and retain the old dictionary longer than expected.

### Validation

- go test ./arrow/array -run 'TestDataReset' -count=1
- go test ./arrow/array -count=1
- PARQUET_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/parquet-testing/data ARROW_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/arrow-testing/data go test ./... -count=1