### PR TITLE
Use semantic type equality in AddColumn

### DIFF
--- a/arrow/array/table.go
+++ b/arrow/array/table.go
@@ -204,7 +204,7 @@ func (tbl *simpleTable) AddColumn(i int, field arrow.Field, column arrow.Column)
 	if int64(column.Len()) != tbl.rows {
 		return nil, fmt.Errorf("arrow/array: column length mismatch: %d != %d", column.Len(), tbl.rows)
 	}
-	if field.Type != column.DataType() {
+	if !arrow.TypeEqual(field.Type, column.DataType()) {
 		return nil, fmt.Errorf("arrow/array: column type mismatch: %v != %v", field.Type, column.DataType())
 	}
 	newSchema, err := tbl.schema.AddField(i, field)

--- a/arrow/array/table_test.go
+++ b/arrow/array/table_test.go
@@ -613,6 +613,32 @@ func TestTable(t *testing.T) {
 	}
 }
 
+func TestTableAddColumnWithEqualDataType(t *testing.T) {
+	columnType := arrow.ListOf(arrow.PrimitiveTypes.Int32)
+	chunk := arrow.NewChunked(columnType, nil)
+	defer chunk.Release()
+
+	column := arrow.NewColumn(arrow.Field{Name: "items", Type: columnType}, chunk)
+	defer column.Release()
+
+	tbl := array.NewTable(arrow.NewSchema(nil, nil), nil, 0)
+	defer tbl.Release()
+
+	field := arrow.Field{Name: "items", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32)}
+	got, err := tbl.AddColumn(0, field, *column)
+	if err != nil {
+		t.Fatalf("could not add column: %+v", err)
+	}
+	defer got.Release()
+
+	if gotField := got.Schema().Field(0); !gotField.Equal(field) {
+		t.Fatalf("invalid field: got=%v, want=%v", gotField, field)
+	}
+	if gotType := got.Column(0).DataType(); !arrow.TypeEqual(gotType, field.Type) {
+		t.Fatalf("invalid type: got=%v, want=%v", gotType, field.Type)
+	}
+}
+
 func TestTableFromRecords(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)


### PR DESCRIPTION
### What changed

simpleTable.AddColumn now compares the new field type and column type with arrow.TypeEqual instead of direct interface inequality.

### Why

Many Arrow data types are structurally equal even when they are not the same pointer. The previous check could reject valid columns, while nearby table and column constructors already use semantic type equality.

### Validation

- go test ./arrow/array -run 'TestTableAddColumnWithEqualDataType' -count=1
- go test ./arrow/array -count=1
- PARQUET_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/parquet-testing/data ARROW_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/arrow-testing/data go test ./... -count=1