### PR TITLE
Reject negative chunked slice bounds

### DIFF
--- a/arrow/array/table.go
+++ b/arrow/array/table.go
@@ -46,7 +46,7 @@ func NewColumnSlice(col *arrow.Column, i, j int64) *arrow.Column {
 // NewSlice panics if the slice is outside the valid range of the input array.
 // NewSlice panics if j < i.
 func NewChunkedSlice(a *arrow.Chunked, i, j int64) *arrow.Chunked {
-	if j > int64(a.Len()) || i > j || i > int64(a.Len()) {
+	if i < 0 || j < 0 || j > int64(a.Len()) || i > j || i > int64(a.Len()) {
 		panic("arrow/array: index out of range")
 	}
 

--- a/arrow/array/table_test.go
+++ b/arrow/array/table_test.go
@@ -207,6 +207,8 @@ func TestChunkedSliceInvalid(t *testing.T) {
 	for _, tc := range []struct {
 		i, j int64
 	}{
+		{i: -1, j: 0},
+		{i: -2, j: -1},
 		{i: 2, j: 1},
 		{i: 10, j: 11},
 		{i: 11, j: 11},


### PR DESCRIPTION
### What changed

NewChunkedSlice now rejects negative start or end bounds in its top-level bounds check.

### Why

The function already rejected out-of-range upper bounds and inverted ranges, but negative bounds could flow into the chunk slicing loop and produce inconsistent behavior from lower-level slicing.

### Validation

- go test ./arrow/array -run 'TestChunkedSliceInvalid' -count=1
- go test ./arrow/array -count=1
- PARQUET_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/parquet-testing/data ARROW_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/arrow-testing/data go test ./... -count=1