### PR TITLE
Support sparse union sliced type ids

### DIFF
--- a/arrow/array/union.go
+++ b/arrow/array/union.go
@@ -289,7 +289,15 @@ func NewSparseUnionFromArraysWithFieldCodes(typeIDs arrow.Array, children []arro
 		return nil, errors.New("arrow/array: type codes must have same length as children")
 	}
 
-	buffers := []*memory.Buffer{nil, typeIDs.Data().Buffers()[1]}
+	typeIDBuffer := typeIDs.Data().Buffers()[1]
+	if typeIDBuffer != nil {
+		typeIDBuffer = memory.SliceBuffer(typeIDBuffer,
+			arrow.Int8Traits.BytesRequired(typeIDs.Data().Offset()),
+			arrow.Int8Traits.BytesRequired(typeIDs.Len()))
+		defer typeIDBuffer.Release()
+	}
+
+	buffers := []*memory.Buffer{nil, typeIDBuffer}
 	ty := arrow.SparseUnionFromArrays(children, fields, codes)
 
 	childData := make([]arrow.ArrayData, len(children))
@@ -300,7 +308,7 @@ func NewSparseUnionFromArraysWithFieldCodes(typeIDs arrow.Array, children []arro
 		}
 	}
 
-	data := NewData(ty, typeIDs.Len(), buffers, childData, 0, typeIDs.Data().Offset())
+	data := NewData(ty, typeIDs.Len(), buffers, childData, 0, 0)
 	defer data.Release()
 	return NewSparseUnionData(data), nil
 }

--- a/arrow/array/union_test.go
+++ b/arrow/array/union_test.go
@@ -578,6 +578,24 @@ func (s *UnionFactorySuite) TestMakeSparse() {
 		s.Error(result.ValidateFull())
 	})
 
+	s.Run("sliced type ids", func() {
+		expected, err := array.NewSparseUnionFromArrays(s.typeIDs, children)
+		s.NoError(err)
+		defer expected.Release()
+
+		baseTypeIDs := s.typeidsFromSlice(3, 0, 1, 2, 0, 1, 3, 2, 0, 2, 1)
+		defer baseTypeIDs.Release()
+		slicedTypeIDs := array.NewSlice(baseTypeIDs, 1, int64(baseTypeIDs.Len()))
+		defer slicedTypeIDs.Release()
+
+		result, err := array.NewSparseUnionFromArrays(slicedTypeIDs, children)
+		s.NoError(err)
+		defer result.Release()
+		s.Zero(result.Data().Offset())
+		s.NoError(result.ValidateFull())
+		s.True(array.Equal(expected, result))
+	})
+
 	s.Run("invalid child length", func() {
 		children[3], _, _ = array.FromJSON(s.mem, arrow.PrimitiveTypes.Int8,
 			strings.NewReader(`[0, 0, 0, 0, 0, -12, 0, 0, 0]`))


### PR DESCRIPTION
### What changed

`NewSparseUnionFromArraysWithFieldCodes` now normalizes the type ID value buffer to the input array's logical window before constructing sparse union data.

### Why

The constructor previously stored `typeIDs.Data().Offset()` on the union `ArrayData` while borrowing the unsliced type ID buffer. For sparse unions, `union.setData` uses that `ArrayData` offset to slice children, so passing sliced type IDs with logical-length children could panic or read the wrong physical type ID entries.

### Validation

- `go test ./arrow/array -run 'TestUnions/TestMakeSparse' -count=1`
- `go test ./arrow/array -count=1`
- `PARQUET_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/parquet-testing/data ARROW_TEST_DATA=/Users/hoangvu/Code/OSS/arrow-go/arrow-testing/data go test ./... -count=1`
