### PR TITLE
fix(array): guard BinaryViewBuilder size checks

### DIFF
--- a/arrow/array/binary_test.go
+++ b/arrow/array/binary_test.go
@@ -18,6 +18,7 @@ package array
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -25,6 +26,12 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/assert"
 )
+
+type binaryViewNoAllocAllocator struct{}
+
+func (binaryViewNoAllocAllocator) Allocate(int) []byte           { panic("unexpected allocation") }
+func (binaryViewNoAllocAllocator) Reallocate(int, []byte) []byte { panic("unexpected allocation") }
+func (binaryViewNoAllocAllocator) Free([]byte)                   {}
 
 func TestBinary(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -699,6 +706,30 @@ func TestBinaryStringRoundTrip(t *testing.T) {
 	defer arr1.Release()
 
 	assert.True(t, Equal(arr, arr1))
+}
+
+func TestBinaryViewBuilderRejectsOversizedValues(t *testing.T) {
+	const expected = "invalid: BinaryView or StringView elements cannot reference strings larger than 2GB"
+	oversizedLen := int64(viewValueSizeLimit) + 1
+
+	t.Run("size guard", func(t *testing.T) {
+		assert.PanicsWithError(t, expected, func() {
+			checkBinaryViewValueSize(oversizedLen)
+		})
+	})
+
+	t.Run("ReserveData", func(t *testing.T) {
+		if strconv.IntSize == 32 {
+			t.Skip("oversized int requires 64-bit int")
+		}
+
+		b := NewBinaryViewBuilder(binaryViewNoAllocAllocator{})
+		defer b.Release()
+
+		assert.PanicsWithError(t, expected, func() {
+			b.ReserveData(int(oversizedLen))
+		})
+	})
 }
 
 func TestBinaryViewStringRoundTrip(t *testing.T) {

--- a/arrow/array/binarybuilder.go
+++ b/arrow/array/binarybuilder.go
@@ -467,11 +467,15 @@ func (b *BinaryViewBuilder) Resize(n int) {
 	b.rawData = arrow.ViewHeaderTraits.CastFromBytes(b.data.Bytes())
 }
 
-func (b *BinaryViewBuilder) ReserveData(length int) {
-	if int32(length) > viewValueSizeLimit {
+func checkBinaryViewValueSize(length int64) {
+	if length > int64(viewValueSizeLimit) {
 		panic(fmt.Errorf("%w: BinaryView or StringView elements cannot reference strings larger than 2GB",
 			arrow.ErrInvalid))
 	}
+}
+
+func (b *BinaryViewBuilder) ReserveData(length int) {
+	checkBinaryViewValueSize(int64(length))
 	b.blockBuilder.Reserve(int(length))
 }
 
@@ -480,9 +484,7 @@ func (b *BinaryViewBuilder) Reserve(n int) {
 }
 
 func (b *BinaryViewBuilder) Append(v []byte) {
-	if int32(len(v)) > viewValueSizeLimit {
-		panic(fmt.Errorf("%w: BinaryView or StringView elements cannot reference strings larger than 2GB", arrow.ErrInvalid))
-	}
+	checkBinaryViewValueSize(int64(len(v)))
 
 	if !arrow.IsViewInline(len(v)) {
 		b.ReserveData(len(v))


### PR DESCRIPTION
### What changed

`BinaryViewBuilder` now checks view value lengths as `int` before any narrowing conversion to `int32`. Both `ReserveData` and `Append` use the same size guard.

The regression test covers oversized `ReserveData` lengths and oversized byte slices without allocating multi-gigabyte buffers.

### Why

The previous check converted lengths to `int32` before comparison. Values larger than `math.MaxInt32` could wrap negative and bypass the 2GB guard.

### Validation

- `go test ./arrow/array -run 'TestBinaryViewBuilderRejectsOversizedValues|TestBinaryViewStringRoundTrip'`
- `go test ./arrow/array`
- `go test ./arrow/...`
- `go test -tags assert ./arrow/array`