### PR TITLE
fix(tmpl): preserve escaped JSON string bytes

### DIFF
--- a/arrow/_tools/tmpl/main.go
+++ b/arrow/_tools/tmpl/main.go
@@ -234,21 +234,29 @@ func StripComments(raw []byte) []byte {
 			continue
 		}
 
-		if esc {
-			esc = false
-			continue
-		}
-
-		if b == '\\' && quoted {
-			esc = true
+		if quoted {
+			buf.WriteByte(b)
+			if esc {
+				esc = false
+				continue
+			}
+			if b == '\\' {
+				esc = true
+				continue
+			}
+			if b == '"' || b == '\'' {
+				quoted = false
+			}
 			continue
 		}
 
 		if b == '"' || b == '\'' {
-			quoted = !quoted
+			quoted = true
+			buf.WriteByte(b)
+			continue
 		}
 
-		if b == '/' && !quoted {
+		if b == '/' {
 			comment = true
 			continue
 		}

--- a/arrow/_tools/tmpl/main_test.go
+++ b/arrow/_tools/tmpl/main_test.go
@@ -32,6 +32,10 @@ func TestStripComments(t *testing.T) {
 		{name: "single-line, block comment at end", in: `[1,2,3] /* /* // */`, exp: `[1,2,3] `},
 		{name: "single-line, block comment in middle", in: `[1,/* foo bar */2,3]`, exp: `[1,2,3]`},
 		{name: "single-line, block comment in string", in: `[1,"/* foo bar */"]`, exp: `[1,"/* foo bar */"]`},
+		{name: "single-line, escaped backslashes in string", in: `{"path":"C:\\tmp\\file"} // keep escapes`, exp: `{"path":"C:\\tmp\\file"} `},
+		{name: "single-line, escaped quote in string", in: `{"quote":"\"// not a comment\""} // comment`, exp: `{"quote":"\"// not a comment\""} `},
+		{name: "single-line, escaped slash in string", in: `{"url":"https:\/\/example.com\/data"} /* comment */`, exp: `{"url":"https:\/\/example.com\/data"} `},
+		{name: "single-line, escaped newline in string", in: `{"line":"first\nsecond"} // comment`, exp: `{"line":"first\nsecond"} `},
 		{name: "single-line, malformed block comment", in: `[1,2,/*]`, exp: `[1,2,/*]`},
 		{name: "single-line, malformed JSON", in: `[1,2,/]`, exp: `[1,2,/]`},
 


### PR DESCRIPTION
### What changed

`StripComments` now writes bytes while it is inside a quoted string, including backslashes and the escaped byte that follows. Comment detection still only runs outside quoted strings.

The regression cases cover escaped backslashes, escaped quotes, escaped slashes, and escaped newline sequences inside JSON strings.

### Why

The previous escape-state handling skipped both the backslash and the escaped character. Valid JSON strings could be changed before `json.Unmarshal` saw them.

### Validation

- `go test -vet=off ./arrow/_tools/tmpl`

Plain `go test ./arrow/_tools/tmpl` is currently blocked by existing vet warnings for non-constant `errExit` format strings in this tool package.