### PR TITLE
fix(build): correct phony target declaration

### DIFF
--- a/arrow/Makefile
+++ b/arrow/Makefile
@@ -23,7 +23,7 @@ GO_SOURCES  := $(shell find . -path ./_lib -prune -o -name '*.go' -not -name '*_
 ALL_SOURCES := $(shell find . -path ./_lib -prune -o -name '*.go' -name '*.s' -not -name '*_test.go')
 SOURCES_NO_VENDOR := $(shell find . -path ./vendor -prune -o -name "*.go" -not -name '*_test.go' -print)
 
-.PHONEY: test bench assembly generate
+.PHONY: test bench assembly generate
 
 assembly:
 	@$(MAKE) -C memory assembly


### PR DESCRIPTION
### What changed

Fixed the typo in `arrow/Makefile` from `.PHONEY` to `.PHONY`.

### Why

GNU Make only recognizes `.PHONY`. With the typo, targets like `test`, `bench`, `assembly`, and `generate` may be treated as real file targets if files with those names exist.

### Validation

- `make -n -C arrow test`
- `make -n -C arrow bench`