### PR TITLE
fix: clarify StringViewBuilder UnmarshalJSON error message

### DIFF
--- a/arrow/array/string.go
+++ b/arrow/array/string.go
@@ -803,7 +803,7 @@ func (b *StringViewBuilder) UnmarshalJSON(data []byte) error {
 	}
 
 	if delim, ok := t.(json.Delim); !ok || delim != '[' {
-		return fmt.Errorf("binary view builder must unpack from json array, found %s", delim)
+		return fmt.Errorf("string view builder must unpack from json array, found %s", delim)
 	}
 
 	return b.Unmarshal(dec)


### PR DESCRIPTION
## Summary

### Problem
`StringViewBuilder.UnmarshalJSON` returned an error message that referenced `binary view builder`. This is misleading, because callers using `StringViewBuilder` see an incorrect component name when `UnmarshalJSON` receives non-array input.

### Change
- Update the error text to correctly say `string view builder`.
- No logic changes; behavior remains otherwise identical.

### Impact
- Improves developer ergonomics and test clarity by ensuring diagnostics identify the correct builder.
- Reduces user confusion and avoids false assumptions when debugging JSON decoding failures.

### Testing
- This is a message-only change.
- No runtime test executed in this PR; update is isolated and validated by review of the edited error path.
