### PR TITLE
fix(arrow/array): avoid allocating for ReserveData(0)

### DIFF
--- a/arrow/array/binary_test.go
+++ b/arrow/array/binary_test.go
@@ -732,6 +732,13 @@ func TestBinaryViewBuilderRejectsOversizedValues(t *testing.T) {
 	})
 }
 
+func TestBinaryViewBuilderReserveData0DoesNotAllocate(t *testing.T) {
+	b := NewBinaryViewBuilder(binaryViewNoAllocAllocator{})
+	defer b.Release()
+
+	b.ReserveData(0)
+}
+
 func TestBinaryViewStringRoundTrip(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)

--- a/arrow/array/binarybuilder.go
+++ b/arrow/array/binarybuilder.go
@@ -476,6 +476,9 @@ func checkBinaryViewValueSize(length int64) {
 
 func (b *BinaryViewBuilder) ReserveData(length int) {
 	checkBinaryViewValueSize(int64(length))
+	if length == 0 {
+		return
+	}
 	b.blockBuilder.Reserve(int(length))
 }
 

--- a/arrow/internal/arrjson/arrjson_test.go
+++ b/arrow/internal/arrjson/arrjson_test.go
@@ -6186,8 +6186,7 @@ func makeViewTypesWantJSONs() string {
               "SIZE": 1,
               "INLINED": "35"
             }
-          ],
-          "VARIADIC_DATA_BUFFERS": [""]
+          ]
         },
         {
           "name": "string_view",
@@ -6220,8 +6219,7 @@ func makeViewTypesWantJSONs() string {
               "SIZE": 1,
               "INLINED": "5"
             }
-          ],
-          "VARIADIC_DATA_BUFFERS": [""]
+          ]
         }
       ]
     },
@@ -6259,8 +6257,7 @@ func makeViewTypesWantJSONs() string {
               "SIZE": 4,
               "INLINED": "35353535"
             }
-          ],
-          "VARIADIC_DATA_BUFFERS": [""]
+          ]
         },
         {
           "name": "string_view",
@@ -6378,8 +6375,7 @@ func makeViewTypesWantJSONs() string {
               "SIZE": 2,
               "INLINED": "55"
             }
-          ],
-          "VARIADIC_DATA_BUFFERS": [""]
+          ]
         }
       ]
     }


### PR DESCRIPTION
### Rationale for this change

BinaryViewBuilder.ReserveData always delegated to the block builder. ReserveData(0) could therefore create a full default data block even when every value remains inline.

### What changes are included in this PR?

- Return after the existing size validation when the requested data length is zero.
- Preserve the normal reserve path for positive lengths.
- Update integration JSON expectations because an unused empty variadic data buffer is no longer created.

### Are these changes tested?

Yes. A no-allocation allocator verifies that ReserveData(0) does not allocate. The array and arrjson packages pass normal and race tests.

### Are there any user-facing changes?

Zero-length reservations no longer allocate an unused data block. Positive reservations and the public API are unchanged.