### PR TITLE
fix: clarify StringViewBuilder.UnmarshalOne expected type

### DIFF
--- a/arrow/array/string.go
+++ b/arrow/array/string.go
@@ -778,7 +778,7 @@ func (b *StringViewBuilder) UnmarshalOne(dec *json.Decoder) error {
 	default:
 		return &json.UnmarshalTypeError{
 			Value:  fmt.Sprint(t),
-			Type:   reflect.TypeOf([]byte{}),
+			Type:   reflect.TypeOf(string("")),
 			Offset: dec.InputOffset(),
 		}
 	}

--- a/arrow/array/string_test.go
+++ b/arrow/array/string_test.go
@@ -18,7 +18,6 @@ package array_test
 
 import (
 	"bytes"
-	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/bitutil"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/internal/json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/arrow/array/string_test.go
+++ b/arrow/array/string_test.go
@@ -18,6 +18,7 @@ package array_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -900,6 +901,24 @@ func TestStringViewBuilder_Empty(t *testing.T) {
 	a = ab.NewStringViewArray()
 	assert.Equal(t, want, stringValues(a))
 	a.Release()
+}
+
+func TestStringViewBuilderUnmarshalOneWrongType(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	bldr := array.NewStringViewBuilder(mem)
+	defer bldr.Release()
+
+	dec := json.NewDecoder(bytes.NewReader([]byte(`1`)))
+	err := bldr.UnmarshalOne(dec)
+
+	assert.Error(t, err)
+	var ute *json.UnmarshalTypeError
+	assert.ErrorAs(t, err, &ute)
+	if assert.NotNil(t, ute) {
+		assert.Equal(t, reflect.TypeOf(""), ute.Type)
+	}
 }
 
 // TestStringReset tests the Reset() method on the String type by creating two different Strings and then


### PR DESCRIPTION
## Summary

### Problem
`StringViewBuilder.UnmarshalOne` reports a `json.UnmarshalTypeError` with an expected type of `[]byte{}` for unsupported token types.

### Change
- Update `StringViewBuilder.UnmarshalOne` to report `reflect.TypeOf("")` when an unsupported JSON token is encountered.
- Add regression test `TestStringViewBuilderUnmarshalOneWrongType` in `arrow/array/string_test.go`.

### Impact
- Aligns error diagnostics with `StringBuilder` behavior.
- Makes JSON import debugging clearer for users expecting string inputs.

### Testing
- Added a focused regression test that asserts the reported expected type is `string` for unsupported JSON token input.
- No full test run in this PR (single-path, message-type assertion).
