### PR TITLE
fix(compute): release temporary arrays in binary view casts

### DIFF
--- a/arrow/compute/cast_test.go
+++ b/arrow/compute/cast_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/bitutil"
 	"github.com/apache/arrow-go/v18/arrow/compute"
+	"github.com/apache/arrow-go/v18/arrow/compute/exec"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/decimal256"
 	"github.com/apache/arrow-go/v18/arrow/internal/testing/gen"
@@ -1680,12 +1681,13 @@ func (c *CastSuite) TestBinaryViewToBinaryLike() {
 }
 
 func (c *CastSuite) TestBinaryToBinaryViewReleasesTemporaryResult() {
-	scope := memory.NewCheckedAllocatorScope(c.mem)
-
 	in, _, err := array.FromJSON(c.mem, arrow.BinaryTypes.Binary, strings.NewReader(`["aGk=", "dGhpcyBpcyB0aGUgZmlyc3QgdGVzdCE=", null]`))
 	c.Require().NoError(err)
 
-	out, err := compute.CastArray(context.Background(), in, compute.SafeCastOptions(arrow.BinaryTypes.BinaryView))
+	scope := memory.NewCheckedAllocatorScope(c.mem)
+	ctx := exec.WithAllocator(context.Background(), c.mem)
+
+	out, err := compute.CastArray(ctx, in, compute.SafeCastOptions(arrow.BinaryTypes.BinaryView))
 	c.Require().NoError(err)
 	out.Release()
 	scope.CheckSize(c.T())
@@ -1693,10 +1695,12 @@ func (c *CastSuite) TestBinaryToBinaryViewReleasesTemporaryResult() {
 }
 
 func (c *CastSuite) TestBinaryViewToBinaryReleasesTemporaryResult() {
-	scope := memory.NewCheckedAllocatorScope(c.mem)
 	in := c.buildStringViewArray([]string{"a", "short", "this is a longer cast value"}, nil)
 
-	out, err := compute.CastArray(context.Background(), in, compute.SafeCastOptions(arrow.BinaryTypes.LargeBinary))
+	scope := memory.NewCheckedAllocatorScope(c.mem)
+	ctx := exec.WithAllocator(context.Background(), c.mem)
+
+	out, err := compute.CastArray(ctx, in, compute.SafeCastOptions(arrow.BinaryTypes.LargeBinary))
 	c.Require().NoError(err)
 	out.Release()
 	scope.CheckSize(c.T())

--- a/arrow/compute/cast_test.go
+++ b/arrow/compute/cast_test.go
@@ -1680,29 +1680,27 @@ func (c *CastSuite) TestBinaryViewToBinaryLike() {
 }
 
 func (c *CastSuite) TestBinaryToBinaryViewReleasesTemporaryResult() {
+	scope := memory.NewCheckedAllocatorScope(c.mem)
+
 	in, _, err := array.FromJSON(c.mem, arrow.BinaryTypes.Binary, strings.NewReader(`["aGk=", "dGhpcyBpcyB0aGUgZmlyc3QgdGVzdCE=", null]`))
 	c.Require().NoError(err)
-
-	scope := memory.NewCheckedAllocatorScope(c.mem)
 
 	out, err := compute.CastArray(context.Background(), in, compute.SafeCastOptions(arrow.BinaryTypes.BinaryView))
 	c.Require().NoError(err)
 	out.Release()
-	in.Release()
-
 	scope.CheckSize(c.T())
+	in.Release()
 }
 
 func (c *CastSuite) TestBinaryViewToBinaryReleasesTemporaryResult() {
-	in := c.buildStringViewArray([]string{"a", "short", "this is a longer cast value"}, nil)
 	scope := memory.NewCheckedAllocatorScope(c.mem)
+	in := c.buildStringViewArray([]string{"a", "short", "this is a longer cast value"}, nil)
 
 	out, err := compute.CastArray(context.Background(), in, compute.SafeCastOptions(arrow.BinaryTypes.LargeBinary))
 	c.Require().NoError(err)
 	out.Release()
-	in.Release()
-
 	scope.CheckSize(c.T())
+	in.Release()
 }
 
 // TestBinaryViewToBinaryView covers cross-view casts (binary_view <->

--- a/arrow/compute/cast_test.go
+++ b/arrow/compute/cast_test.go
@@ -1679,6 +1679,32 @@ func (c *CastSuite) TestBinaryViewToBinaryLike() {
 	})
 }
 
+func (c *CastSuite) TestBinaryToBinaryViewReleasesTemporaryResult() {
+	in, _, err := array.FromJSON(c.mem, arrow.BinaryTypes.Binary, strings.NewReader(`["aGk=", "dGhpcyBpcyB0aGUgZmlyc3QgdGVzdCE=", null]`))
+	c.Require().NoError(err)
+
+	scope := memory.NewCheckedAllocatorScope(c.mem)
+
+	out, err := compute.CastArray(context.Background(), in, compute.SafeCastOptions(arrow.BinaryTypes.BinaryView))
+	c.Require().NoError(err)
+	out.Release()
+	in.Release()
+
+	scope.CheckSize(c.T())
+}
+
+func (c *CastSuite) TestBinaryViewToBinaryReleasesTemporaryResult() {
+	in := c.buildStringViewArray([]string{"a", "short", "this is a longer cast value"}, nil)
+	scope := memory.NewCheckedAllocatorScope(c.mem)
+
+	out, err := compute.CastArray(context.Background(), in, compute.SafeCastOptions(arrow.BinaryTypes.LargeBinary))
+	c.Require().NoError(err)
+	out.Release()
+	in.Release()
+
+	scope.CheckSize(c.T())
+}
+
 // TestBinaryViewToBinaryView covers cross-view casts (binary_view <->
 // string_view) and identity casts. These are zero-copy except for UTF-8
 // validation in the binary_view -> string_view direction.

--- a/arrow/compute/internal/kernels/binary_view_casts.go
+++ b/arrow/compute/internal/kernels/binary_view_casts.go
@@ -200,6 +200,7 @@ func CastBinaryToBinaryView(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec
 	appendBinaryValues(arr, getVal, ba)
 
 	result := ba.bldr.NewArray()
+	defer result.Release()
 	out.TakeOwnership(result.Data())
 	return nil
 }
@@ -253,6 +254,7 @@ func CastBinaryViewToBinary[OutOffsetT int32 | int64](ctx *exec.KernelCtx, batch
 	appendBinaryValues(arr, getVal, ba)
 
 	result := ba.bldr.NewArray()
+	defer result.Release()
 	out.TakeOwnership(result.Data())
 	return nil
 }


### PR DESCRIPTION
### Rationale for this change

CastBinaryToBinaryView and CastBinaryViewToBinary create a temporary result array, transfer its buffers with ArraySpan.TakeOwnership, and return without releasing the temporary array. TakeOwnership retains the buffers, so the temporary reference leaks on every cast.

### What changes are included in this PR?

Release each temporary result after transferring its data to the output span. The output keeps its retained ownership, so successful cast behavior is unchanged.

### Are these changes tested?

Yes. Both cast directions are exercised with a checked allocator bound to the compute context. Each test releases the cast output and verifies that memory returns to the pre-cast baseline while the input remains alive. The compute package passes normal and race tests.

### Are there any user-facing changes?

Binary-to-binary-view and binary-view-to-binary casts no longer retain temporary allocations. There is no API change.