### PR TITLE
fix(array): validate MakeFromData type IDs before constructor lookup

### DIFF
--- a/arrow/array/array.go
+++ b/arrow/array/array.go
@@ -117,7 +117,12 @@ func invalidDataType(data arrow.ArrayData) arrow.Array {
 
 // MakeFromData constructs a strongly-typed array instance from generic Data.
 func MakeFromData(data arrow.ArrayData) arrow.Array {
-	return makeArrayFn[byte(data.DataType().ID()&0x3f)](data)
+	typeID := data.DataType().ID()
+	idx := int(typeID)
+	if idx < 0 || idx >= len(makeArrayFn) || makeArrayFn[idx] == nil {
+		panic("invalid data type: " + typeID.String())
+	}
+	return makeArrayFn[idx](data)
 }
 
 // NewSlice constructs a zero-copy slice of the array with the indicated

--- a/arrow/array/array_test.go
+++ b/arrow/array/array_test.go
@@ -133,6 +133,7 @@ func TestMakeFromData(t *testing.T) {
 
 		// invalid types
 		{name: "invalid(-1)", d: &testDataType{arrow.Type(-1)}, expPanic: true, expError: "invalid data type: Type(-1)"},
+		{name: "invalid(64)", d: &testDataType{arrow.Type(64)}, expPanic: true, expError: "invalid data type: Type(64)"},
 		{name: "invalid(63)", d: &testDataType{arrow.Type(63)}, expPanic: true, expError: "invalid data type: Type(63)"},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Description

This change makes MakeFromData validate Arrow type IDs before dispatching to the concrete constructor.

## Details
- Removes the 0x3f mask so IDs are not wrapped around.
- Adds bounds and nil checks before constructor lookup.
- Panics with a clear `invalid data type: <id>` message for unsupported types.

## Testing
- Added regression test coverage for invalid Type(64) in `TestMakeFromData`.