### PR TITLE
fix(ci): align benchmark json flag handling

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
           check-latest: false
       - name: Run Benchmarks
         if: github.event_name != 'push'
-        run: bash ci/scripts/bench.sh $(pwd) --json
+        run: bash ci/scripts/bench.sh $(pwd) -json
       - name: Upload results
         if: github.event_name == 'push' && github.repository == 'apache/arrow-go' && github.ref_name == 'main'
         env:

--- a/ci/scripts/bench.sh
+++ b/ci/scripts/bench.sh
@@ -17,8 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# this will output the benchmarks to STDOUT but if `-json` is passed
-# as the second argument, it will create a file "bench_stats.json"
+# this will output the benchmarks to STDOUT but if `-json` or `--json` is
+# passed as an argument, it will create a file "bench_stats.json"
 # in the directory this is called from containing a json representation
 
 set -ex
@@ -30,6 +30,15 @@ if [ -z "$1" ]; then
 fi
 
 source_dir="$1"
+json_requested=false
+
+for arg in "$@"; do
+	case "$arg" in
+	-json|--json)
+		json_requested=true
+		;;
+	esac
+done
 
 PARQUET_TEST_DATA="${source_dir}/parquet-testing/data"
 export PARQUET_TEST_DATA
@@ -43,8 +52,8 @@ go test -bench=. -benchmem -timeout 40m -run=^$ ./... | tee bench_stat.dat
 
 popd
 
-if [[ "$2" = "-json" ]]; then
-  go install go.bobheadxi.dev/gobenchdata@latest
+if [[ "${json_requested}" == "true" ]]; then
+  go install go.bobheadxi.dev/gobenchdata@v1.3.1
   PATH=$(go env GOPATH)/bin:$PATH
   export PATH
   cat "${source_dir}"/bench_*.dat | gobenchdata --json bench_stats.json


### PR DESCRIPTION
## Description

Fixes a benchmark CI mismatch between workflow invocation and script argument parsing for JSON output generation.

## Changes
- `.github/workflows/benchmark.yml`: pass `-json` to `ci/scripts/bench.sh` on PR benchmark runs.
- `ci/scripts/bench.sh`:
  - Accept both `-json` and `--json` flags.
  - Pin `gobenchdata` to `v1.3.1` for reproducible installs.

## Notes
- No functional change when JSON output is not requested.
