### PR TITLE
docs: fix malformed CPU markdown link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ advanced optimizer and generate PLAN9 assembly functions from C/C++ code. The
 arrow package can be compiled without these optimizations using the `noasm`
 build tag. Alternatively, by configuring an environment variable, it is
 possible to dynamically configure which architecture optimizations are used at
-runtime. We use the (cpu)[https://pkg.go.dev/golang.org/x/sys/cpu] package to
+runtime. We use the [cpu](https://pkg.go.dev/golang.org/x/sys/cpu) package to
 check dynamically for these features.
 
 ### Example Usage


### PR DESCRIPTION
## Description

Tiny README markdown typo fix in the Performance section.

## Changes
- Corrected the CPU package link from `(cpu)[https://pkg.go.dev/golang.org/x/sys/cpu]`
  to `[cpu](https://pkg.go.dev/golang.org/x/sys/cpu)`.
