### PR TITLE
fix(array): validate MakeFromData type IDs

### DIFF
--- a/arrow/array/array.go
+++ b/arrow/array/array.go
@@ -117,7 +117,11 @@ func invalidDataType(data arrow.ArrayData) arrow.Array {
 
 // MakeFromData constructs a strongly-typed array instance from generic Data.
 func MakeFromData(data arrow.ArrayData) arrow.Array {
-	return makeArrayFn[byte(data.DataType().ID()&0x3f)](data)
+	id := int(data.DataType().ID())
+	if id < 0 || id >= len(makeArrayFn) || makeArrayFn[id] == nil {
+		invalidDataType(data)
+	}
+	return makeArrayFn[id](data)
 }
 
 // NewSlice constructs a zero-copy slice of the array with the indicated

--- a/arrow/array/array_test.go
+++ b/arrow/array/array_test.go
@@ -133,6 +133,7 @@ func TestMakeFromData(t *testing.T) {
 
 		// invalid types
 		{name: "invalid(-1)", d: &testDataType{arrow.Type(-1)}, expPanic: true, expError: "invalid data type: Type(-1)"},
+		{name: "invalid(64)", d: &testDataType{arrow.Type(64)}, expPanic: true, expError: "invalid data type: Type(64)"},
 		{name: "invalid(63)", d: &testDataType{arrow.Type(63)}, expPanic: true, expError: "invalid data type: Type(63)"},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Summary
Fail fast on invalid Arrow type IDs in `array.MakeFromData` instead of masking and dispatching into the wrong constructor slot.

## Why this fix
`MakeFromData` currently masks the type ID (`& 0x3f`) before table lookup. New or invalid IDs can wrap to valid indices, causing wrong constructors or nil dispatch and a confusing panic.

## Changes
- Convert ID to `int` and validate it explicitly.
- Reject IDs that are:
  - less than zero
  - greater/equal to `len(makeArrayFn)`
  - mapped to `nil` constructors
- Keep existing `invalidDataType(...)` panic path for unsupported IDs.

## Files
- `arrow/array/array.go`
- `arrow/array/array_test.go`

## Validation
- Added `TestMakeFromData` case for invalid type `64` and assertion of panic text.

### Bug details
- Severity: 88/100
- Ask product?: 0/100
