### PR TITLE
fix(array): make SetNull idempotent and track null count

### DIFF
--- a/arrow/array/builder.go
+++ b/arrow/array/builder.go
@@ -133,6 +133,9 @@ func (b *builder) SetNull(i int) {
 	if i < 0 || i >= b.length {
 		panic("arrow/array: index out of range")
 	}
+	if bitutil.BitIsSet(b.nullBitmap.Bytes(), i) {
+		b.nulls++
+	}
 	bitutil.ClearBit(b.nullBitmap.Bytes(), i)
 }
 

--- a/arrow/array/builder_test.go
+++ b/arrow/array/builder_test.go
@@ -112,6 +112,11 @@ func TestBuilder_SetNull(t *testing.T) {
 			b.SetNull(i)
 		}
 	}
+	assert.Equal(t, n/2, b.NullN())
+
+	// idempotent SetNull
+	b.SetNull(0)
+	assert.Equal(t, n/2, b.NullN())
 
 	for i := 0; i < n; i++ {
 		if i%2 == 0 {

--- a/arrow/array/map_test.go
+++ b/arrow/array/map_test.go
@@ -244,6 +244,10 @@ func TestMapBuilder_SetNull(t *testing.T) {
 
 	bldr.SetNull(0)
 	bldr.SetNull(3)
+	assert.EqualValues(t, 2, bldr.NullN())
+
+	bldr.SetNull(3) // idempotent
+	assert.EqualValues(t, 2, bldr.NullN())
 
 	arr = bldr.NewMapArray()
 	defer arr.Release()


### PR DESCRIPTION
## Summary
Fix `builder.SetNull` null-count accounting and idempotency.

## Why this fix
`SetNull` cleared the validity bit but did not update `b.nulls`, so bitmap and `NullN()` metadata could diverge. Repeated `SetNull(i)` also inflated null count.

## Changes
- Increment `NullN` only when the targeted entry is currently valid.
- Keep behavior idempotent for already-null entries.
- Validate in tests that `MapBuilder` delegates the same semantics.

## Files
- `arrow/array/builder.go`
- `arrow/array/builder_test.go`
- `arrow/array/map_test.go`

## Validation
- Added assertions for:
  - `NullN()` after setting initial nulls
  - idempotent `SetNull(0)` does not change count
  - `MapBuilder.NullN()` reflects null transitions.

### Bug details
- Severity: 86/100
- Ask product?: 0/100
