### PR TITLE
fix(ci): accept --json and pin gobenchdata

### DIFF
--- a/ci/scripts/bench.sh
+++ b/ci/scripts/bench.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# this will output the benchmarks to STDOUT but if `-json` is passed
+# this will output the benchmarks to STDOUT but if `-json` or `--json` is passed
 # as the second argument, it will create a file "bench_stats.json"
 # in the directory this is called from containing a json representation
 
@@ -43,8 +43,8 @@ go test -bench=. -benchmem -timeout 40m -run=^$ ./... | tee bench_stat.dat
 
 popd
 
-if [[ "$2" = "-json" ]]; then
-  go install go.bobheadxi.dev/gobenchdata@latest
+if [[ "$2" = "-json" || "$2" = "--json" ]]; then
+  go install go.bobheadxi.dev/gobenchdata@v1.3.1
   PATH=$(go env GOPATH)/bin:$PATH
   export PATH
   cat "${source_dir}"/bench_*.dat | gobenchdata --json bench_stats.json


### PR DESCRIPTION
## Summary
Fix benchmark script JSON flag handling and pin gobenchdata to a specific version.

## Why this fix
Workflow runs pass `--json`, but `ci/scripts/bench.sh` only accepted `-json`, so JSON export step could be skipped. Using `@latest` for `gobenchdata` also makes CI behavior non-reproducible.

## Changes
- Accept both `-json` and `--json` as valid flags.
- Pin install to `go.bobheadxi.dev/gobenchdata@v1.3.1`.
- Update inline script comment to document accepted flags.

## Files
- `ci/scripts/bench.sh`

## Validation
- Manual logic path parity with workflow invocation.

### Bug details
- Severity: 35/100
- Ask product?: 0/100
