### PR TITLE
fix(docs): fix CPU markdown link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ advanced optimizer and generate PLAN9 assembly functions from C/C++ code. The
 arrow package can be compiled without these optimizations using the `noasm`
 build tag. Alternatively, by configuring an environment variable, it is
 possible to dynamically configure which architecture optimizations are used at
-runtime. We use the (cpu)[https://pkg.go.dev/golang.org/x/sys/cpu] package to
+runtime. We use the [cpu](https://pkg.go.dev/golang.org/x/sys/cpu) package to
 check dynamically for these features.
 
 ### Example Usage


### PR DESCRIPTION
## Summary
Fix a small README Markdown link typo.

## Why this fix
The CPU link in Performance section used swapped Markdown delimiters: `(cpu)[url]`.

## Changes
- Corrected to `[cpu](https://pkg.go.dev/golang.org/x/sys/cpu)`.

## Files
- `README.md`

### Bug details
- Severity: 5/100
- Ask product?: 0/100
