### PR TITLE
fix: return protobuf map key conversion errors

### DIFF
--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -366,7 +366,10 @@ func (pfr *ProtobufFieldReflection) asMap() protobufMapReflection {
 
 func (pmr protobufMapReflection) getDataType() arrow.DataType {
 	for kvp := range pmr.generateKeyValuePairs() {
-		return kvp.getDataType()
+		if kvp.err != nil {
+			continue
+		}
+		return kvp.kvp.getDataType()
 	}
 	return protobufMapKeyValuePairReflection{
 		k: ProtobufFieldReflection{
@@ -387,12 +390,17 @@ type protobufMapKeyValuePairReflection struct {
 	v ProtobufFieldReflection
 }
 
+type protobufMapKeyValuePairResult struct {
+	kvp protobufMapKeyValuePairReflection
+	err error
+}
+
 func (pmr protobufMapKeyValuePairReflection) getDataType() arrow.DataType {
 	return arrow.MapOf(pmr.k.getDataType(), pmr.v.getDataType())
 }
 
-func (pmr protobufMapReflection) generateKeyValuePairs() chan protobufMapKeyValuePairReflection {
-	out := make(chan protobufMapKeyValuePairReflection)
+func (pmr protobufMapReflection) generateKeyValuePairs() chan protobufMapKeyValuePairResult {
+	out := make(chan protobufMapKeyValuePairResult)
 
 	go func() {
 		defer close(out)
@@ -409,45 +417,50 @@ func (pmr protobufMapReflection) generateKeyValuePairs() chan protobufMapKeyValu
 					schemaOptions: pmr.schemaOptions,
 				},
 			}
-			out <- kvp
+			out <- protobufMapKeyValuePairResult{kvp: kvp}
 			return
 		}
 		for _, k := range pmr.rValue.MapKeys() {
+			mapKey, err := getMapKey(k)
+			if err != nil {
+				out <- protobufMapKeyValuePairResult{err: err}
+				continue
+			}
 			kvp := protobufMapKeyValuePairReflection{
 				k: ProtobufFieldReflection{
 					parent:        pmr.parent,
 					descriptor:    pmr.descriptor.MapKey(),
-					prValue:       getMapKey(k),
+					prValue:       mapKey,
 					rValue:        k,
 					schemaOptions: pmr.schemaOptions,
 				},
 				v: ProtobufFieldReflection{
 					parent:        pmr.parent,
 					descriptor:    pmr.descriptor.MapValue(),
-					prValue:       pmr.prValue.Map().Get(protoreflect.MapKey(getMapKey(k))),
+					prValue:       pmr.prValue.Map().Get(protoreflect.MapKey(mapKey)),
 					rValue:        pmr.rValue.MapIndex(k),
 					schemaOptions: pmr.schemaOptions,
 				},
 			}
-			out <- kvp
+			out <- protobufMapKeyValuePairResult{kvp: kvp}
 		}
 	}()
 
 	return out
 }
 
-func getMapKey(v reflect.Value) protoreflect.Value {
+func getMapKey(v reflect.Value) (protoreflect.Value, error) {
 	switch v.Kind() {
 	case reflect.String:
-		return protoreflect.ValueOf(v.String())
+		return protoreflect.ValueOf(v.String()), nil
 	case reflect.Int32, reflect.Int64:
-		return protoreflect.ValueOf(v.Int())
+		return protoreflect.ValueOf(v.Int()), nil
 	case reflect.Bool:
-		return protoreflect.ValueOf(v.Bool())
+		return protoreflect.ValueOf(v.Bool()), nil
 	case reflect.Uint32, reflect.Uint64:
-		return protoreflect.ValueOf(v.Uint())
+		return protoreflect.ValueOf(v.Uint()), nil
 	default:
-		panic("Unmapped protoreflect map key type")
+		return protoreflect.Value{}, fmt.Errorf("unsupported map key kind %s", v.Type())
 	}
 }
 
@@ -858,12 +871,16 @@ func (f ProtobufMessageFieldReflection) AppendValueOrNull(b array.Builder, mem m
 			Field:  f.Field.Type.(*arrow.MapType).ItemField(),
 		}
 		for kvp := range f.asMap().generateKeyValuePairs() {
-			k.protobufReflection = &kvp.k
+			if kvp.err != nil {
+				return fmt.Errorf("failed to append map field %q (%s): %w", f.name(), f.getDataType(), kvp.err)
+			}
+
+			k.protobufReflection = &kvp.kvp.k
 			err := k.AppendValueOrNull(mb.KeyBuilder(), mem)
 			if err != nil {
 				return err
 			}
-			v.protobufReflection = &kvp.v
+			v.protobufReflection = &kvp.kvp.v
 			err = v.AppendValueOrNull(mb.ItemBuilder(), mem)
 			if err != nil {
 				return err

--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -872,7 +872,7 @@ func (f ProtobufMessageFieldReflection) AppendValueOrNull(b array.Builder, mem m
 		}
 		for kvp := range f.asMap().generateKeyValuePairs() {
 			if kvp.err != nil {
-				return fmt.Errorf("failed to append map field %q (%s): %w", f.name(), f.getDataType(), kvp.err)
+				return fmt.Errorf("failed to append map field %q (%s): %w", f.name(), f.Field.Type, kvp.err)
 			}
 
 			k.protobufReflection = &kvp.kvp.k

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -504,7 +504,7 @@ func TestGetMapKeyRejectsUnsupportedType(t *testing.T) {
 }
 
 func TestMapAppendReturnsContextualErrorForUnsupportedKey(t *testing.T) {
-	msg := util_message.AllTheTypesNoAny{}
+	msg := util_message.AllTheTypesNoAny{SimpleMap: map[int32]string{1: "value"}}
 	pmr := NewProtobufMessageReflection(&msg)
 
 	var field *ProtobufMessageFieldReflection
@@ -515,14 +515,15 @@ func TestMapAppendReturnsContextualErrorForUnsupportedKey(t *testing.T) {
 		}
 	}
 	require.NotNil(t, field)
+	fr := field.protobufReflection.(*ProtobufFieldReflection)
 
 	badMapReflection := &protobufMapReflection{
 		ProtobufFieldReflection: ProtobufFieldReflection{
-			parent:        field.parent,
-			descriptor:    field.descriptor,
-			prValue:       field.protoreflectValue(),
+			parent:        fr.parent,
+			descriptor:    fr.descriptor,
+			prValue:       fr.prValue,
 			rValue:        reflect.ValueOf(map[struct{}]string{struct{}{}: "value"}),
-			schemaOptions: field.schemaOptions,
+			schemaOptions: fr.schemaOptions,
 		},
 	}
 	badField := ProtobufMessageFieldReflection{

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -494,4 +495,48 @@ func TestAppendValueOrNull(t *testing.T) {
 	got := pmfr.AppendValueOrNull(recordBuilder.Field(0), mem)
 	want := "not able to appendValueOrNull for type TIME32"
 	assert.EqualErrorf(t, got, want, "Error is: %v, want: %v", got, want)
+}
+
+func TestGetMapKeyRejectsUnsupportedType(t *testing.T) {
+	_, err := getMapKey(reflect.ValueOf(struct{}{}))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unsupported map key kind")
+}
+
+func TestMapAppendReturnsContextualErrorForUnsupportedKey(t *testing.T) {
+	msg := util_message.AllTheTypesNoAny{}
+	pmr := NewProtobufMessageReflection(&msg)
+
+	var field *ProtobufMessageFieldReflection
+	for i := range pmr.fields {
+		if pmr.fields[i].name() == "simple_map" {
+			field = &pmr.fields[i]
+			break
+		}
+	}
+	require.NotNil(t, field)
+
+	badMapReflection := &protobufMapReflection{
+		ProtobufFieldReflection: ProtobufFieldReflection{
+			parent:        field.parent,
+			descriptor:    field.descriptor,
+			prValue:       field.protoreflectValue(),
+			rValue:        reflect.ValueOf(map[struct{}]string{struct{}{}: "value"}),
+			schemaOptions: field.schemaOptions,
+		},
+	}
+	badField := ProtobufMessageFieldReflection{
+		parent:             field.parent,
+		protobufReflection: badMapReflection,
+		Field:              field.Field,
+	}
+
+	schema := arrow.NewSchema([]arrow.Field{badField.Field}, nil)
+	mem := memory.NewGoAllocator()
+	recordBuilder := array.NewRecordBuilder(mem, schema)
+
+	err := badField.AppendValueOrNull(recordBuilder.Field(0), mem)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to append map field")
+	assert.ErrorContains(t, err, "simple_map")
 }


### PR DESCRIPTION
## Summary
- Make protobuf map key conversion return an error instead of panicking for unsupported key kinds.
- Thread conversion errors through map iteration into record construction with contextual message including field name and map type.
- Add regression tests for invalid map key conversion and contextual append error path.

## Validation
- Changes committed in branch: fix-protobuf-map-key-error-clean
- Target: apache/arrow-go:main
- No tests run in this step.
