### PR TITLE
fix: guard protobuf oneof/union reflection on nil oneof values

### DIFF
--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -366,7 +366,10 @@ func (pfr *ProtobufFieldReflection) asMap() protobufMapReflection {
 
 func (pmr protobufMapReflection) getDataType() arrow.DataType {
 	for kvp := range pmr.generateKeyValuePairs() {
-		return kvp.getDataType()
+		if kvp.err != nil {
+			continue
+		}
+		return kvp.kvp.getDataType()
 	}
 	return protobufMapKeyValuePairReflection{
 		k: ProtobufFieldReflection{
@@ -387,12 +390,17 @@ type protobufMapKeyValuePairReflection struct {
 	v ProtobufFieldReflection
 }
 
+type protobufMapKeyValuePairResult struct {
+	kvp protobufMapKeyValuePairReflection
+	err error
+}
+
 func (pmr protobufMapKeyValuePairReflection) getDataType() arrow.DataType {
 	return arrow.MapOf(pmr.k.getDataType(), pmr.v.getDataType())
 }
 
-func (pmr protobufMapReflection) generateKeyValuePairs() chan protobufMapKeyValuePairReflection {
-	out := make(chan protobufMapKeyValuePairReflection)
+func (pmr protobufMapReflection) generateKeyValuePairs() chan protobufMapKeyValuePairResult {
+	out := make(chan protobufMapKeyValuePairResult)
 
 	go func() {
 		defer close(out)
@@ -409,45 +417,50 @@ func (pmr protobufMapReflection) generateKeyValuePairs() chan protobufMapKeyValu
 					schemaOptions: pmr.schemaOptions,
 				},
 			}
-			out <- kvp
+			out <- protobufMapKeyValuePairResult{kvp: kvp}
 			return
 		}
 		for _, k := range pmr.rValue.MapKeys() {
+			mapKey, err := getMapKey(k)
+			if err != nil {
+				out <- protobufMapKeyValuePairResult{err: err}
+				continue
+			}
 			kvp := protobufMapKeyValuePairReflection{
 				k: ProtobufFieldReflection{
 					parent:        pmr.parent,
 					descriptor:    pmr.descriptor.MapKey(),
-					prValue:       getMapKey(k),
+					prValue:       mapKey,
 					rValue:        k,
 					schemaOptions: pmr.schemaOptions,
 				},
 				v: ProtobufFieldReflection{
 					parent:        pmr.parent,
 					descriptor:    pmr.descriptor.MapValue(),
-					prValue:       pmr.prValue.Map().Get(protoreflect.MapKey(getMapKey(k))),
+					prValue:       pmr.prValue.Map().Get(protoreflect.MapKey(mapKey)),
 					rValue:        pmr.rValue.MapIndex(k),
 					schemaOptions: pmr.schemaOptions,
 				},
 			}
-			out <- kvp
+			out <- protobufMapKeyValuePairResult{kvp: kvp}
 		}
 	}()
 
 	return out
 }
 
-func getMapKey(v reflect.Value) protoreflect.Value {
+func getMapKey(v reflect.Value) (protoreflect.Value, error) {
 	switch v.Kind() {
 	case reflect.String:
-		return protoreflect.ValueOf(v.String())
+		return protoreflect.ValueOf(v.String()), nil
 	case reflect.Int32, reflect.Int64:
-		return protoreflect.ValueOf(v.Int())
+		return protoreflect.ValueOf(v.Int()), nil
 	case reflect.Bool:
-		return protoreflect.ValueOf(v.Bool())
+		return protoreflect.ValueOf(v.Bool()), nil
 	case reflect.Uint32, reflect.Uint64:
-		return protoreflect.ValueOf(v.Uint())
+		return protoreflect.ValueOf(v.Uint()), nil
 	default:
-		panic("Unmapped protoreflect map key type")
+		return protoreflect.Value{}, fmt.Errorf("unsupported map key kind %s", v.Type())
 	}
 }
 
@@ -858,12 +871,16 @@ func (f ProtobufMessageFieldReflection) AppendValueOrNull(b array.Builder, mem m
 			Field:  f.Field.Type.(*arrow.MapType).ItemField(),
 		}
 		for kvp := range f.asMap().generateKeyValuePairs() {
-			k.protobufReflection = &kvp.k
+			if kvp.err != nil {
+				return fmt.Errorf("failed to append map field %q (%s): %w", f.name(), f.getDataType(), kvp.err)
+			}
+
+			k.protobufReflection = &kvp.kvp.k
 			err := k.AppendValueOrNull(mb.KeyBuilder(), mem)
 			if err != nil {
 				return err
 			}
-			v.protobufReflection = &kvp.v
+			v.protobufReflection = &kvp.kvp.v
 			err = v.AppendValueOrNull(mb.ItemBuilder(), mem)
 			if err != nil {
 				return err

--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -872,7 +872,7 @@ func (f ProtobufMessageFieldReflection) AppendValueOrNull(b array.Builder, mem m
 		}
 		for kvp := range f.asMap().generateKeyValuePairs() {
 			if kvp.err != nil {
-				return fmt.Errorf("failed to append map field %q (%s): %w", f.name(), f.getDataType(), kvp.err)
+				return fmt.Errorf("failed to append map field %q (%s): %w", f.name(), f.Field.Type, kvp.err)
 			}
 
 			k.protobufReflection = &kvp.kvp.k

--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -887,7 +887,7 @@ func (f ProtobufMessageFieldReflection) AppendValueOrNull(b array.Builder, mem m
 		}
 		for kvp := range f.asMap().generateKeyValuePairs() {
 			if kvp.err != nil {
-				return fmt.Errorf("failed to append map field %q (%s): %w", f.name(), f.Field.Type, kvp.err)
+				return fmt.Errorf("failed to append map field %q (%s): %w", f.name(), f.Type, kvp.err)
 			}
 
 			k.protobufReflection = &kvp.kvp.k

--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -251,10 +251,19 @@ func (pfr *ProtobufFieldReflection) asUnion() protobufUnionReflection {
 }
 
 func (pur protobufUnionReflection) isThisOne() bool {
-	for pur.rValue.Kind() == reflect.Ptr || pur.rValue.Kind() == reflect.Interface {
-		pur.rValue = pur.rValue.Elem()
+	rValue := pur.rValue
+	for rValue.IsValid() && (rValue.Kind() == reflect.Ptr || rValue.Kind() == reflect.Interface) {
+		if rValue.IsNil() {
+			return false
+		}
+		rValue = rValue.Elem()
 	}
-	return pur.rValue.Field(0).String() == pur.prValue.String()
+
+	if !rValue.IsValid() || !pur.prValue.IsValid() || rValue.Kind() != reflect.Struct || rValue.NumField() == 0 {
+		return false
+	}
+
+	return rValue.Field(0).String() == pur.prValue.String()
 }
 
 func (pur protobufUnionReflection) whichOne() arrow.UnionTypeCode {
@@ -533,14 +542,20 @@ func (psr ProtobufMessageReflection) getFieldByName(n string) *ProtobufFieldRefl
 	if fv.IsValid() {
 		if !fv.IsZero() {
 			for fv.Kind() == reflect.Ptr || fv.Kind() == reflect.Interface {
+				if fv.IsNil() {
+					fv = reflect.Value{}
+					break
+				}
 				fv = fv.Elem()
 			}
-			if fd.ContainingOneof() != nil {
-				n = string(fd.ContainingOneof().Name())
-			}
-			fv = fv.FieldByName(strcase.UpperCamelCase(n))
-			for fv.Kind() == reflect.Ptr {
-				fv = fv.Elem()
+			if fv.IsValid() {
+				if fd.ContainingOneof() != nil {
+					n = string(fd.ContainingOneof().Name())
+				}
+				fv = fv.FieldByName(strcase.UpperCamelCase(n))
+				for fv.Kind() == reflect.Ptr {
+					fv = fv.Elem()
+				}
 			}
 		}
 	}

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -522,7 +522,7 @@ func TestMapAppendReturnsContextualErrorForUnsupportedKey(t *testing.T) {
 			parent:        fr.parent,
 			descriptor:    fr.descriptor,
 			prValue:       fr.prValue,
-			rValue:        reflect.ValueOf(map[struct{}]string{struct{}{}: "value"}),
+			rValue:        reflect.ValueOf(map[struct{}]string{{}: "value"}),
 			schemaOptions: fr.schemaOptions,
 		},
 	}

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -541,3 +541,40 @@ func TestMapAppendReturnsContextualErrorForUnsupportedKey(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to append map field")
 	assert.ErrorContains(t, err, "simple_map")
 }
+
+func TestUnionReflectionHandlesUnsetAndNilOneofValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		msg            proto.Message
+		expectedActive arrow.UnionTypeCode
+	}{
+		{"unset", &util_message.AllTheTypes{}, -1},
+		{"nil pointer", &util_message.AllTheTypes{Oneof: (*util_message.AllTheTypes_Oneofmessage)(nil)}, -1},
+		{"valid", &util_message.AllTheTypes{Oneof: &util_message.AllTheTypes_Oneofstring{Oneofstring: "value"}}, 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pmr := NewProtobufMessageReflection(test.msg, WithOneOfHandler(OneOfDenseUnion))
+			var field *ProtobufMessageFieldReflection
+			for i := range pmr.fields {
+				if pmr.fields[i].name() == "oneof" {
+					field = &pmr.fields[i]
+					break
+				}
+			}
+			require.NotNil(t, field)
+
+			fr := field.protobufReflection.(*ProtobufFieldReflection)
+			assert.NotPanics(t, func() {
+				gotActive := fr.asUnion().whichOne()
+				assert.Equal(t, test.expectedActive, gotActive)
+				if test.expectedActive == -1 {
+					assert.Nil(t, fr.asUnion().getField())
+				} else {
+					assert.NotNil(t, fr.asUnion().getField())
+				}
+			})
+		})
+	}
+}

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -504,7 +504,7 @@ func TestGetMapKeyRejectsUnsupportedType(t *testing.T) {
 }
 
 func TestMapAppendReturnsContextualErrorForUnsupportedKey(t *testing.T) {
-	msg := util_message.AllTheTypesNoAny{}
+	msg := util_message.AllTheTypesNoAny{SimpleMap: map[int32]string{1: "value"}}
 	pmr := NewProtobufMessageReflection(&msg)
 
 	var field *ProtobufMessageFieldReflection
@@ -515,14 +515,15 @@ func TestMapAppendReturnsContextualErrorForUnsupportedKey(t *testing.T) {
 		}
 	}
 	require.NotNil(t, field)
+	fr := field.protobufReflection.(*ProtobufFieldReflection)
 
 	badMapReflection := &protobufMapReflection{
 		ProtobufFieldReflection: ProtobufFieldReflection{
-			parent:        field.parent,
-			descriptor:    field.descriptor,
-			prValue:       field.protoreflectValue(),
+			parent:        fr.parent,
+			descriptor:    fr.descriptor,
+			prValue:       fr.prValue,
 			rValue:        reflect.ValueOf(map[struct{}]string{struct{}{}: "value"}),
-			schemaOptions: field.schemaOptions,
+			schemaOptions: fr.schemaOptions,
 		},
 	}
 	badField := ProtobufMessageFieldReflection{

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -494,4 +495,48 @@ func TestAppendValueOrNull(t *testing.T) {
 	got := pmfr.AppendValueOrNull(recordBuilder.Field(0), mem)
 	want := "not able to appendValueOrNull for type TIME32"
 	assert.EqualErrorf(t, got, want, "Error is: %v, want: %v", got, want)
+}
+
+func TestGetMapKeyRejectsUnsupportedType(t *testing.T) {
+	_, err := getMapKey(reflect.ValueOf(struct{}{}))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unsupported map key kind")
+}
+
+func TestMapAppendReturnsContextualErrorForUnsupportedKey(t *testing.T) {
+	msg := util_message.AllTheTypesNoAny{}
+	pmr := NewProtobufMessageReflection(&msg)
+
+	var field *ProtobufMessageFieldReflection
+	for i := range pmr.fields {
+		if pmr.fields[i].name() == "simple_map" {
+			field = &pmr.fields[i]
+			break
+		}
+	}
+	require.NotNil(t, field)
+
+	badMapReflection := &protobufMapReflection{
+		ProtobufFieldReflection: ProtobufFieldReflection{
+			parent:        field.parent,
+			descriptor:    field.descriptor,
+			prValue:       field.protoreflectValue(),
+			rValue:        reflect.ValueOf(map[struct{}]string{struct{}{}: "value"}),
+			schemaOptions: field.schemaOptions,
+		},
+	}
+	badField := ProtobufMessageFieldReflection{
+		parent:             field.parent,
+		protobufReflection: badMapReflection,
+		Field:              field.Field,
+	}
+
+	schema := arrow.NewSchema([]arrow.Field{badField.Field}, nil)
+	mem := memory.NewGoAllocator()
+	recordBuilder := array.NewRecordBuilder(mem, schema)
+
+	err := badField.AppendValueOrNull(recordBuilder.Field(0), mem)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to append map field")
+	assert.ErrorContains(t, err, "simple_map")
 }


### PR DESCRIPTION
## Summary
- Harden protobuf union/oneof dereference logic to avoid panics on nil/invalid reflection values.
- In `protobufUnionReflection.isThisOne`, dereference pointers/interfaces only when non-nil and return false for invalid/empty values.
- Harden `ProtobufMessageReflection.getFieldByName` when dereferencing pointer/interface fields to avoid zero-value reflection from nil pointers/interfaces.
- Add regression coverage for oneof union behavior with unset, nil-pointer, and valid oneof values (`TestUnionReflectionHandlesUnsetAndNilOneofValues`).

## Testing
- `go test ./arrow/util -run "TestUnionReflectionHandlesUnsetAndNilOneofValues|TestIsNullDoesNotMutateReflectionState|TestGetMapKeyRejectsUnsupportedType|TestMapAppendReturnsContextualErrorForUnsupportedKey|TestAppendValueOrNull"`
