### PR TITLE
fix(array): bounds check FixedSizeBinary.Value

### DIFF
--- a/arrow/array/fixedsize_binary.go
+++ b/arrow/array/fixedsize_binary.go
@@ -44,6 +44,9 @@ func NewFixedSizeBinaryData(data arrow.ArrayData) *FixedSizeBinary {
 
 // Value returns the fixed-size slice at index i. This value should not be mutated.
 func (a *FixedSizeBinary) Value(i int) []byte {
+	if i < 0 || i >= a.Len() {
+		panic("arrow/array: index out of range")
+	}
 	i += a.data.offset
 	var (
 		bw  = int(a.bytewidth)

--- a/arrow/array/fixedsize_binary_test.go
+++ b/arrow/array/fixedsize_binary_test.go
@@ -113,6 +113,33 @@ func TestFixedSizeBinarySlice(t *testing.T) {
 	}
 }
 
+func TestFixedSizeBinaryValueBounds(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	dtype := &arrow.FixedSizeBinaryType{ByteWidth: 4}
+	b := array.NewFixedSizeBinaryBuilder(mem, dtype)
+	b.AppendValues([][]byte{
+		[]byte("ABCD"),
+		[]byte("1234"),
+		[]byte("AZER"),
+	}, nil)
+	arr := b.NewFixedSizeBinaryArray()
+	defer arr.Release()
+	b.Release()
+
+	slice := array.NewSlice(arr, 1, 2).(*array.FixedSizeBinary)
+	defer slice.Release()
+
+	assert.Equal(t, []byte("1234"), slice.Value(0))
+	assert.PanicsWithValue(t, "arrow/array: index out of range", func() {
+		slice.Value(-1)
+	})
+	assert.PanicsWithValue(t, "arrow/array: index out of range", func() {
+		slice.Value(1)
+	})
+}
+
 func TestFixedSizeBinary_MarshalUnmarshalJSON(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)


### PR DESCRIPTION
FixedSizeBinary.Value applied the physical slice offset before validating the logical index. On sliced arrays, negative and one-past-the-end indexes could therefore expose adjacent values from the shared backing buffer.

This adds the standard array bounds check before applying the physical offset and covers valid, negative, and one-past-the-end access on a sliced three-element array.

Tests:
- go test ./arrow/array -run 'TestFixedSizeBinary(ValueBounds|Slice|$)'
- go test ./arrow/array