### PR TITLE
fix(array): reject unsupported type IDs

### DIFF
--- a/arrow/array/array.go
+++ b/arrow/array/array.go
@@ -117,7 +117,11 @@ func invalidDataType(data arrow.ArrayData) arrow.Array {
 
 // MakeFromData constructs a strongly-typed array instance from generic Data.
 func MakeFromData(data arrow.ArrayData) arrow.Array {
-	return makeArrayFn[byte(data.DataType().ID()&0x3f)](data)
+	id := data.DataType().ID()
+	if id < 0 || int(id) >= len(makeArrayFn) || makeArrayFn[id] == nil {
+		return invalidDataType(data)
+	}
+	return makeArrayFn[id](data)
 }
 
 // NewSlice constructs a zero-copy slice of the array with the indicated

--- a/arrow/array/array_test.go
+++ b/arrow/array/array_test.go
@@ -40,6 +40,7 @@ func (testDataType) Layout() arrow.DataTypeLayout { return arrow.DataTypeLayout{
 func (testDataType) String() string               { return "" }
 
 func TestMakeFromData(t *testing.T) {
+	const veryLargeTypeID arrow.Type = 1 << 30
 	tests := []struct {
 		name     string
 		d        arrow.DataType
@@ -134,6 +135,10 @@ func TestMakeFromData(t *testing.T) {
 		// invalid types
 		{name: "invalid(-1)", d: &testDataType{arrow.Type(-1)}, expPanic: true, expError: "invalid data type: Type(-1)"},
 		{name: "invalid(63)", d: &testDataType{arrow.Type(63)}, expPanic: true, expError: "invalid data type: Type(63)"},
+		{name: "invalid(64)", d: &testDataType{arrow.Type(64)}, expPanic: true, expError: "invalid data type: Type(64)"},
+		{name: "invalid(65)", d: &testDataType{arrow.Type(65)}, expPanic: true, expError: "invalid data type: Type(65)"},
+		{name: "invalid(127)", d: &testDataType{arrow.Type(127)}, expPanic: true, expError: "invalid data type: Type(127)"},
+		{name: "invalid(very large)", d: &testDataType{veryLargeTypeID}, expPanic: true, expError: "invalid data type: Type(1073741824)"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
MakeFromData masked datatype IDs to six bits before dispatching to array constructors. Unsupported IDs could therefore alias valid constructors, silently producing the wrong concrete array type.

This validates the ID bounds and constructor entry before dispatching, while preserving the documented invalid-data-type panic. Regression coverage now includes IDs -1, 63, 64, 65, 127, and a large positive ID.

Tests:
- go test ./arrow/array -run TestMakeFromData
- go test ./arrow/array
- go test ./arrow/... -run '^$'