### PR TITLE
fix(scalar): hash list values logically

### DIFF
--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -995,6 +995,10 @@ func Hash(seed maphash.Seed, s Scalar) uint64 {
 		out ^= h.Sum64()
 		h.Reset()
 	}
+	hashUint64 := func(v uint64) {
+		binary.Write(&h, endian.Native, v)
+		hash()
+	}
 
 	valueHash := func(v interface{}) uint64 {
 		switch v := v.(type) {
@@ -1063,8 +1067,26 @@ func Hash(seed maphash.Seed, s Scalar) uint64 {
 	case TemporalScalar:
 		return valueHash(s.value())
 	case ListScalar:
-		array.Hash(&h, s.GetList().Data())
-		hash()
+		list := s.GetList()
+		hashUint64(uint64(list.Len()))
+		for i := 0; i < list.Len(); i++ {
+			if list.IsNull(i) {
+				h.Write([]byte{0})
+				hash()
+				continue
+			}
+
+			value, err := GetScalar(list, i)
+			if err != nil {
+				panic(err)
+			}
+			h.Write([]byte{1})
+			binary.Write(&h, endian.Native, Hash(seed, value))
+			hash()
+			if r, ok := value.(Releasable); ok {
+				r.Release()
+			}
+		}
 	case *Struct:
 		for _, c := range s.Value {
 			if c.IsValid() {

--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -1079,16 +1079,9 @@ func Hash(seed maphash.Seed, s Scalar) uint64 {
 				continue
 			}
 
-			value, err := GetScalar(list, i)
-			if err != nil {
-				panic(err)
-			}
 			h.Write([]byte{1})
-			binary.Write(&h, endian.Native, Hash(seed, value))
+			binary.Write(&h, endian.Native, hashListElement(seed, list, i))
 			hash()
-			if r, ok := value.(Releasable); ok {
-				r.Release()
-			}
 		}
 	case *Struct:
 		for _, c := range s.Value {
@@ -1099,4 +1092,29 @@ func Hash(seed maphash.Seed, s Scalar) uint64 {
 	}
 
 	return out
+}
+
+func hashListElement(seed maphash.Seed, list arrow.Array, index int) uint64 {
+	value, err := GetScalar(list, index)
+	if err == nil {
+		defer func() {
+			if r, ok := value.(Releasable); ok {
+				r.Release()
+			}
+		}()
+		return Hash(seed, value)
+	}
+
+	// Some valid array types do not have a scalar representation yet. ValueStr
+	// is their logical value representation and avoids making list hashing
+	// depend on GetScalar supporting every array type.
+	var h maphash.MapHash
+	h.SetSeed(seed)
+	binary.Write(&h, endian.Native, arrow.HashType(seed, list.DataType()))
+	out := h.Sum64()
+	h.Reset()
+	valueString := list.ValueStr(index)
+	binary.Write(&h, endian.Native, uint64(len(valueString)))
+	h.Write([]byte(valueString))
+	return out ^ h.Sum64()
 }

--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -1070,6 +1070,9 @@ func Hash(seed maphash.Seed, s Scalar) uint64 {
 		list := s.GetList()
 		hashUint64(uint64(list.Len()))
 		for i := 0; i < list.Len(); i++ {
+			// Include the logical position in the same chunk as the element so
+			// that list order affects the aggregate hash.
+			binary.Write(&h, endian.Native, uint64(i))
 			if list.IsNull(i) {
 				h.Write([]byte{0})
 				hash()

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/decimal"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/decimal256"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -821,6 +822,90 @@ func TestListScalarHashUsesLogicalValues(t *testing.T) {
 
 		assertDifferentHash(leftValues, rightValues)
 	})
+}
+
+func TestListScalarHashSupportsChildArraysWithoutScalars(t *testing.T) {
+	seed := maphash.MakeSeed()
+	tests := []struct {
+		name      string
+		newValues func() arrow.Array
+	}{
+		{
+			name: "string view",
+			newValues: func() arrow.Array {
+				b := array.NewStringViewBuilder(memory.DefaultAllocator)
+				defer b.Release()
+				b.AppendValues([]string{"one", "two"}, nil)
+				return b.NewStringViewArray()
+			},
+		},
+		{
+			name: "binary view",
+			newValues: func() arrow.Array {
+				b := array.NewBinaryViewBuilder(memory.DefaultAllocator)
+				defer b.Release()
+				b.AppendValues([][]byte{[]byte("one"), []byte("two")}, nil)
+				return b.NewBinaryViewArray()
+			},
+		},
+		{
+			name: "decimal32",
+			newValues: func() arrow.Array {
+				b := array.NewDecimal32Builder(memory.DefaultAllocator, &arrow.Decimal32Type{Precision: 6, Scale: 2})
+				defer b.Release()
+				b.AppendValues([]decimal.Decimal32{123, 456}, nil)
+				return b.NewDecimalArray()
+			},
+		},
+		{
+			name: "decimal64",
+			newValues: func() arrow.Array {
+				b := array.NewDecimal64Builder(memory.DefaultAllocator, &arrow.Decimal64Type{Precision: 12, Scale: 2})
+				defer b.Release()
+				b.AppendValues([]decimal.Decimal64{123, 456}, nil)
+				return b.NewDecimalArray()
+			},
+		},
+		{
+			name: "list view",
+			newValues: func() arrow.Array {
+				b := array.NewListViewBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int32)
+				defer b.Release()
+				b.ValueBuilder().(*array.Int32Builder).AppendValues([]int32{1, 2}, nil)
+				b.AppendDimensions(0, 2)
+				return b.NewListViewArray()
+			},
+		},
+		{
+			name: "large list view",
+			newValues: func() arrow.Array {
+				b := array.NewLargeListViewBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int32)
+				defer b.Release()
+				b.ValueBuilder().(*array.Int32Builder).AppendValues([]int32{1, 2}, nil)
+				b.AppendDimensions(0, 2)
+				return b.NewLargeListViewArray()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leftValues := tt.newValues()
+			defer leftValues.Release()
+			rightValues := tt.newValues()
+			defer rightValues.Release()
+
+			left := scalar.NewListScalar(leftValues)
+			defer left.Release()
+			right := scalar.NewListScalar(rightValues)
+			defer right.Release()
+
+			assert.True(t, scalar.Equals(left, right))
+			assert.NotPanics(t, func() {
+				assert.Equal(t, scalar.Hash(seed, left), scalar.Hash(seed, right))
+			})
+		})
+	}
 }
 
 func TestFixedSizeListScalarWrongNumber(t *testing.T) {

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -739,6 +739,12 @@ func newInt32DataArray(values []int32, validity []byte, length, offset int) *arr
 
 func TestListScalarHashUsesLogicalValues(t *testing.T) {
 	seed := maphash.MakeSeed()
+	newArray := func(values []int32, valid []bool) *array.Int32 {
+		builder := array.NewInt32Builder(memory.DefaultAllocator)
+		defer builder.Release()
+		builder.AppendValues(values, valid)
+		return builder.NewInt32Array()
+	}
 	assertEqualAndSameHash := func(leftValues, rightValues arrow.Array) {
 		left := scalar.NewListScalar(leftValues)
 		right := scalar.NewListScalar(rightValues)
@@ -747,6 +753,15 @@ func TestListScalarHashUsesLogicalValues(t *testing.T) {
 
 		assert.True(t, scalar.Equals(left, right))
 		assert.Equal(t, scalar.Hash(seed, left), scalar.Hash(seed, right))
+	}
+	assertDifferentHash := func(leftValues, rightValues arrow.Array) {
+		left := scalar.NewListScalar(leftValues)
+		right := scalar.NewListScalar(rightValues)
+		defer left.Release()
+		defer right.Release()
+
+		assert.False(t, scalar.Equals(left, right))
+		assert.NotEqual(t, scalar.Hash(seed, left), scalar.Hash(seed, right))
 	}
 
 	t.Run("different backing values and offsets", func(t *testing.T) {
@@ -759,18 +774,11 @@ func TestListScalarHashUsesLogicalValues(t *testing.T) {
 	})
 
 	t.Run("different slices", func(t *testing.T) {
-		newArray := func(values []int32) *array.Int32 {
-			builder := array.NewInt32Builder(memory.DefaultAllocator)
-			defer builder.Release()
-			builder.AppendValues(values, nil)
-			return builder.NewInt32Array()
-		}
-
-		leftBase := newArray([]int32{0, 1, 2, 3, 4})
+		leftBase := newArray([]int32{0, 1, 2, 3, 4}, nil)
 		defer leftBase.Release()
 		leftValues := array.NewSlice(leftBase, 1, 4)
 		defer leftValues.Release()
-		rightBase := newArray([]int32{1, 2, 3, 4, 5})
+		rightBase := newArray([]int32{1, 2, 3, 4, 5}, nil)
 		defer rightBase.Release()
 		rightValues := array.NewSlice(rightBase, 0, 3)
 		defer rightValues.Release()
@@ -785,6 +793,33 @@ func TestListScalarHashUsesLogicalValues(t *testing.T) {
 		defer rightValues.Release()
 
 		assertEqualAndSameHash(leftValues, rightValues)
+	})
+
+	t.Run("different element order produces different hashes", func(t *testing.T) {
+		leftValues := newArray([]int32{1, 2}, nil)
+		defer leftValues.Release()
+		rightValues := newArray([]int32{2, 1}, nil)
+		defer rightValues.Release()
+
+		assertDifferentHash(leftValues, rightValues)
+	})
+
+	t.Run("repeated values do not cancel", func(t *testing.T) {
+		leftValues := newArray([]int32{1, 1}, nil)
+		defer leftValues.Release()
+		rightValues := newArray([]int32{2, 2}, nil)
+		defer rightValues.Release()
+
+		assertDifferentHash(leftValues, rightValues)
+	})
+
+	t.Run("null positions affect the hash", func(t *testing.T) {
+		leftValues := newArray([]int32{0, 1}, []bool{false, true})
+		defer leftValues.Release()
+		rightValues := newArray([]int32{1, 0}, []bool{true, false})
+		defer rightValues.Release()
+
+		assertDifferentHash(leftValues, rightValues)
 	})
 }
 

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -724,6 +724,70 @@ func TestListScalars(t *testing.T) {
 	suite.Run(t, ls)
 }
 
+func newInt32DataArray(values []int32, validity []byte, length, offset int) *array.Int32 {
+	validityBuffer := memory.NewBufferBytes(validity)
+	valuesBuffer := memory.NewBufferBytes(arrow.Int32Traits.CastToBytes(values))
+	data := array.NewData(arrow.PrimitiveTypes.Int32, length,
+		[]*memory.Buffer{validityBuffer, valuesBuffer}, nil, array.UnknownNullCount, offset)
+	validityBuffer.Release()
+	valuesBuffer.Release()
+
+	arr := array.NewInt32Data(data)
+	data.Release()
+	return arr
+}
+
+func TestListScalarHashUsesLogicalValues(t *testing.T) {
+	seed := maphash.MakeSeed()
+	assertEqualAndSameHash := func(leftValues, rightValues arrow.Array) {
+		left := scalar.NewListScalar(leftValues)
+		right := scalar.NewListScalar(rightValues)
+		defer left.Release()
+		defer right.Release()
+
+		assert.True(t, scalar.Equals(left, right))
+		assert.Equal(t, scalar.Hash(seed, left), scalar.Hash(seed, right))
+	}
+
+	t.Run("different backing values and offsets", func(t *testing.T) {
+		leftValues := newInt32DataArray([]int32{1, 2, 3}, []byte{0x07}, 3, 0)
+		defer leftValues.Release()
+		rightValues := newInt32DataArray([]int32{9, 1, 2, 3, 8}, []byte{0xff}, 3, 1)
+		defer rightValues.Release()
+
+		assertEqualAndSameHash(leftValues, rightValues)
+	})
+
+	t.Run("different slices", func(t *testing.T) {
+		newArray := func(values []int32) *array.Int32 {
+			builder := array.NewInt32Builder(memory.DefaultAllocator)
+			defer builder.Release()
+			builder.AppendValues(values, nil)
+			return builder.NewInt32Array()
+		}
+
+		leftBase := newArray([]int32{0, 1, 2, 3, 4})
+		defer leftBase.Release()
+		leftValues := array.NewSlice(leftBase, 1, 4)
+		defer leftValues.Release()
+		rightBase := newArray([]int32{1, 2, 3, 4, 5})
+		defer rightBase.Release()
+		rightValues := array.NewSlice(rightBase, 0, 3)
+		defer rightValues.Release()
+
+		assertEqualAndSameHash(leftValues, rightValues)
+	})
+
+	t.Run("different null bitmap padding", func(t *testing.T) {
+		leftValues := newInt32DataArray([]int32{0, 1, 2, 3, 4}, []byte{0x1b}, 3, 1)
+		defer leftValues.Release()
+		rightValues := newInt32DataArray([]int32{1, 2, 3}, []byte{0xf5}, 3, 0)
+		defer rightValues.Release()
+
+		assertEqualAndSameHash(leftValues, rightValues)
+	})
+}
+
 func TestFixedSizeListScalarWrongNumber(t *testing.T) {
 	typ := arrow.FixedSizeListOf(3, arrow.PrimitiveTypes.Int16)
 	bld := array.NewInt16Builder(memory.DefaultAllocator)


### PR DESCRIPTION
### What

Hash list scalar values from their logical length, validity, and recursively hashed elements instead of physical ArrayData metadata. This keeps equal list scalars backed by independent arrays or slices on the same hash path.

### Tests

- `go test ./arrow/scalar ./arrow/array -count=1`
- `GOOS=linux GOARCH=386 go test -c -o /dev/null ./arrow/scalar`
- `pre-commit run golangci-lint-full --all-files`

Regression coverage includes independent backing arrays, zero-copy slices with different offsets, extra leading/trailing values, and different validity bitmap padding.