### PR TITLE
fix(avro): decode nullable logical timestamps

### DIFF
--- a/arrow/avro/reader_test.go
+++ b/arrow/avro/reader_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -274,6 +275,92 @@ func TestOCFReaderBytesValues(t *testing.T) {
 	nullable := rec.Column(1).(*array.Binary)
 	assert.Equal(t, payload, nullable.Value(0))
 	assert.True(t, nullable.IsNull(1))
+}
+
+func TestOCFReaderNullableLocalTimestampMicros(t *testing.T) {
+	schema := `{
+		"type": "record",
+		"name": "event",
+		"fields": [{
+			"name": "started_at",
+			"type": [
+				"null",
+				{"type": "long", "logicalType": "local-timestamp-micros"}
+			]
+		}]
+	}`
+	wantWallClock := time.Date(2026, 7, 13, 14, 15, 16, 123456000, time.FixedZone("source", 3*60*60))
+
+	var buf bytes.Buffer
+	enc, err := ocf.NewEncoder(schema, &buf)
+	assert.NoError(t, err)
+	assert.NoError(t, enc.Encode(map[string]any{
+		"started_at": map[string]any{"long.local-timestamp-micros": wantWallClock},
+	}))
+	assert.NoError(t, enc.Encode(map[string]any{"started_at": nil}))
+	assert.NoError(t, enc.Close())
+
+	ar, err := NewOCFReader(bytes.NewReader(buf.Bytes()), WithChunk(-1))
+	assert.NoError(t, err)
+	defer ar.Close()
+
+	wantType := &arrow.TimestampType{Unit: arrow.Microsecond}
+	field := ar.Schema().Field(0)
+	assert.Equal(t, wantType, field.Type)
+	assert.True(t, field.Nullable)
+
+	assert.True(t, ar.Next())
+	assert.NoError(t, ar.Err())
+	values := ar.RecordBatch().Column(0).(*array.Timestamp)
+	assert.False(t, values.IsNull(0))
+	assert.True(t, values.IsNull(1))
+	assert.Equal(t, 1, values.NullN())
+
+	wantUTCWallClock := time.Date(2026, 7, 13, 14, 15, 16, 123456000, time.UTC)
+	wantValue, err := arrow.TimestampFromTime(wantUTCWallClock, arrow.Microsecond)
+	assert.NoError(t, err)
+	assert.Equal(t, wantValue, values.Value(0))
+	assert.Equal(t, wantUTCWallClock, values.Value(0).ToTime(arrow.Microsecond))
+}
+
+func TestAppendTimestampDataUnionBranches(t *testing.T) {
+	value := time.Date(2026, 7, 13, 14, 15, 16, 123456789, time.FixedZone("source", 3*60*60))
+	localValue := time.Date(2026, 7, 13, 14, 15, 16, 123456789, time.UTC)
+	tests := []struct {
+		name   string
+		branch string
+		typ    *arrow.TimestampType
+		want   time.Time
+	}{
+		{"timestamp-millis", "long.timestamp-millis", arrow.FixedWidthTypes.Timestamp_ms.(*arrow.TimestampType), value},
+		{"timestamp-micros", "long.timestamp-micros", arrow.FixedWidthTypes.Timestamp_us.(*arrow.TimestampType), value},
+		{"local-timestamp-millis", "long.local-timestamp-millis", &arrow.TimestampType{Unit: arrow.Millisecond}, localValue},
+		{"local-timestamp-micros", "long.local-timestamp-micros", &arrow.TimestampType{Unit: arrow.Microsecond}, localValue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := array.NewTimestampBuilder(memory.DefaultAllocator, tt.typ)
+			defer b.Release()
+			appendTimestampData(b, map[string]any{tt.branch: value})
+
+			values := b.NewTimestampArray()
+			defer values.Release()
+			want, err := arrow.TimestampFromTime(tt.want, tt.typ.Unit)
+			assert.NoError(t, err)
+			assert.False(t, values.IsNull(0))
+			assert.Equal(t, want, values.Value(0))
+		})
+	}
+
+	b := array.NewTimestampBuilder(memory.DefaultAllocator, arrow.FixedWidthTypes.Timestamp_us.(*arrow.TimestampType))
+	defer b.Release()
+	appendTimestampData(b, map[string]any{"long": int64(42)})
+	appendTimestampData(b, nil)
+	values := b.NewTimestampArray()
+	defer values.Release()
+	assert.Equal(t, arrow.Timestamp(42), values.Value(0))
+	assert.True(t, values.IsNull(1))
 }
 
 // Types outside what the hamba decoder produces must error rather than append

--- a/arrow/avro/reader_test.go
+++ b/arrow/avro/reader_test.go
@@ -277,50 +277,67 @@ func TestOCFReaderBytesValues(t *testing.T) {
 	assert.True(t, nullable.IsNull(1))
 }
 
-func TestOCFReaderNullableLocalTimestampMicros(t *testing.T) {
-	schema := `{
-		"type": "record",
-		"name": "event",
-		"fields": [{
-			"name": "started_at",
-			"type": [
-				"null",
-				{"type": "long", "logicalType": "local-timestamp-micros"}
-			]
-		}]
-	}`
-	wantWallClock := time.Date(2026, 7, 13, 14, 15, 16, 123456000, time.Local)
+func TestOCFReaderNullableTimestamps(t *testing.T) {
+	tests := []struct {
+		logicalType string
+		branch      string
+		typ         *arrow.TimestampType
+	}{
+		{"timestamp-millis", "long.timestamp-millis", arrow.FixedWidthTypes.Timestamp_ms.(*arrow.TimestampType)},
+		{"timestamp-micros", "long.timestamp-micros", arrow.FixedWidthTypes.Timestamp_us.(*arrow.TimestampType)},
+		{"local-timestamp-millis", "long.local-timestamp-millis", &arrow.TimestampType{Unit: arrow.Millisecond}},
+		{"local-timestamp-micros", "long.local-timestamp-micros", &arrow.TimestampType{Unit: arrow.Microsecond}},
+	}
 
-	var buf bytes.Buffer
-	enc, err := ocf.NewEncoder(schema, &buf)
-	assert.NoError(t, err)
-	assert.NoError(t, enc.Encode(map[string]any{
-		"started_at": map[string]any{"long.local-timestamp-micros": wantWallClock},
-	}))
-	assert.NoError(t, enc.Encode(map[string]any{"started_at": nil}))
-	assert.NoError(t, enc.Close())
+	for _, tt := range tests {
+		t.Run(tt.logicalType, func(t *testing.T) {
+			schema := fmt.Sprintf(`{
+				"type": "record",
+				"name": "event",
+				"fields": [{
+					"name": "started_at",
+					"type": [
+						"null",
+						{"type": "long", "logicalType": %q}
+					]
+				}]
+			}`, tt.logicalType)
+			value := time.Date(2026, 7, 13, 14, 15, 16, 123456000, time.Local)
 
-	ar, err := NewOCFReader(bytes.NewReader(buf.Bytes()), WithChunk(-1))
-	assert.NoError(t, err)
-	defer ar.Close()
+			var buf bytes.Buffer
+			enc, err := ocf.NewEncoder(schema, &buf)
+			assert.NoError(t, err)
+			assert.NoError(t, enc.Encode(map[string]any{
+				"started_at": map[string]any{tt.branch: value},
+			}))
+			assert.NoError(t, enc.Encode(map[string]any{"started_at": nil}))
+			assert.NoError(t, enc.Close())
 
-	wantType := &arrow.TimestampType{Unit: arrow.Microsecond}
-	field := ar.Schema().Field(0)
-	assert.Equal(t, wantType, field.Type)
-	assert.True(t, field.Nullable)
+			ar, err := NewOCFReader(bytes.NewReader(buf.Bytes()), WithChunk(-1))
+			assert.NoError(t, err)
+			defer ar.Close()
 
-	assert.True(t, ar.Next())
-	assert.NoError(t, ar.Err())
-	values := ar.RecordBatch().Column(0).(*array.Timestamp)
-	assert.False(t, values.IsNull(0))
-	assert.True(t, values.IsNull(1))
-	assert.Equal(t, 1, values.NullN())
+			field := ar.Schema().Field(0)
+			assert.Equal(t, tt.typ, field.Type)
+			assert.True(t, field.Nullable)
 
-	wantUTCWallClock := time.Date(2026, 7, 13, 14, 15, 16, 123456000, time.UTC)
-	wantValue, err := arrow.TimestampFromTime(wantUTCWallClock, arrow.Microsecond)
-	assert.NoError(t, err)
-	assert.Equal(t, wantValue, values.Value(0))
-	assert.Equal(t, wantUTCWallClock, values.Value(0).ToTime(arrow.Microsecond))
+			assert.True(t, ar.Next())
+			assert.NoError(t, ar.Err())
+			values := ar.RecordBatch().Column(0).(*array.Timestamp)
+			assert.False(t, values.IsNull(0))
+			assert.True(t, values.IsNull(1))
+			assert.Equal(t, 1, values.NullN())
+
+			wantTime := value
+			if tt.typ.TimeZone == "" {
+				wantTime = time.Date(value.Year(), value.Month(), value.Day(), value.Hour(), value.Minute(), value.Second(), value.Nanosecond(), time.UTC)
+			}
+			wantValue, err := arrow.TimestampFromTime(wantTime, tt.typ.Unit)
+			assert.NoError(t, err)
+			assert.Equal(t, wantValue, values.Value(0))
+			assert.Equal(t, wantValue.ToTime(tt.typ.Unit), values.Value(0).ToTime(tt.typ.Unit))
+		})
+	}
 }
 
 func TestAppendTimestampDataUnionBranches(t *testing.T) {

--- a/arrow/avro/reader_test.go
+++ b/arrow/avro/reader_test.go
@@ -289,7 +289,7 @@ func TestOCFReaderNullableLocalTimestampMicros(t *testing.T) {
 			]
 		}]
 	}`
-	wantWallClock := time.Date(2026, 7, 13, 14, 15, 16, 123456000, time.FixedZone("source", 3*60*60))
+	wantWallClock := time.Date(2026, 7, 13, 14, 15, 16, 123456000, time.Local)
 
 	var buf bytes.Buffer
 	enc, err := ocf.NewEncoder(schema, &buf)

--- a/arrow/avro/reader_types.go
+++ b/arrow/avro/reader_types.go
@@ -970,12 +970,18 @@ func appendTimestampData(b *array.TimestampBuilder, data interface{}) {
 	case int64:
 		b.Append(arrow.Timestamp(dt))
 	case map[string]any:
-		switch v := dt["long"].(type) {
-		case nil:
-			b.AppendNull()
-		case int64:
-			b.Append(arrow.Timestamp(v))
+		for branch, value := range dt {
+			switch branch {
+			case "long",
+				"long.timestamp-millis",
+				"long.timestamp-micros",
+				"long.local-timestamp-millis",
+				"long.local-timestamp-micros":
+				appendTimestampData(b, value)
+				return
+			}
 		}
+		b.AppendNull()
 	case time.Time:
 		tt := b.Type().(*arrow.TimestampType)
 		// hamba decodes a local-timestamp logical type into a time.Time whose wall-clock


### PR DESCRIPTION
### Rationale for this change

This is a follow-up to https://github.com/apache/arrow-go/pull/832, which added support for Avro local timestamp logical types.

For nullable timestamp fields, Hamba decodes a selected logical union branch as a one-entry map such as `"long.local-timestamp-micros": time.Time`. `appendTimestampData` only inspected the plain `"long"` branch, so it treated valid non-null logical timestamp values as null.

### What changes are included in this PR?

- Recognize Hamba's exact union branch names for `timestamp-millis`, `timestamp-micros`, `local-timestamp-millis`, and `local-timestamp-micros`, while preserving plain `long` unions.
- Route decoded `time.Time` union values through the existing timestamp conversion, including UTC wall-clock reinterpretation for local timestamps.
- Add end-to-end nullable OCF coverage for all four timestamp logical types, with one non-null and one null record per type, plus focused appender coverage.

### Are these changes tested?

Yes. The regression failed before the fix because non-null logical timestamp values were appended as null. The full Avro suite passes in UTC and a non-UTC timezone:

- `TZ=UTC go test ./arrow/avro/... -count=1`
- `TZ=Asia/Jerusalem go test ./arrow/avro/... -count=1`
- `golangci-lint v2.11.3 run --timeout=5m ./arrow/avro/...`

### Are there any user-facing changes?

Yes. Non-null values in nullable Avro timestamp logical fields are now decoded as Arrow timestamps instead of null.
