### PR TITLE
fix(flight/flightsql/example): support dictionary-encoded parameter columns

### DIFF
--- a/arrow/flight/flightsql/example/sqlite_server.go
+++ b/arrow/flight/flightsql/example/sqlite_server.go
@@ -581,6 +581,18 @@ func scalarToIFace(s scalar.Scalar) (interface{}, error) {
 		return val.ToTime(), nil
 	case *scalar.DenseUnion:
 		return scalarToIFace(val.Value)
+	case *scalar.Dictionary:
+		if err := val.ValidateFull(); err != nil {
+			return nil, err
+		}
+		value, err := val.GetEncodedValue()
+		if err != nil {
+			return nil, err
+		}
+		if r, ok := value.(scalar.Releasable); ok {
+			defer r.Release()
+		}
+		return scalarToIFace(value)
 	default:
 		return nil, fmt.Errorf("unsupported type: %s", val)
 	}

--- a/arrow/flight/flightsql/sqlite_server_test.go
+++ b/arrow/flight/flightsql/sqlite_server_test.go
@@ -615,6 +615,179 @@ func (s *FlightSqliteServerSuite) TestCommandPreparedStatementUpdateWithParams()
 	s.EqualValues(4, s.execCountQuery("SELECT COUNT(*) FROM intTable"))
 }
 
+func (s *FlightSqliteServerSuite) TestCommandPreparedStatementUpdateWithDictionaryParams() {
+	ctx := context.Background()
+	stmt, err := s.cl.Prepare(ctx, "INSERT INTO intTable (keyName, value) VALUES (?, 9876)")
+	s.NoError(err)
+	defer stmt.Close(ctx)
+
+	dictType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+	// index 2 points at a null dictionary value, the last index is itself null
+	indices := s.fromJSON(arrow.PrimitiveTypes.Int32, `[0, 1, 2, null]`)
+	dict := s.fromJSON(arrow.BinaryTypes.String, `["apple", "banana", null]`)
+	paramArr := array.NewDictionaryArray(dictType, indices, dict)
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{
+		{Name: "parameter_1", Type: dictType, Nullable: true}}, nil),
+		[]arrow.Array{paramArr}, 4)
+	defer func() {
+		indices.Release()
+		dict.Release()
+		paramArr.Release()
+		batch.Release()
+	}()
+
+	stmt.SetParameters(batch)
+	s.EqualValues(4, s.execCountQuery("SELECT COUNT(*) FROM intTable"))
+	n, err := stmt.ExecuteUpdate(ctx)
+	s.NoError(err)
+	s.EqualValues(4, n)
+
+	info, err := s.cl.Execute(ctx, "SELECT keyName FROM intTable WHERE value = 9876 ORDER BY id")
+	s.NoError(err)
+	rdr, err := s.cl.DoGet(ctx, info.Endpoint[0].Ticket)
+	s.NoError(err)
+	defer rdr.Release()
+
+	expectedSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "keyName", Type: arrow.BinaryTypes.String, Metadata: s.getColMetadata(sqlite3.SQLITE_TEXT, ""), Nullable: true}}, nil)
+	keyNameArr := s.fromJSON(arrow.BinaryTypes.String, `["apple", "banana", null, null]`)
+	defer keyNameArr.Release()
+	expected := array.NewRecordBatch(expectedSchema, []arrow.Array{keyNameArr}, 4)
+	defer expected.Release()
+
+	s.True(rdr.Next())
+	rec := rdr.RecordBatch()
+	s.Truef(array.RecordEqual(expected, rec), "expected: %s\ngot: %s", expected, rec)
+	s.False(rdr.Next())
+
+	n, err = s.cl.ExecuteUpdate(ctx, "DELETE FROM intTable WHERE value = 9876")
+	s.NoError(err)
+	s.EqualValues(4, n)
+	s.EqualValues(4, s.execCountQuery("SELECT COUNT(*) FROM intTable"))
+}
+
+func (s *FlightSqliteServerSuite) TestCommandPreparedStatementUpdateWithNonStringDictionaryParams() {
+	ctx := context.Background()
+	stmt, err := s.cl.Prepare(ctx, "INSERT INTO intTable (keyName, value) VALUES ('dict_int', ?)")
+	s.NoError(err)
+	defer stmt.Close(ctx)
+
+	dictType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.PrimitiveTypes.Int64}
+	indices := s.fromJSON(arrow.PrimitiveTypes.Int32, `[1, 0]`)
+	dict := s.fromJSON(arrow.PrimitiveTypes.Int64, `[1111, 2222]`)
+	paramArr := array.NewDictionaryArray(dictType, indices, dict)
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{
+		{Name: "parameter_1", Type: dictType, Nullable: true}}, nil),
+		[]arrow.Array{paramArr}, 2)
+	defer func() {
+		indices.Release()
+		dict.Release()
+		paramArr.Release()
+		batch.Release()
+	}()
+
+	stmt.SetParameters(batch)
+	n, err := stmt.ExecuteUpdate(ctx)
+	s.NoError(err)
+	s.EqualValues(2, n)
+	s.EqualValues(1, s.execCountQuery("SELECT COUNT(*) FROM intTable WHERE keyName = 'dict_int' AND value = 1111"))
+	s.EqualValues(1, s.execCountQuery("SELECT COUNT(*) FROM intTable WHERE keyName = 'dict_int' AND value = 2222"))
+
+	n, err = s.cl.ExecuteUpdate(ctx, "DELETE FROM intTable WHERE keyName = 'dict_int'")
+	s.NoError(err)
+	s.EqualValues(2, n)
+	s.EqualValues(4, s.execCountQuery("SELECT COUNT(*) FROM intTable"))
+}
+
+func (s *FlightSqliteServerSuite) TestCommandPreparedStatementQueryWithDictionaryParams() {
+	ctx := context.Background()
+	stmt, err := s.cl.Prepare(ctx, "SELECT * FROM intTable WHERE keyName LIKE ?")
+	s.NoError(err)
+	defer stmt.Close(ctx)
+
+	dictType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+	indices := s.fromJSON(arrow.PrimitiveTypes.Int32, `[0]`)
+	dict := s.fromJSON(arrow.BinaryTypes.String, `["%one"]`)
+	paramArr := array.NewDictionaryArray(dictType, indices, dict)
+	batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{
+		{Name: "parameter_1", Type: dictType, Nullable: true}}, nil),
+		[]arrow.Array{paramArr}, 1)
+	defer func() {
+		indices.Release()
+		dict.Release()
+		paramArr.Release()
+		batch.Release()
+	}()
+
+	stmt.SetParameters(batch)
+	info, err := stmt.Execute(ctx)
+	s.NoError(err)
+	rdr, err := s.cl.DoGet(ctx, info.Endpoint[0].Ticket)
+	s.NoError(err)
+	defer rdr.Release()
+
+	expectedSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Metadata: s.getColMetadata(sqlite3.SQLITE_INTEGER, ""), Nullable: true},
+		{Name: "keyName", Type: arrow.BinaryTypes.String, Metadata: s.getColMetadata(sqlite3.SQLITE_TEXT, ""), Nullable: true},
+		{Name: "value", Type: arrow.PrimitiveTypes.Int64, Metadata: s.getColMetadata(sqlite3.SQLITE_INTEGER, ""), Nullable: true},
+		{Name: "foreignId", Type: arrow.PrimitiveTypes.Int64, Metadata: s.getColMetadata(sqlite3.SQLITE_INTEGER, ""), Nullable: true}}, nil)
+
+	idArr := s.fromJSON(arrow.PrimitiveTypes.Int64, `[1, 3]`)
+	defer idArr.Release()
+	keyNameArr := s.fromJSON(arrow.BinaryTypes.String, `["one", "negative one"]`)
+	defer keyNameArr.Release()
+	valueArr := s.fromJSON(arrow.PrimitiveTypes.Int64, `[1, -1]`)
+	defer valueArr.Release()
+	foreignIdArr := s.fromJSON(arrow.PrimitiveTypes.Int64, `[1, 1]`)
+	defer foreignIdArr.Release()
+
+	expected := array.NewRecordBatch(expectedSchema, []arrow.Array{idArr, keyNameArr, valueArr, foreignIdArr}, 2)
+	defer expected.Release()
+
+	s.True(rdr.Next())
+	rec := rdr.RecordBatch()
+	s.Truef(array.RecordEqual(expected, rec), "expected: %s\ngot: %s", expected, rec)
+	s.False(rdr.Next())
+}
+
+func (s *FlightSqliteServerSuite) TestCommandPreparedStatementDictionaryParamsInvalidIndex() {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name    string
+		indices string
+	}{
+		{"negative index", `[-1]`},
+		{"out of range index", `[2]`},
+	} {
+		s.Run(tc.name, func() {
+			stmt, err := s.cl.Prepare(ctx, "INSERT INTO intTable (keyName, value) VALUES (?, 9876)")
+			s.NoError(err)
+			defer stmt.Close(ctx)
+
+			dictType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+			indices := s.fromJSON(arrow.PrimitiveTypes.Int32, tc.indices)
+			dict := s.fromJSON(arrow.BinaryTypes.String, `["apple", "banana"]`)
+			paramArr := array.NewDictionaryArray(dictType, indices, dict)
+			batch := array.NewRecordBatch(arrow.NewSchema([]arrow.Field{
+				{Name: "parameter_1", Type: dictType, Nullable: true}}, nil),
+				[]arrow.Array{paramArr}, 1)
+			defer func() {
+				indices.Release()
+				dict.Release()
+				paramArr.Release()
+				batch.Release()
+			}()
+
+			stmt.SetParameters(batch)
+			_, err = stmt.ExecuteUpdate(ctx)
+			s.Error(err)
+			s.Contains(err.Error(), "out of bounds")
+			s.EqualValues(4, s.execCountQuery("SELECT COUNT(*) FROM intTable"))
+		})
+	}
+}
+
 func (s *FlightSqliteServerSuite) TestCommandPreparedStatementUpdate() {
 	ctx := context.Background()
 	stmt, err := s.cl.Prepare(ctx, "INSERT INTO intTable (keyName, value) VALUES ('new_value', 999)")


### PR DESCRIPTION
**DISCLAIMER**: Most of this code was AI generated, but reviewed by me and I'm ready to answer questions, make changes or look into details.

When a client binds a dictionary-encoded parameter column to a prepared statement (e.g. a pyarrow `dictionary<values=string, indices=int32>` array bound via the ADBC Flight SQL driver), the example SQLite server failed with:

    error gathering parameters for prepared statement: unsupported
    type: ["apple" "banana"][0] (Internal; ExecuteQuery)

Dictionary encoding is an encoding, not a distinct logical type, so decode each value via the dictionary and bind the underlying value exactly as if the column were of the plain values type.

Dictionary encoding for parameters works with with e.g. the sqlite and postgresql adbc driver.

Proposed test in the ADBC driver validation suite that will test this: https://github.com/adbc-drivers/validation/pull/256