### PR TITLE
fix(arrow/scalar): reject negative indices in GetScalar

### DIFF
--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -574,13 +574,13 @@ func init() {
 // GetScalar creates a scalar object from the value at a given index in the
 // passed in array, returns an error if unable to do so.
 func GetScalar(arr arrow.Array, idx int) (Scalar, error) {
-	if arr.DataType().ID() != arrow.DICTIONARY && arr.IsNull(idx) {
-		return MakeNullScalar(arr.DataType()), nil
+	if idx < 0 || idx >= arr.Len() {
+		return nil, fmt.Errorf("%w: called GetScalar with index out of range",
+			arrow.ErrIndex)
 	}
 
-	if idx >= arr.Len() {
-		return nil, fmt.Errorf("%w: called GetScalar with index larger than array len",
-			arrow.ErrIndex)
+	if arr.DataType().ID() != arrow.DICTIONARY && arr.IsNull(idx) {
+		return MakeNullScalar(arr.DataType()), nil
 	}
 
 	switch arr := arr.(type) {

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -1110,6 +1110,19 @@ func TestDictionaryScalarBasics(t *testing.T) {
 	}
 }
 
+func TestGetScalarIndexOutOfRange(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	arr, _, _ := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["alpha", "beta"]`))
+	defer arr.Release()
+
+	_, err := scalar.GetScalar(arr, -1)
+	assert.ErrorIs(t, err, arrow.ErrIndex)
+	_, err = scalar.GetScalar(arr, 2)
+	assert.ErrorIs(t, err, arrow.ErrIndex)
+}
+
 func TestDictionaryScalarValidateErrors(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)


### PR DESCRIPTION
`GetScalar` only guarded the upper bound (`idx >= arr.Len()`), and the `IsNull(idx)` call ran before that check, so a negative index panicked inside the null-bitmap lookup instead of returning an error.

Check both bounds first and return `arrow.ErrIndex` for any out-of-range index.

Split out from review comment in #936.