### PR TITLE
fix(flight): reject malformed unary bearer headers

### DIFF
--- a/arrow/flight/basic_auth_flight_test.go
+++ b/arrow/flight/basic_auth_flight_test.go
@@ -151,6 +151,27 @@ func TestErrorAuths(t *testing.T) {
 			t.Fatal("should have errored")
 		}
 	})
+
+	for _, auth := range []string{"", "Bearer", "Bearer ", "BearerX token"} {
+		t.Run("malformed unary auth "+auth, func(t *testing.T) {
+			ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("authorization", auth))
+			_, err := client.GetSchema(ctx, &flight.FlightDescriptor{})
+			if status.Code(err) != codes.Unauthenticated {
+				t.Fatalf("expected unauthenticated error, got %v", err)
+			}
+		})
+	}
+
+	t.Run("unary auth with multiple spaces", func(t *testing.T) {
+		ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("authorization", "Bearer   "+validBearer))
+		result, err := client.GetSchema(ctx, &flight.FlightDescriptor{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := string(result.Schema), "carebears"; got != want {
+			t.Fatalf("unexpected schema: got %q, want %q", got, want)
+		}
+	})
 }
 
 func TestBasicAuthHelpers(t *testing.T) {

--- a/arrow/flight/server_auth.go
+++ b/arrow/flight/server_auth.go
@@ -150,16 +150,21 @@ type BasicAuthValidator interface {
 
 func createServerBearerTokenUnaryInterceptor(validator BasicAuthValidator) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		var auth string
+		var scheme, credential string
 		md, ok := metadata.FromIncomingContext(ctx)
 		if ok {
 			vals := md.Get(basicAuthHeader)
-			if len(vals) > 0 && strings.HasPrefix(vals[0], bearerTokenPrefix) {
-				auth = vals[0][len(bearerTokenPrefix)+1:]
+			if len(vals) > 0 {
+				scheme, credential, _ = strings.Cut(strings.TrimSpace(vals[0]), " ")
+				credential = strings.TrimLeft(credential, " ")
 			}
 		}
 
-		identity, err := validator.IsValid(auth)
+		if scheme != bearerTokenPrefix || credential == "" {
+			return nil, status.Error(codes.Unauthenticated, "must authenticate first")
+		}
+
+		identity, err := validator.IsValid(credential)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Rationale for this change

The unary bearer interceptor used a prefix check and then sliced past an assumed space. An authorization value containing exactly `Bearer` could therefore panic, while values such as `BearerX token` were treated as bearer credentials.

### What changes are included in this PR?

Parse the authorization scheme and credential separately, require the exact Bearer scheme and a non-empty credential, and reject malformed headers before invoking the validator. Additional spaces before the credential are accepted.

### Are these changes tested?

Yes. Regression coverage includes missing headers, missing credentials, malformed schemes, and valid credentials separated by multiple spaces. `go test ./arrow/flight` and the race-enabled package test pass.

### Are there any user-facing changes?

Missing or malformed bearer headers now return Unauthenticated instead of reaching the validator or panicking. Multiple spaces after the scheme are accepted.