### PR TITLE
fix(flight): reject Basic credentials without a separator

### DIFF
--- a/arrow/flight/basic_auth_flight_test.go
+++ b/arrow/flight/basic_auth_flight_test.go
@@ -18,6 +18,7 @@ package flight_test
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"io"
 	"testing"
@@ -32,7 +33,7 @@ import (
 
 const (
 	validUsername   = "flight_username"
-	validPassword   = "flight_password"
+	validPassword   = "flight_password:with_colon"
 	invalidUsername = "invalid_flight_username"
 	invalidPassword = "invalid_flight_password"
 	validBearer     = "CAREBARESTARE"
@@ -247,5 +248,32 @@ func TestBasicAuthMissingCredential(t *testing.T) {
 	}
 	if got, want := st.Code(), codes.Unauthenticated; got != want {
 		t.Fatalf("unexpected code: got %v, want %v", got, want)
+	}
+}
+
+func TestBasicAuthMalformedCredentials(t *testing.T) {
+	s := flight.NewServerWithMiddleware([]flight.ServerMiddleware{flight.CreateServerBasicAuthMiddleware(&validator{})})
+	s.Init("localhost:0")
+	s.RegisterFlightService(&HeaderAuthTestFlight{})
+	go s.Serve()
+	defer s.Shutdown()
+
+	client, err := flight.NewFlightClient(s.Addr().String(), nil, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, credentials := range []string{"", "username-only", ":password", "username:"} {
+		t.Run(credentials, func(t *testing.T) {
+			encoded := base64.StdEncoding.EncodeToString([]byte(credentials))
+			ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("authorization", "Basic "+encoded))
+			stream, err := client.Handshake(ctx)
+			if err == nil {
+				_, err = stream.Recv()
+			}
+			if status.Code(err) != codes.Unauthenticated {
+				t.Fatalf("expected unauthenticated error, got %v", err)
+			}
+		})
 	}
 }

--- a/arrow/flight/server_auth.go
+++ b/arrow/flight/server_auth.go
@@ -195,8 +195,11 @@ func createServerBearerTokenStreamInterceptor(validator BasicAuthValidator) grpc
 					}
 				}
 
-				creds := strings.SplitN(string(val), ":", 2)
-				token, err := validator.Validate(creds[0], creds[1])
+				username, password, found := strings.Cut(string(val), ":")
+				if !found {
+					return status.Error(codes.Unauthenticated, "invalid basic auth credentials")
+				}
+				token, err := validator.Validate(username, password)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
### Rationale for this change

A valid Base64 Basic credential without a colon decoded to a one-element slice. The streaming authentication interceptor then indexed the missing password and panicked.

### What changes are included in this PR?

Use `strings.Cut` to split the decoded username and password, and return an Unauthenticated error when the separator is absent. Empty usernames and passwords remain validator policy.

### Are these changes tested?

Yes. Regression cases cover empty input, a username without a separator, empty username/password values, and passwords containing additional colons. `go test ./arrow/flight` passes.

### Are there any user-facing changes?

Malformed Basic credentials now return Unauthenticated instead of panicking.