### PR TITLE
fix(parquet): limit page allocations

### DIFF
--- a/parquet/file/page_reader.go
+++ b/parquet/file/page_reader.go
@@ -421,9 +421,11 @@ type serializedPageReader struct {
 	maxRepLevel     int16
 	maxDefLevel     int16
 
-	curPageHdr        *format.PageHeader
-	pageOrd           int16
-	maxPageHeaderSize int
+	curPageHdr              *format.PageHeader
+	pageOrd                 int16
+	maxPageHeaderSize       int
+	maxCompressedPageSize   int64
+	maxUncompressedPageSize int64
 
 	curPage           Page
 	cryptoCtx         CryptoContext
@@ -502,11 +504,13 @@ func NewPageReader(r parquet.BufferedReader, nrows int64, compressType compress.
 	}
 
 	rdr := &serializedPageReader{
-		r:                 r,
-		maxPageHeaderSize: defaultMaxPageHeaderSize,
-		nrows:             nrows,
-		mem:               mem,
-		codec:             codec,
+		r:                       r,
+		maxPageHeaderSize:       defaultMaxPageHeaderSize,
+		nrows:                   nrows,
+		mem:                     mem,
+		codec:                   codec,
+		maxCompressedPageSize:   parquet.DefaultMaxCompressedPageSize,
+		maxUncompressedPageSize: parquet.DefaultMaxUncompressedPageSize,
 
 		decompressBuffer: memory.NewResizableBuffer(mem),
 		dataPageBuffer:   memory.NewResizableBuffer(mem),
@@ -547,6 +551,21 @@ func (p *serializedPageReader) Err() error { return p.err }
 
 func (p *serializedPageReader) SetMaxPageHeaderSize(sz int) {
 	p.maxPageHeaderSize = sz
+}
+
+func (p *serializedPageReader) validatePageSizes(hdr *format.PageHeader) (int, int, error) {
+	compressed := int64(hdr.GetCompressedPageSize())
+	uncompressed := int64(hdr.GetUncompressedPageSize())
+	if compressed < 0 || uncompressed < 0 {
+		return 0, 0, errors.New("parquet: invalid page header (negative page size)")
+	}
+	if compressed > p.maxCompressedPageSize {
+		return 0, 0, fmt.Errorf("parquet: compressed page size %d exceeds configured limit %d", compressed, p.maxCompressedPageSize)
+	}
+	if uncompressed > p.maxUncompressedPageSize {
+		return 0, 0, fmt.Errorf("parquet: uncompressed page size %d exceeds configured limit %d", uncompressed, p.maxUncompressedPageSize)
+	}
+	return int(compressed), int(uncompressed), nil
 }
 
 func (p *serializedPageReader) initDecryption() {
@@ -726,10 +745,9 @@ func (p *serializedPageReader) GetDictionaryPage() (*DictionaryPage, error) {
 			p.updateDecryption(p.cryptoCtx.DataDecryptor, encryption.DictPageModule, p.dataPageAad)
 		}
 
-		lenCompressed := int(hdr.GetCompressedPageSize())
-		lenUncompressed := int(hdr.GetUncompressedPageSize())
-		if lenCompressed < 0 || lenUncompressed < 0 {
-			return nil, errors.New("parquet: invalid page header")
+		lenCompressed, lenUncompressed, err := p.validatePageSizes(hdr)
+		if err != nil {
+			return nil, err
 		}
 
 		p.cryptoCtx.StartDecryptWithDictionaryPage = false
@@ -958,10 +976,9 @@ func (p *serializedPageReader) Next() bool {
 			return false
 		}
 
-		lenCompressed := int(p.curPageHdr.GetCompressedPageSize())
-		lenUncompressed := int(p.curPageHdr.GetUncompressedPageSize())
-		if lenCompressed < 0 || lenUncompressed < 0 {
-			p.err = errors.New("parquet: invalid page header")
+		lenCompressed, lenUncompressed, err := p.validatePageSizes(p.curPageHdr)
+		if err != nil {
+			p.err = err
 			return false
 		}
 

--- a/parquet/file/page_reader_internal_test.go
+++ b/parquet/file/page_reader_internal_test.go
@@ -19,12 +19,43 @@ package file
 import (
 	"bytes"
 	"encoding/binary"
+	"math"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPageReaderRejectsOversizedPages(t *testing.T) {
+	p := &serializedPageReader{
+		maxCompressedPageSize:   64,
+		maxUncompressedPageSize: 128,
+	}
+
+	tests := []struct {
+		name         string
+		compressed   int32
+		uncompressed int32
+		match        string
+	}{
+		{"compressed", 65, 128, "compressed page size 65 exceeds configured limit 64"},
+		{"uncompressed", 1, 129, "uncompressed page size 129 exceeds configured limit 128"},
+		{"maximum int32", math.MaxInt32, math.MaxInt32, "exceeds configured limit"},
+		{"negative", -1, 1, "negative page size"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hdr := format.NewPageHeader()
+			hdr.CompressedPageSize = tt.compressed
+			hdr.UncompressedPageSize = tt.uncompressed
+
+			_, _, err := p.validatePageSizes(hdr)
+			require.ErrorContains(t, err, tt.match)
+		})
+	}
+}
 
 func TestReadLevelDataRLELengthBound(t *testing.T) {
 	p := &serializedPageReader{maxDefLevel: 1, mem: memory.DefaultAllocator}

--- a/parquet/file/row_group_reader.go
+++ b/parquet/file/row_group_reader.go
@@ -124,13 +124,15 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 	if cryptoMetadata == nil {
 		descr := r.fileMetadata.Schema.Column(i)
 		pr := &serializedPageReader{
-			r:                 stream,
-			chunk:             col,
-			colIdx:            i,
-			pgIndexReader:     rgIdxRdr,
-			maxPageHeaderSize: defaultMaxPageHeaderSize,
-			nrows:             col.NumValues(),
-			mem:               r.props.Allocator(),
+			r:                       stream,
+			chunk:                   col,
+			colIdx:                  i,
+			pgIndexReader:           rgIdxRdr,
+			maxPageHeaderSize:       defaultMaxPageHeaderSize,
+			nrows:                   col.NumValues(),
+			mem:                     r.props.Allocator(),
+			maxCompressedPageSize:   r.props.GetMaxCompressedPageSize(),
+			maxUncompressedPageSize: r.props.GetMaxUncompressedPageSize(),
 			// Streaming (PageStreamingEnabled) inputs; only the unencrypted path is
 			// ever streaming-eligible, so columnCanStream is left false elsewhere.
 			columnCanStream: r.props.PageStreamingEnabled &&
@@ -160,14 +162,16 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 			DataDecryptor:                  r.fileDecryptor.GetFooterDecryptorForColumnData(""),
 		}
 		pr := &serializedPageReader{
-			r:                 stream,
-			chunk:             col,
-			colIdx:            i,
-			pgIndexReader:     rgIdxRdr,
-			maxPageHeaderSize: defaultMaxPageHeaderSize,
-			nrows:             col.NumValues(),
-			mem:               r.props.Allocator(),
-			cryptoCtx:         ctx,
+			r:                       stream,
+			chunk:                   col,
+			colIdx:                  i,
+			pgIndexReader:           rgIdxRdr,
+			maxPageHeaderSize:       defaultMaxPageHeaderSize,
+			nrows:                   col.NumValues(),
+			mem:                     r.props.Allocator(),
+			maxCompressedPageSize:   r.props.GetMaxCompressedPageSize(),
+			maxUncompressedPageSize: r.props.GetMaxUncompressedPageSize(),
+			cryptoCtx:               ctx,
 		}
 		return pr, pr.init(col.Compression(), &ctx)
 	}
@@ -184,14 +188,16 @@ func (r *RowGroupReader) GetColumnPageReader(i int) (PageReader, error) {
 		DataDecryptor:                  r.fileDecryptor.GetColumnDataDecryptor(parquet.ColumnPath(columnPath).String(), string(columnKeyMeta), ""),
 	}
 	pr := &serializedPageReader{
-		r:                 stream,
-		chunk:             col,
-		colIdx:            i,
-		pgIndexReader:     rgIdxRdr,
-		maxPageHeaderSize: defaultMaxPageHeaderSize,
-		nrows:             col.NumValues(),
-		mem:               r.props.Allocator(),
-		cryptoCtx:         ctx,
+		r:                       stream,
+		chunk:                   col,
+		colIdx:                  i,
+		pgIndexReader:           rgIdxRdr,
+		maxPageHeaderSize:       defaultMaxPageHeaderSize,
+		nrows:                   col.NumValues(),
+		mem:                     r.props.Allocator(),
+		maxCompressedPageSize:   r.props.GetMaxCompressedPageSize(),
+		maxUncompressedPageSize: r.props.GetMaxUncompressedPageSize(),
+		cryptoCtx:               ctx,
 	}
 	return pr, pr.init(col.Compression(), &ctx)
 }

--- a/parquet/reader_properties.go
+++ b/parquet/reader_properties.go
@@ -24,6 +24,15 @@ import (
 	"github.com/apache/arrow-go/v18/internal/utils"
 )
 
+const (
+	// DefaultMaxCompressedPageSize is the largest compressed page body accepted
+	// by readers created with NewReaderProperties.
+	DefaultMaxCompressedPageSize int64 = 64 * 1024 * 1024
+	// DefaultMaxUncompressedPageSize is the largest uncompressed page body
+	// accepted by readers created with NewReaderProperties.
+	DefaultMaxUncompressedPageSize int64 = 256 * 1024 * 1024
+)
+
 // ReaderProperties are used to define how the file reader will handle buffering and allocating buffers
 type ReaderProperties struct {
 	alloc memory.Allocator
@@ -60,6 +69,12 @@ type ReaderProperties struct {
 	// level region; the decoded values read through RowGroup.Column()/ReadBatch are the
 	// same as without streaming.
 	PageStreamingEnabled bool
+	// MaxCompressedPageSize limits the compressed body size declared by a page
+	// header. Values less than or equal to zero use DefaultMaxCompressedPageSize.
+	MaxCompressedPageSize int64
+	// MaxUncompressedPageSize limits the uncompressed body size declared by a
+	// page header. Values less than or equal to zero use DefaultMaxUncompressedPageSize.
+	MaxUncompressedPageSize int64
 }
 
 type BufferedReader interface {
@@ -78,11 +93,32 @@ func NewReaderProperties(alloc memory.Allocator) *ReaderProperties {
 	if alloc == nil {
 		alloc = memory.DefaultAllocator
 	}
-	return &ReaderProperties{alloc: alloc, BufferSize: DefaultBufSize}
+	return &ReaderProperties{
+		alloc:                   alloc,
+		BufferSize:              DefaultBufSize,
+		MaxCompressedPageSize:   DefaultMaxCompressedPageSize,
+		MaxUncompressedPageSize: DefaultMaxUncompressedPageSize,
+	}
 }
 
 // Allocator returns the allocator that the properties were initialized with
 func (r *ReaderProperties) Allocator() memory.Allocator { return r.alloc }
+
+// GetMaxCompressedPageSize returns the configured compressed page limit.
+func (r *ReaderProperties) GetMaxCompressedPageSize() int64 {
+	if r.MaxCompressedPageSize <= 0 {
+		return DefaultMaxCompressedPageSize
+	}
+	return r.MaxCompressedPageSize
+}
+
+// GetMaxUncompressedPageSize returns the configured uncompressed page limit.
+func (r *ReaderProperties) GetMaxUncompressedPageSize() int64 {
+	if r.MaxUncompressedPageSize <= 0 {
+		return DefaultMaxUncompressedPageSize
+	}
+	return r.MaxUncompressedPageSize
+}
 
 // GetStream returns a section of the underlying reader based on whether or not BufferedStream is enabled.
 //


### PR DESCRIPTION
### Rationale for this change

Parquet page sizes come from file metadata and are used to resize buffers. Positive int32 values can request multi-gigabyte allocations before decoding proves that the page is usable.

Refs #950

### What changes are included in this PR?

- Add configurable compressed and uncompressed page-size limits to ReaderProperties.
- Use defaults of 64 MiB compressed and 256 MiB uncompressed.
- Apply the limits to dictionary pages and data page versions 1 and 2 before buffer allocation or decompression.
- Preserve explicit overrides for workloads with unusually large valid pages.
- Apply the same limits to encrypted and unencrypted column readers.

### Are these changes tested?

Yes. Focused tests cover compressed, uncompressed, negative, and math.MaxInt32 declarations. Page-reader tests and vet checks pass.

The full Parquet suite also requires the external parquet-testing data checkout, which is not present in this environment.

### Are there any user-facing changes?

Readers now reject pages above the default limits. Applications that intentionally read larger pages can raise MaxCompressedPageSize and MaxUncompressedPageSize in ReaderProperties.
