### PR TITLE
fix(parquet): return decompression errors

### DIFF
--- a/parquet/compress/brotli.go
+++ b/parquet/compress/brotli.go
@@ -18,6 +18,7 @@ package compress
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/andybalholm/brotli"
@@ -56,6 +57,14 @@ func (b brotliCodec) Encode(dst, src []byte) []byte {
 }
 
 func (brotliCodec) Decode(dst, src []byte) []byte {
+	dst, err := (brotliCodec{}).DecodeWithError(dst, src)
+	if err != nil {
+		panic(err)
+	}
+	return dst
+}
+
+func (brotliCodec) DecodeWithError(dst, src []byte) ([]byte, error) {
 	rdr := brotli.NewReader(bytes.NewReader(src))
 	if dst != nil {
 		var (
@@ -68,17 +77,26 @@ func (brotliCodec) Decode(dst, src []byte) []byte {
 			sofar += n
 		}
 		if err != nil && err != io.EOF {
-			panic(err)
+			return nil, err
 		}
-		return dst[:sofar]
+		if sofar == len(dst) {
+			var extra [1]byte
+			if n, err := rdr.Read(extra[:]); n != 0 || err != io.EOF {
+				if err != nil {
+					return nil, err
+				}
+				return nil, fmt.Errorf("codec: brotli: decoded data exceeds destination size %d", len(dst))
+			}
+		}
+		return dst[:sofar], nil
 	}
 
 	dst, err := io.ReadAll(rdr)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return dst
+	return dst, nil
 }
 
 // taken from brotli/enc/encode.c:1426

--- a/parquet/compress/compress.go
+++ b/parquet/compress/compress.go
@@ -94,6 +94,34 @@ type Codec interface {
 	Decode(dst, src []byte) []byte
 }
 
+// ErrorCodec is implemented by codecs that can report block decoding errors.
+// It is optional so codecs registered by existing users remain compatible.
+type ErrorCodec interface {
+	Codec
+	DecodeWithError(dst, src []byte) ([]byte, error)
+}
+
+// Decode decodes a block and returns malformed-input errors instead of panicking.
+// Codecs that do not implement ErrorCodec are protected by a panic recovery for
+// backwards compatibility with the original Codec interface.
+func Decode(codec Codec, dst, src []byte) (decoded []byte, err error) {
+	if codec, ok := codec.(ErrorCodec); ok {
+		return codec.DecodeWithError(dst, src)
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			switch recovered := recovered.(type) {
+			case error:
+				err = recovered
+			default:
+				err = fmt.Errorf("parquet/compress: decode failed: %v", recovered)
+			}
+		}
+	}()
+	return codec.Decode(dst, src), nil
+}
+
 // StreamingCodec is an interface that may be implemented for compression codecs that expose a streaming API.
 type StreamingCodec interface {
 	// NewReader provides a reader that wraps a stream with compressed data to stream the uncompressed data
@@ -141,6 +169,10 @@ func (nocodec) Decode(dst, src []byte) []byte {
 		copy(dst, src)
 	}
 	return dst
+}
+
+func (n nocodec) DecodeWithError(dst, src []byte) ([]byte, error) {
+	return n.Decode(dst, src), nil
 }
 
 type writerNopCloser struct {

--- a/parquet/compress/compress_test.go
+++ b/parquet/compress/compress_test.go
@@ -18,6 +18,7 @@ package compress_test
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"math/rand"
 	"sync"
@@ -28,6 +29,10 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 )
+
+type panickingCodec struct{ compress.Codec }
+
+func (panickingCodec) Decode([]byte, []byte) []byte { panic(errors.New("invalid block")) }
 
 const (
 	RandomDataSize       = 3 * 1024 * 1024
@@ -58,6 +63,29 @@ func TestErrorForUnimplemented(t *testing.T) {
 
 	_, err = compress.GetCodec(compress.Codecs.Lz4)
 	assert.Error(t, err)
+}
+
+func TestDecodeReturnsMalformedInputErrors(t *testing.T) {
+	for _, compression := range []compress.Compression{
+		compress.Codecs.Snappy,
+		compress.Codecs.Gzip,
+		compress.Codecs.Brotli,
+		compress.Codecs.Zstd,
+		compress.Codecs.Lz4Raw,
+	} {
+		t.Run(compression.String(), func(t *testing.T) {
+			codec, err := compress.GetCodec(compression)
+			assert.NoError(t, err)
+
+			_, err = compress.Decode(codec, make([]byte, 32), []byte("not compressed data"))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestDecodeRecoversLegacyCodecPanic(t *testing.T) {
+	_, err := compress.Decode(panickingCodec{}, nil, nil)
+	assert.EqualError(t, err, "invalid block")
 }
 
 func TestCompressDataOneShot(t *testing.T) {

--- a/parquet/compress/gzip.go
+++ b/parquet/compress/gzip.go
@@ -41,25 +41,41 @@ func (gzipCodec) NewReader(r io.Reader) io.ReadCloser {
 }
 
 func (gzipCodec) Decode(dst, src []byte) []byte {
-	rdr, err := gzip.NewReader(bytes.NewReader(src))
+	dst, err := (gzipCodec{}).DecodeWithError(dst, src)
 	if err != nil {
 		panic(err)
 	}
+	return dst
+}
+
+func (gzipCodec) DecodeWithError(dst, src []byte) ([]byte, error) {
+	rdr, err := gzip.NewReader(bytes.NewReader(src))
+	if err != nil {
+		return nil, err
+	}
+	defer rdr.Close()
 
 	if dst != nil {
 		n, err := io.ReadFull(rdr, dst)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
-		return dst[:n]
+		var extra [1]byte
+		if nExtra, err := rdr.Read(extra[:]); nExtra != 0 || err != io.EOF {
+			if err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("codec: gzip: decoded data exceeds destination size %d", len(dst))
+		}
+		return dst[:n], nil
 	}
 
 	dst, err = io.ReadAll(rdr)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return dst
+	return dst, nil
 }
 
 func (g gzipCodec) EncodeLevel(dst, src []byte, level int) []byte {

--- a/parquet/compress/lz4_raw.go
+++ b/parquet/compress/lz4_raw.go
@@ -49,12 +49,20 @@ func (c lz4RawCodec) EncodeLevel(dst, src []byte, _ int) []byte {
 }
 
 func (lz4RawCodec) Decode(dst, src []byte) []byte {
-	n, err := lz4.UncompressBlock(src, dst)
+	dst, err := (lz4RawCodec{}).DecodeWithError(dst, src)
 	if err != nil {
 		panic(err)
 	}
+	return dst
+}
 
-	return dst[:n]
+func (lz4RawCodec) DecodeWithError(dst, src []byte) ([]byte, error) {
+	n, err := lz4.UncompressBlock(src, dst)
+	if err != nil {
+		return nil, err
+	}
+
+	return dst[:n], nil
 }
 
 func (c lz4RawCodec) CompressBound(len int64) int64 {

--- a/parquet/compress/snappy.go
+++ b/parquet/compress/snappy.go
@@ -33,11 +33,15 @@ func (snappyCodec) EncodeLevel(dst, src []byte, _ int) []byte {
 }
 
 func (snappyCodec) Decode(dst, src []byte) []byte {
-	dst, err := snappy.Decode(dst, src)
+	dst, err := (snappyCodec{}).DecodeWithError(dst, src)
 	if err != nil {
 		panic(err)
 	}
 	return dst
+}
+
+func (snappyCodec) DecodeWithError(dst, src []byte) ([]byte, error) {
+	return snappy.Decode(dst, src)
 }
 
 func (snappyCodec) NewReader(r io.Reader) io.ReadCloser {

--- a/parquet/compress/zstd.go
+++ b/parquet/compress/zstd.go
@@ -105,11 +105,16 @@ func getdecoder() *zstd.Decoder {
 }
 
 func (zstdCodec) Decode(dst, src []byte) []byte {
-	dst, err := getdecoder().DecodeAll(src, dst[:0])
+	dst, err := (zstdCodec{}).DecodeWithError(dst, src)
 	if err != nil {
 		panic(err)
 	}
 	return dst
+}
+
+func (zstdCodec) DecodeWithError(dst, src []byte) ([]byte, error) {
+	dst, err := getdecoder().DecodeAll(src, dst[:0])
+	return dst, err
 }
 
 var globalDecoderPool = sync.Pool{

--- a/parquet/file/page_reader.go
+++ b/parquet/file/page_reader.go
@@ -592,7 +592,11 @@ func (p *serializedPageReader) decompress(rd io.Reader, lenCompressed int, buf [
 		data = p.cryptoCtx.DataDecryptor.Decrypt(data)
 	}
 
-	return p.codec.Decode(buf, data), nil
+	decoded, err := compress.Decode(p.codec, buf, data)
+	if err != nil {
+		return nil, fmt.Errorf("parquet: could not decompress page: %w", err)
+	}
+	return decoded, nil
 }
 
 func (p *serializedPageReader) readV2Encrypted(rd io.Reader, lenCompressed int, lenUncompressed int, levelsBytelen int, compressed bool, buf []byte) (int, error) {
@@ -633,7 +637,10 @@ func (p *serializedPageReader) readV2Encrypted(rd io.Reader, lenCompressed int, 
 		}
 		data = data[levelsBytelen:]
 	}
-	decoded := p.codec.Decode(buf[levelsBytelen:], data)
+	decoded, err := compress.Decode(p.codec, buf[levelsBytelen:], data)
+	if err != nil {
+		return n, fmt.Errorf("parquet: could not decompress data page: %w", err)
+	}
 	if len(decoded) != lenUncompressed-levelsBytelen {
 		return levelsBytelen + len(decoded), fmt.Errorf("parquet: metadata said %d bytes uncompressed data page, got %d bytes", lenUncompressed, levelsBytelen+len(decoded))
 	}


### PR DESCRIPTION
### Rationale for this change

Malformed compressed page data should be reported as a Parquet read error, but the existing block codec API has no error return and built-in codecs panic on decode failures.

Refs #949

### What changes are included in this PR?

- Add an optional ErrorCodec interface and a safe Decode adapter without breaking existing registered codecs.
- Implement error-returning block decoding for Snappy, Gzip, Brotli, Zstd, LZ4_RAW, and the uncompressed codec.
- Recover decode panics from legacy custom codecs in one compatibility adapter.
- Route Parquet page decompression through the adapter and add contextual errors.
- Validate complete gzip and Brotli output, including checksum and trailing output when a destination is supplied.

### Are these changes tested?

Yes. Tests cover malformed input for every built-in compressed block codec and panic recovery for a legacy codec. The compression package passes its race test, and focused page-reader tests pass.

### Are there any user-facing changes?

The API change is additive. Existing Codec implementations continue to compile, while codecs can implement ErrorCodec to return decoding failures directly. File reads now return malformed-compression errors instead of exposing codec panics.
