### PR TITLE
ci: shard the benchmark workflow across parallel jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,36 +23,81 @@ on:
     paths:
       - ".github/workflows/benchmark.yml"
       - "ci/scripts/bench.sh"
+      - "ci/scripts/bench_shard.sh"
       - "ci/scripts/bench_adapt.py"
   workflow_dispatch:
 permissions:
   contents: read
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.shards.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Compute benchmark shards
+        id: shards
+        run: echo "matrix=$(bash ci/scripts/bench_shard.sh 6)" >> "$GITHUB_OUTPUT"
   benchmark:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        go: ['1.26.1']
-        arch: ['amd64']
+        include: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
         with:
           submodules: recursive
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.9'
-      - name: Install Go ${{ matrix.go }} for Benchmarks
+      - name: Install Go for Benchmarks
         uses: actions/setup-go@v6.5.0
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.26.1'
           cache: true
           cache-dependency-path: go.sum
           check-latest: false
-      - name: Run Benchmarks
-        if: github.event_name != 'push'
-        run: bash ci/scripts/bench.sh $(pwd) --json
+      - name: Run benchmark shard ${{ matrix.id }}
+        run: bash ci/scripts/bench.sh "$(pwd)" --run --packages "${{ matrix.packages }}" --out "bench_stat_${{ matrix.id }}.dat"
+      - name: Upload shard results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-dat-${{ matrix.id }}
+          path: bench_stat_${{ matrix.id }}.dat
+          if-no-files-found: error
+          retention-days: 1
+  combine:
+    needs: benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Install Go for Benchmarks
+        uses: actions/setup-go@v6.5.0
+        with:
+          go-version: '1.26.1'
+          cache: true
+          cache-dependency-path: go.sum
+          check-latest: false
+      - name: Download shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bench-dat-*
+          path: bench-dat
+          merge-multiple: true
+      - name: Combine shard results
+        run: bash ci/scripts/bench.sh "$(pwd)" --aggregate --dat "bench-dat/bench_stat_*.dat" --json-out bench_stats.json
+      - name: Upload combined results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-stats-json
+          path: bench_stats.json
+      - name: Set up Python
+        if: github.event_name == 'push' && github.repository == 'apache/arrow-go' && github.ref_name == 'main'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.9'
       - name: Upload results
         if: github.event_name == 'push' && github.repository == 'apache/arrow-go' && github.ref_name == 'main'
         env:
@@ -60,7 +105,7 @@ jobs:
           CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
           CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASS }}
           CONBENCH_REF: ${{ github.ref_name }}
-          CONBENCH_MACHINE_INFO_NAME: ${{ matrix.arch }}-debian-12
+          CONBENCH_MACHINE_INFO_NAME: amd64-debian-12
         run: |
           python3 -m pip install benchadapt@git+https://github.com/conbench/conbench.git@3af4a55206ad3918762cc8dd7d3012eadbe96a54#subdirectory=benchadapt/python
           python3 ci/scripts/bench_adapt.py

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,36 +23,81 @@ on:
     paths:
       - ".github/workflows/benchmark.yml"
       - "ci/scripts/bench.sh"
+      - "ci/scripts/bench_shard.sh"
       - "ci/scripts/bench_adapt.py"
   workflow_dispatch:
 permissions:
   contents: read
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.shards.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+      - name: Compute benchmark shards
+        id: shards
+        run: echo "matrix=$(bash ci/scripts/bench_shard.sh 6)" >> "$GITHUB_OUTPUT"
   benchmark:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        go: ['1.26.1']
-        arch: ['amd64']
+        include: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
         with:
           submodules: recursive
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: '3.9'
-      - name: Install Go ${{ matrix.go }} for Benchmarks
+      - name: Install Go for Benchmarks
         uses: actions/setup-go@v7.0.0
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.26.1'
           cache: true
           cache-dependency-path: go.sum
           check-latest: false
-      - name: Run Benchmarks
-        if: github.event_name != 'push'
-        run: bash ci/scripts/bench.sh $(pwd) --json
+      - name: Run benchmark shard ${{ matrix.id }}
+        run: bash ci/scripts/bench.sh "$(pwd)" --run --packages "${{ matrix.packages }}" --out "bench_stat_${{ matrix.id }}.dat"
+      - name: Upload shard results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-dat-${{ matrix.id }}
+          path: bench_stat_${{ matrix.id }}.dat
+          if-no-files-found: error
+          retention-days: 1
+  combine:
+    needs: benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+      - name: Install Go for Benchmarks
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version: '1.26.1'
+          cache: true
+          cache-dependency-path: go.sum
+          check-latest: false
+      - name: Download shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bench-dat-*
+          path: bench-dat
+          merge-multiple: true
+      - name: Combine shard results
+        run: bash ci/scripts/bench.sh "$(pwd)" --aggregate --dat "bench-dat/bench_stat_*.dat" --json-out bench_stats.json
+      - name: Upload combined results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-stats-json
+          path: bench_stats.json
+      - name: Set up Python
+        if: github.event_name == 'push' && github.repository == 'apache/arrow-go' && github.ref_name == 'main'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.9'
       - name: Upload results
         if: github.event_name == 'push' && github.repository == 'apache/arrow-go' && github.ref_name == 'main'
         env:
@@ -60,7 +105,7 @@ jobs:
           CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
           CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASS }}
           CONBENCH_REF: ${{ github.ref_name }}
-          CONBENCH_MACHINE_INFO_NAME: ${{ matrix.arch }}-debian-12
+          CONBENCH_MACHINE_INFO_NAME: amd64-debian-12
         run: |
           python3 -m pip install benchadapt@git+https://github.com/conbench/conbench.git@3af4a55206ad3918762cc8dd7d3012eadbe96a54#subdirectory=benchadapt/python
           python3 ci/scripts/bench_adapt.py

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,6 +42,10 @@ jobs:
   benchmark:
     needs: setup
     runs-on: ubuntu-latest
+    # The slowest shard (./arrow/array) takes ~40m, so 90m leaves headroom for
+    # runner variance while still failing a pathological benchmark ~4x sooner
+    # than the 6h GitHub default.
+    timeout-minutes: 100
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +63,11 @@ jobs:
           cache-dependency-path: go.sum
           check-latest: false
       - name: Run benchmark shard ${{ matrix.id }}
-        run: bash ci/scripts/bench.sh "$(pwd)" --run --packages "${{ matrix.packages }}" --out "bench_stat_${{ matrix.id }}.dat"
+        run: |
+          bash ci/scripts/bench.sh "$(pwd)" --run \
+            --packages "${{ matrix.packages }}" \
+            --out "bench_stat_${{ matrix.id }}.dat" \
+            --timeout 90m
       - name: Upload shard results
         uses: actions/upload-artifact@v4
         with:

--- a/arrow/array/json_reader_test.go
+++ b/arrow/array/json_reader_test.go
@@ -245,6 +245,13 @@ func TestJSONReaderExponentialNotation(t *testing.T) {
 	}
 }
 
+// benchMetadataPad keeps each generated record around 500 bytes of payload.
+// It must stay printable: JSON-escaping non-printable bytes (e.g. the NUL
+// bytes a zeroed []byte would produce) turns every byte into a \uXXXX escape,
+// and unescaping those is quadratic in goccy/go-json, which made these
+// benchmarks take hours.
+var benchMetadataPad = strings.Repeat("x", 500)
+
 func generateJSONData(n int) []byte {
 	records := make([]map[string]any, n)
 	for i := range n {
@@ -253,7 +260,7 @@ func generateJSONData(n int) []byte {
 			"name":     fmt.Sprintf("record_%d", i),
 			"value":    float64(i) * 1.5,
 			"active":   i%2 == 0,
-			"metadata": fmt.Sprintf("metadata_%d_%s", i, make([]byte, 500)),
+			"metadata": fmt.Sprintf("metadata_%d_%s", i, benchMetadataPad),
 		}
 	}
 

--- a/ci/scripts/bench.sh
+++ b/ci/scripts/bench.sh
@@ -17,37 +17,140 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# this will output the benchmarks to STDOUT but if `-json` or `--json` is passed
-# as the second argument, it will create a file "bench_stats.json"
-# in the directory this is called from containing a json representation
+# --run and --aggregate split a benchmark run so CI can shard packages across
+# parallel jobs and then combine the shards into one JSON for a single upload.
+# See usage() for the full interface.
 
 set -exo pipefail
 
-# Validate input arguments
-if [ -z "$1" ]; then
-  echo "Error: Missing source directory argument"
+GOBENCHDATA_VERSION="v1.3.1"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  bench.sh <source_dir> [--json|-json]
+      Run every benchmark (BENCH_PACKAGES, default "./..."); with --json/-json
+      also aggregate into "bench_stats.json". Removes .dat files afterwards.
+  bench.sh <source_dir> --run [--packages "<patterns>"] [--out <file>] [--timeout <dur>]
+      Run benchmarks only and write raw output to <file> (default
+      "bench_stat.dat"); leaves it in place for later aggregation.
+  bench.sh <source_dir> --aggregate [--dat "<glob>"] [--json-out <file>]
+      Combine .dat files (default "<source_dir>/bench_*.dat") into <file>
+      (default "bench_stats.json") via gobenchdata.
+
+Environment:
+  BENCH_PACKAGES  Default packages for full/--run modes (default "./...").
+  BENCH_TIMEOUT   Default per-package `go test` timeout (default "40m").
+EOF
+}
+
+run_benchmarks() {
+  local source_dir="$1" packages="$2" out_file="$3" timeout="$4"
+
+  PARQUET_TEST_DATA="${source_dir}/parquet-testing/data"
+  export PARQUET_TEST_DATA
+
+  pushd "${source_dir}" >/dev/null
+  # -timeout is applied to each package's test binary separately, so the full
+  # "./..." wall-clock cost is the sum across packages; --run shards a subset.
+  # shellcheck disable=SC2086  # intentional word-splitting of package patterns
+  go test -bench=. -benchmem -timeout "${timeout}" -run='^$' ${packages} | tee "${out_file}"
+  popd >/dev/null
+}
+
+aggregate_results() {
+  local dat_glob="$1" json_out="$2"
+
+  go install "go.bobheadxi.dev/gobenchdata@${GOBENCHDATA_VERSION}"
+  PATH="$(go env GOPATH)/bin:$PATH"
+  export PATH
+
+  # shellcheck disable=SC2086  # dat_glob is an intentional glob / list of files
+  cat ${dat_glob} | gobenchdata --json "${json_out}"
+}
+
+if [ -z "${1:-}" ]; then
+  echo "Error: Missing source directory argument" >&2
+  usage
   exit 1
 fi
 
 source_dir="$1"
+shift
 
-PARQUET_TEST_DATA="${source_dir}/parquet-testing/data"
-export PARQUET_TEST_DATA
+mode="${1:-}"
 
-pushd "${source_dir}"
+packages="${BENCH_PACKAGES:-./...}"
+timeout="${BENCH_TIMEOUT:-40m}"
 
-# lots of benchmarks, they can take a while
-# the timeout is for *ALL* benchmarks together,
-# not per benchmark
-go test -bench=. -benchmem -timeout 40m -run=^$ ./... | tee bench_stat.dat
+case "${mode}" in
+"" | -json | --json)
+  run_benchmarks "${source_dir}" "${packages}" "bench_stat.dat" "${timeout}"
+  if [[ "${mode}" == "-json" || "${mode}" == "--json" ]]; then
+    aggregate_results "${source_dir}/bench_*.dat" "bench_stats.json"
+  fi
+  rm "${source_dir}"/bench_*.dat
+  ;;
 
-popd
+--run)
+  shift
+  out_file="bench_stat.dat"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --packages)
+      packages="$2"
+      shift 2
+      ;;
+    --out)
+      out_file="$2"
+      shift 2
+      ;;
+    --timeout)
+      timeout="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: unknown --run option: $1" >&2
+      usage
+      exit 1
+      ;;
+    esac
+  done
+  run_benchmarks "${source_dir}" "${packages}" "${out_file}" "${timeout}"
+  ;;
 
-if [[ "$2" = "-json" || "$2" = "--json" ]]; then
-  go install go.bobheadxi.dev/gobenchdata@v1.3.1
-  PATH=$(go env GOPATH)/bin:$PATH
-  export PATH
-  cat "${source_dir}"/bench_*.dat | gobenchdata --json bench_stats.json
-fi
+--aggregate)
+  shift
+  dat_glob="${source_dir}/bench_*.dat"
+  json_out="bench_stats.json"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --dat)
+      dat_glob="$2"
+      shift 2
+      ;;
+    --json-out)
+      json_out="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: unknown --aggregate option: $1" >&2
+      usage
+      exit 1
+      ;;
+    esac
+  done
+  aggregate_results "${dat_glob}" "${json_out}"
+  ;;
 
-rm "${source_dir}"/bench_*.dat
+-h | --help)
+  usage
+  exit 0
+  ;;
+
+*)
+  echo "Error: unknown mode: ${mode}" >&2
+  usage
+  exit 1
+  ;;
+esac

--- a/ci/scripts/bench.sh
+++ b/ci/scripts/bench.sh
@@ -40,7 +40,8 @@ Usage:
 
 Environment:
   BENCH_PACKAGES  Default packages for full/--run modes (default "./...").
-  BENCH_TIMEOUT   Default per-package `go test` timeout (default "40m").
+  BENCH_TIMEOUT   Wall-clock limit for the whole `go test` invocation
+                  (default "4h", sized for "./..."); "0" disables it.
 EOF
 }
 
@@ -50,11 +51,18 @@ run_benchmarks() {
   PARQUET_TEST_DATA="${source_dir}/parquet-testing/data"
   export PARQUET_TEST_DATA
 
+  # `go test -timeout` does not cover benchmarks: the testing package stops its
+  # alarm before running them, so a runaway benchmark would otherwise burn the
+  # full 6h GitHub Actions job limit. Bound the whole run with timeout(1)
+  # instead, so a shard that goes pathological fails fast and visibly.
+  local runner=()
+  if [ "${timeout}" != "0" ]; then
+    runner=(timeout --signal=QUIT --kill-after=1m "${timeout}")
+  fi
+
   pushd "${source_dir}" >/dev/null
-  # -timeout is applied to each package's test binary separately, so the full
-  # "./..." wall-clock cost is the sum across packages; --run shards a subset.
   # shellcheck disable=SC2086  # intentional word-splitting of package patterns
-  go test -bench=. -benchmem -timeout "${timeout}" -run='^$' ${packages} | tee "${out_file}"
+  "${runner[@]}" go test -bench=. -benchmem -run='^$' ${packages} | tee "${out_file}"
   popd >/dev/null
 }
 
@@ -81,7 +89,8 @@ shift
 mode="${1:-}"
 
 packages="${BENCH_PACKAGES:-./...}"
-timeout="${BENCH_TIMEOUT:-40m}"
+# Sized for the whole "./..." suite; CI passes a tighter --timeout per shard.
+timeout="${BENCH_TIMEOUT:-4h}"
 
 case "${mode}" in
 "" | -json | --json)

--- a/ci/scripts/bench_adapt.py
+++ b/ci/scripts/bench_adapt.py
@@ -69,10 +69,15 @@ else:
 
 class GoAdapter(BenchmarkAdapter):
     result_file = "bench_stats.json"
-    command = ["bash", SCRIPTS_PATH / "bench.sh", ARROW_ROOT, "-json"]
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(command=self.command, *args, **kwargs)
+        # Reuse an existing results file (e.g. combined from the sharded
+        # benchmark jobs) rather than running the whole suite again.
+        if Path(self.result_file).exists():
+            command = ["true"]
+        else:
+            command = ["bash", SCRIPTS_PATH / "bench.sh", ARROW_ROOT, "-json"]
+        super().__init__(command=command, *args, **kwargs)
 
     def _transform_results(self) -> List[BenchmarkResult]:
         with open(self.result_file, "r") as f:

--- a/ci/scripts/bench_shard.sh
+++ b/ci/scripts/bench_shard.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Print a GitHub Actions matrix (JSON) that splits the packages containing Go
+# benchmarks into up to <num_shards> groups, so bench.sh --run can execute them
+# in parallel jobs. Each element is {"id":N,"packages":"./pkg-a ./pkg-b ..."}.
+
+set -eo pipefail
+
+num_shards="${1:-6}"
+source_dir="${2:-.}"
+
+cd "${source_dir}"
+
+grep -rlE '^func Benchmark' --include='*_test.go' . |
+  xargs -n1 dirname |
+  sort -u |
+  awk -v want="${num_shards}" '
+      $0 == "" { next }
+      { pkg = ($0 ~ /^\.\//) ? $0 : "./" $0; pkgs[++count] = pkg }
+      END {
+        if (count == 0) { print "[]"; exit }
+        n = (want < count) ? want : count
+        for (k = 1; k <= count; k++) {
+          s = (k - 1) % n
+          shard[s] = shard[s] (shard[s] == "" ? "" : " ") pkgs[k]
+        }
+        printf "["
+        for (i = 0; i < n; i++) {
+          if (i > 0) printf ","
+          printf "{\"id\":%d,\"packages\":\"%s\"}", i, shard[i]
+        }
+        printf "]\n"
+      }'


### PR DESCRIPTION
### Rationale for this change

The `Benchmarks` workflow runs `go test -bench=. ./...` sequentially across every
package. Because `go test`'s `-timeout` is applied per package, the wall-clock time
is the sum over all packages — recent `main` runs have taken roughly 3.3 hours
(198–208 min).

### What changes are included in this PR?

Split the benchmark run so it can be parallelized, then combine the results into a
single upload:

- **`ci/scripts/bench.sh`** — adds `--run` (benchmark a subset of packages, writing
  raw output to a `.dat`) and `--aggregate` (merge one or more `.dat` files into a
  single `bench_stats.json` via `gobenchdata`) modes. The existing
  `bench.sh <dir> [--json|-json]` interface is unchanged, so nothing else that calls
  it needs to change.
- **`ci/scripts/bench_shard.sh`** (new) — prints a GitHub Actions matrix that buckets
  the packages containing benchmarks into N shards.
- **`.github/workflows/benchmark.yml`** — reworked into three jobs: `setup` (compute
  the shard matrix) → `benchmark` (matrix; each shard runs its packages and uploads
  its `.dat`) → `combine` (download all `.dat`, aggregate into one `bench_stats.json`,
  and — only on push to `main` — upload once to Conbench).
- **`ci/scripts/bench_adapt.py`** — reuses an existing `bench_stats.json` (produced by
  `combine`) instead of re-running the whole suite.

Because the shards are merged into one JSON and uploaded once, Conbench still sees a
single run (no `run_id` fragmentation).

### Are these changes tested?

Locally:
- `shellcheck` clean on both scripts; `actionlint` clean on the workflow; `py_compile`
  OK on `bench_adapt.py`.
- Verified the split→merge end to end: ran `--run` on two packages, then `--aggregate`
  produced one `bench_stats.json` containing both suites, in the exact shape
  `bench_adapt.py` consumes.
- The legacy `bench.sh <dir> --json` path still runs → aggregates → cleans up.

Opened as a **draft** to exercise the reworked workflow in CI end to end (it triggers
on changes to these files).

### Are there any user-facing changes?

No. This only touches CI / benchmark tooling.

### Notes / follow-ups

- Sharding is currently round-robin by package, not runtime-weighted, so a single
  shard can hold two heavy packages (e.g. `arrow/compute` + `parquet/internal/encoding`)
  and become the long pole. The per-package `-timeout` (40m) remains the hard floor for
  any single package. Once this runs, per-shard timings can seed a runtime-weighted
  split or tune the shard count.
