### PR TITLE
chore(dev/release): filter out non numeric go releases (rc's and beta's) when finding latest go

### DIFF
--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -148,7 +148,7 @@ latest_go_version() {
   curl \
     "${options[@]}" \
     https://api.github.com/repos/golang/go/git/matching-refs/tags/go |
-    jq -r ' .[] | .ref' |
+    jq -r '.[] | .ref | select(test("^refs/tags/go[0-9]+(\\.[0-9]+){1,2}$"))' |
     sort -V |
     tail -1 |
     sed 's,refs/tags/go,,g'


### PR DESCRIPTION
### Rationale for this change

When running the release verification script without a local go version it currently might download RC or Beta releases. We should test verification with Released go versions.

### What changes are included in this PR?

Add a filter to force only numeric releases. Filtering releases for go with rc or beta suffixes.

### Are these changes tested?

Yes I tested this locally, prior to the issue it downloaded `+ go_version=1.27rc2` after the fix it downloaded `+ go_version=1.26.5`

### Are there any user-facing changes?

No

Closes https://github.com/apache/arrow-go/issues/967