### PR TITLE
fix: remove superfluous struct field index compare

### DIFF
--- a/arrow/compare.go
+++ b/arrow/compare.go
@@ -97,10 +97,7 @@ func TypeEqual(left, right DataType, opts ...TypeEqualOption) bool {
 		return true
 	case *StructType:
 		r := right.(*StructType)
-		switch {
-		case len(l.fields) != len(r.fields):
-			return false
-		case !reflect.DeepEqual(l.index, r.index):
+		if len(l.fields) != len(r.fields) {
 			return false
 		}
 		for i := range l.fields {


### PR DESCRIPTION
### What changes are included in this PR?
Remove superfluous check in the TypeEqual path to improve performance

### Rationale for this change
The check is superfluous because:
- Length is verified to equal
- Next step iterates over fields & asserts the names are equal for each index. These 2 steps essentially check the same thing, without needing expensive DeepEqual of 2 maps.


### Are these changes tested?
passes on `go test -v ./arrow`

### Are there any user-facing changes?
No
