### PR TITLE
fix(parquet/variant): handle empty metadata keys

### DIFF
--- a/parquet/variant/variant.go
+++ b/parquet/variant/variant.go
@@ -258,7 +258,8 @@ func (m Metadata) KeyAt(id uint32) (string, error) {
 			id, len(m.keys))
 	}
 
-	return unsafe.String(&m.keys[id][0], len(m.keys[id])), nil
+	key := m.keys[id]
+	return unsafe.String(unsafe.SliceData(key), len(key)), nil
 }
 
 // IdFor returns the dictionary IDs for the given key.

--- a/parquet/variant/variant_test.go
+++ b/parquet/variant/variant_test.go
@@ -122,6 +122,22 @@ func TestBasicRead(t *testing.T) {
 	})
 }
 
+func TestMetadataEmptyKey(t *testing.T) {
+	var b variant.Builder
+	start := b.Offset()
+	fields := []variant.FieldEntry{b.NextField(start, "")}
+	require.NoError(t, b.AppendNull())
+	require.NoError(t, b.FinishObject(start, fields))
+	value, err := b.Build()
+	require.NoError(t, err)
+	metadata := value.Metadata()
+
+	key, err := metadata.KeyAt(0)
+	require.NoError(t, err)
+	assert.Empty(t, key)
+	assert.Equal(t, []uint32{0}, metadata.IdFor(""))
+}
+
 func loadVariant(t *testing.T, test string) variant.Value {
 	dir := getVariantDir()
 	if dir == "" {


### PR DESCRIPTION
### Rationale for this change

Variant metadata may contain an empty object key. `Metadata.KeyAt` validates the dictionary index, then previously took the address of the key's first byte. That panics when the key is empty.

### What changes are included in this PR?

Use `unsafe.SliceData` for the existing zero-copy byte-to-string conversion so zero-length keys are handled safely. Add a builder-based regression covering both `KeyAt` and `IdFor`.

### Are these changes tested?

Yes:

- `go test ./parquet/variant`
- `go test -race -count=1 ./parquet/variant`

### Are there any user-facing changes?

`Metadata.KeyAt` now returns an empty string for a valid empty key instead of panicking. There is no API change.