### PR TITLE
fix(arrow/ipc): propagate CLI stream errors

### DIFF
--- a/arrow/ipc/cmd/arrow-cat/main.go
+++ b/arrow/ipc/cmd/arrow-cat/main.go
@@ -105,7 +105,11 @@ func processStream(w io.Writer, rin io.Reader) error {
 				fmt.Fprintf(w, "  col[%d] %q: %v\n", i, rec.ColumnName(i), col)
 			}
 		}
+		err = r.Err()
 		r.Release()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/arrow/ipc/cmd/arrow-cat/main_test.go
+++ b/arrow/ipc/cmd/arrow-cat/main_test.go
@@ -223,6 +223,34 @@ record 3...
 	}
 }
 
+func TestCatStreamReturnsRecordReadError(t *testing.T) {
+	rec := arrdata.Records["primitives"][0]
+
+	var schemaOnly bytes.Buffer
+	schemaWriter := ipc.NewWriter(&schemaOnly, ipc.WithSchema(rec.Schema()))
+	if err := schemaWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var full bytes.Buffer
+	writer := ipc.NewWriter(&full, ipc.WithSchema(rec.Schema()))
+	if err := writer.Write(rec); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	const eosSize = 8
+	schemaSize := schemaOnly.Len() - eosSize
+	// Keep the record framing and one metadata byte so the record read fails
+	// with io.ErrUnexpectedEOF instead of being treated as a clean stream end.
+	truncated := full.Bytes()[:schemaSize+eosSize+1]
+	if err := processStream(io.Discard, bytes.NewReader(truncated)); err == nil {
+		t.Fatal("processStream returned nil for a truncated record message")
+	}
+}
+
 func TestCatFile(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/arrow/ipc/cmd/arrow-ls/main.go
+++ b/arrow/ipc/cmd/arrow-ls/main.go
@@ -101,10 +101,13 @@ func processStream(w io.Writer, rin io.Reader) error {
 		for r.Next() {
 			nrecs++
 		}
-		fmt.Fprintf(w, "records: %d\n", nrecs)
+		err = r.Err()
 		r.Release()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "records: %d\n", nrecs)
 	}
-	return nil
 }
 
 func processFiles(w io.Writer, names []string) error {

--- a/arrow/ipc/cmd/arrow-ls/main_test.go
+++ b/arrow/ipc/cmd/arrow-ls/main_test.go
@@ -168,6 +168,34 @@ records: 3
 	}
 }
 
+func TestLsStreamReturnsRecordReadError(t *testing.T) {
+	rec := arrdata.Records["primitives"][0]
+
+	var schemaOnly bytes.Buffer
+	schemaWriter := ipc.NewWriter(&schemaOnly, ipc.WithSchema(rec.Schema()))
+	if err := schemaWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var full bytes.Buffer
+	writer := ipc.NewWriter(&full, ipc.WithSchema(rec.Schema()))
+	if err := writer.Write(rec); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	const eosSize = 8
+	schemaSize := schemaOnly.Len() - eosSize
+	// Keep the record framing and one metadata byte so the record read fails
+	// with io.ErrUnexpectedEOF instead of being treated as a clean stream end.
+	truncated := full.Bytes()[:schemaSize+eosSize+1]
+	if err := processStream(io.Discard, bytes.NewReader(truncated)); err == nil {
+		t.Fatal("processStream returned nil for a truncated record message")
+	}
+}
+
 func TestLsFile(t *testing.T) {
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
### Rationale for this change

`arrow-cat` and `arrow-ls` stopped when `Reader.Next` returned false but did not inspect `Reader.Err`. A record read failure could therefore be reported as a successful end of stream. `arrow-cat` could exit successfully after partial output, while `arrow-ls` could print a record count for an incomplete stream.

### What changes are included in this PR?

Check `Reader.Err` after iteration in both commands and return it after releasing the reader. `arrow-ls` now prints the record count only after the stream completes successfully. Regression tests use a valid schema followed by truncated record metadata.

### Are these changes tested?

Yes:

- `go test ./arrow/ipc/cmd/arrow-cat ./arrow/ipc/cmd/arrow-ls`
- `go test -race -count=1 ./arrow/ipc/cmd/arrow-cat ./arrow/ipc/cmd/arrow-ls`

### Are there any user-facing changes?

Both command-line tools now return an error for a failed record read instead of reporting success. Valid stream output is unchanged.