### PR TITLE
fix(arrow/flight): avoid blocking after stream cancellation

### DIFF
--- a/arrow/flight/flight_test.go
+++ b/arrow/flight/flight_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -633,6 +634,42 @@ func TestStreamChunksFromReader_OK(t *testing.T) {
 	require.Equal(t, 5, chunksReceived, "should receive all 5 batches")
 	require.True(t, rdr.released.Load(), "reader should be released")
 
+}
+
+type immediateErrorRecordReader struct {
+	err      error
+	released atomic.Bool
+}
+
+func (*immediateErrorRecordReader) Retain()                        {}
+func (r *immediateErrorRecordReader) Release()                     { r.released.Store(true) }
+func (*immediateErrorRecordReader) Schema() *arrow.Schema          { return nil }
+func (*immediateErrorRecordReader) Next() bool                     { return false }
+func (*immediateErrorRecordReader) RecordBatch() arrow.RecordBatch { return nil }
+func (*immediateErrorRecordReader) Record() arrow.RecordBatch      { return nil }
+func (r *immediateErrorRecordReader) Err() error                   { return r.err }
+
+func TestStreamChunksFromReader_CancellationWhileSendingError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rdr := &immediateErrorRecordReader{err: errors.New("read failed")}
+	ch := make(chan flight.StreamChunk)
+	done := make(chan struct{})
+	go func() {
+		flight.StreamChunksFromReader(ctx, rdr, ch)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("StreamChunksFromReader blocked sending an error after cancellation")
+	}
+
+	if !rdr.released.Load() {
+		t.Fatal("reader was not released")
+	}
 }
 
 // TestStreamChunksFromReader_HandlesCancellation verifies that context cancellation

--- a/arrow/flight/record_batch_reader.go
+++ b/arrow/flight/record_batch_reader.go
@@ -248,8 +248,11 @@ func StreamChunksFromReader(ctx context.Context, rdr array.RecordReader, ch chan
 	}
 
 	if e, ok := rdr.(haserr); ok {
-		if e.Err() != nil {
-			ch <- StreamChunk{Err: e.Err()}
+		if err := e.Err(); err != nil {
+			select {
+			case ch <- StreamChunk{Err: err}:
+			case <-ctx.Done():
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Rationale for this change

`StreamChunksFromReader` observes context cancellation while sending record batches, but its final reader-error send still wrote directly to the output channel. If the consumer stopped receiving after cancellation, that send could block forever, preventing reader release and channel closure. This is a follow-up to the cancellation handling added in #615.

### What changes are included in this PR?

Race final error delivery against context cancellation, matching the existing record-batch send behavior. Capture the reader error once before delivery. Add a regression with an already-canceled context, an unbuffered channel, and a reader that fails immediately.

### Are these changes tested?

Yes:

- `go test ./arrow/flight`
- `go test -race -count=1 ./arrow/flight`

### Are there any user-facing changes?

`StreamChunksFromReader` now returns promptly and releases its reader when cancellation prevents final error delivery. Error delivery is unchanged while the context remains active.