### PR TITLE
fix(array): validate run-end encoded invariants

### DIFF
--- a/arrow/array/encoded.go
+++ b/arrow/array/encoded.go
@@ -251,11 +251,14 @@ func (r *RunEndEncoded) String() string {
 
 func validateRunEndEncoded(r *RunEndEncoded, full bool) error {
 	reeType := r.data.dtype.(*arrow.RunEndEncodedType)
-	runEndsData := r.data.childData[0]
+	runEndsData := r.data.childData[0].(*Data)
 	valuesData := r.data.childData[1]
 
 	if reeNullCount(r.data) != 0 {
 		return fmt.Errorf("arrow/array: run-end encoded array cannot contain nulls")
+	}
+	if err := validateArrayData(runEndsData); err != nil {
+		return fmt.Errorf("arrow/array: run ends array invalid: %w", err)
 	}
 	if !arrow.TypeEqual(runEndsData.DataType(), reeType.RunEnds()) {
 		return fmt.Errorf("arrow/array: run ends array must match parent type %s, got %s", reeType.RunEnds(), runEndsData.DataType())
@@ -279,8 +282,8 @@ func validateRunEndEncoded(r *RunEndEncoded, full bool) error {
 		return fmt.Errorf("arrow/array: offset + length of a run-end encoded array must fit in the run end type %s", runEndsData.DataType())
 	}
 
-	runEnds := getRunEnds64(runEndsData)
-	lastRunEnd := runEnds[len(runEnds)-1]
+	runEnds := encoded.GetRunEnds(runEndsData)
+	lastRunEnd := runEnds(int64(runEndsData.Len() - 1))
 	if lastRunEnd < int64(r.data.offset+r.data.length) {
 		return fmt.Errorf("arrow/array: last run end is %d but it should cover %d", lastRunEnd, r.data.offset+r.data.length)
 	}
@@ -289,13 +292,17 @@ func validateRunEndEncoded(r *RunEndEncoded, full bool) error {
 		return nil
 	}
 
-	if runEnds[0] < 1 {
-		return fmt.Errorf("arrow/array: first run end must be greater than 0, got %d", runEnds[0])
+	firstRunEnd := runEnds(0)
+	if firstRunEnd < 1 {
+		return fmt.Errorf("arrow/array: first run end must be greater than 0, got %d", firstRunEnd)
 	}
-	for i := 1; i < len(runEnds); i++ {
-		if runEnds[i] <= runEnds[i-1] {
-			return fmt.Errorf("arrow/array: run end at position %d (%d) must be strictly greater than previous run end (%d)", i, runEnds[i], runEnds[i-1])
+	lastSeenRunEnd := firstRunEnd
+	for i := int64(1); i < int64(runEndsData.Len()); i++ {
+		runEnd := runEnds(i)
+		if runEnd <= lastSeenRunEnd {
+			return fmt.Errorf("arrow/array: run end at position %d (%d) must be strictly greater than previous run end (%d)", i, runEnd, lastSeenRunEnd)
 		}
+		lastSeenRunEnd = runEnd
 	}
 	return nil
 }
@@ -313,35 +320,11 @@ func reeNullCount(data *Data) int {
 func runEndTypeLimit(id arrow.Type) int64 {
 	switch id {
 	case arrow.INT16:
-		return 1<<15 - 1
+		return math.MaxInt16
 	case arrow.INT32:
 		return math.MaxInt32
 	default:
 		return math.MaxInt64
-	}
-}
-
-func getRunEnds64(data arrow.ArrayData) []int64 {
-	switch data.DataType().ID() {
-	case arrow.INT16:
-		runEnds := arrow.Int16Traits.CastFromBytes(data.Buffers()[1].Bytes())
-		runEnds = runEnds[data.Offset() : data.Offset()+data.Len()]
-		out := make([]int64, len(runEnds))
-		for i, v := range runEnds {
-			out[i] = int64(v)
-		}
-		return out
-	case arrow.INT32:
-		runEnds := arrow.Int32Traits.CastFromBytes(data.Buffers()[1].Bytes())
-		runEnds = runEnds[data.Offset() : data.Offset()+data.Len()]
-		out := make([]int64, len(runEnds))
-		for i, v := range runEnds {
-			out[i] = int64(v)
-		}
-		return out
-	default:
-		runEnds := arrow.Int64Traits.CastFromBytes(data.Buffers()[1].Bytes())
-		return runEnds[data.Offset() : data.Offset()+data.Len()]
 	}
 }
 

--- a/arrow/array/encoded.go
+++ b/arrow/array/encoded.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/bitutil"
 	"github.com/apache/arrow-go/v18/arrow/encoded"
 	"github.com/apache/arrow-go/v18/arrow/internal/debug"
 	"github.com/apache/arrow-go/v18/arrow/memory"
@@ -253,7 +254,7 @@ func validateRunEndEncoded(r *RunEndEncoded, full bool) error {
 	runEndsData := r.data.childData[0]
 	valuesData := r.data.childData[1]
 
-	if r.data.nulls != 0 {
+	if reeNullCount(r.data) != 0 {
 		return fmt.Errorf("arrow/array: run-end encoded array cannot contain nulls")
 	}
 	if !arrow.TypeEqual(runEndsData.DataType(), reeType.RunEnds()) {
@@ -262,7 +263,7 @@ func validateRunEndEncoded(r *RunEndEncoded, full bool) error {
 	if !arrow.TypeEqual(valuesData.DataType(), reeType.Encoded()) {
 		return fmt.Errorf("arrow/array: values array must match parent type %s, got %s", reeType.Encoded(), valuesData.DataType())
 	}
-	if runEndsData.NullN() != 0 {
+	if r.ends.NullN() != 0 {
 		return fmt.Errorf("arrow/array: run ends array cannot contain nulls")
 	}
 	if runEndsData.Len() > valuesData.Len() {
@@ -297,6 +298,16 @@ func validateRunEndEncoded(r *RunEndEncoded, full bool) error {
 		}
 	}
 	return nil
+}
+
+func reeNullCount(data *Data) int {
+	if data.nulls != UnknownNullCount {
+		return data.nulls
+	}
+	if len(data.buffers) > 0 && data.buffers[0] != nil {
+		return data.length - bitutil.CountSetBits(data.buffers[0].Bytes(), data.offset, data.length)
+	}
+	return 0
 }
 
 func runEndTypeLimit(id arrow.Type) int64 {

--- a/arrow/array/encoded.go
+++ b/arrow/array/encoded.go
@@ -57,6 +57,14 @@ func NewRunEndEncodedData(data arrow.ArrayData) *RunEndEncoded {
 func (r *RunEndEncoded) Values() arrow.Array     { return r.values }
 func (r *RunEndEncoded) RunEndsArr() arrow.Array { return r.ends }
 
+func (r *RunEndEncoded) Validate() error {
+	return validateRunEndEncoded(r, false)
+}
+
+func (r *RunEndEncoded) ValidateFull() error {
+	return validateRunEndEncoded(r, true)
+}
+
 func (r *RunEndEncoded) Retain() {
 	r.array.Retain()
 	r.values.Retain()
@@ -238,6 +246,92 @@ func (r *RunEndEncoded) String() string {
 
 	buf.WriteByte(']')
 	return buf.String()
+}
+
+func validateRunEndEncoded(r *RunEndEncoded, full bool) error {
+	reeType := r.data.dtype.(*arrow.RunEndEncodedType)
+	runEndsData := r.data.childData[0]
+	valuesData := r.data.childData[1]
+
+	if r.data.nulls != 0 {
+		return fmt.Errorf("arrow/array: run-end encoded array cannot contain nulls")
+	}
+	if !arrow.TypeEqual(runEndsData.DataType(), reeType.RunEnds()) {
+		return fmt.Errorf("arrow/array: run ends array must match parent type %s, got %s", reeType.RunEnds(), runEndsData.DataType())
+	}
+	if !arrow.TypeEqual(valuesData.DataType(), reeType.Encoded()) {
+		return fmt.Errorf("arrow/array: values array must match parent type %s, got %s", reeType.Encoded(), valuesData.DataType())
+	}
+	if runEndsData.NullN() != 0 {
+		return fmt.Errorf("arrow/array: run ends array cannot contain nulls")
+	}
+	if runEndsData.Len() > valuesData.Len() {
+		return fmt.Errorf("arrow/array: length of run ends array is greater than length of values array (%d > %d)", runEndsData.Len(), valuesData.Len())
+	}
+	if runEndsData.Len() == 0 {
+		if r.data.length == 0 {
+			return nil
+		}
+		return fmt.Errorf("arrow/array: run-end encoded array has non-zero length %d, but run ends array has zero length", r.data.length)
+	}
+	if int64(r.data.offset)+int64(r.data.length) > runEndTypeLimit(runEndsData.DataType().ID()) {
+		return fmt.Errorf("arrow/array: offset + length of a run-end encoded array must fit in the run end type %s", runEndsData.DataType())
+	}
+
+	runEnds := getRunEnds64(runEndsData)
+	lastRunEnd := runEnds[len(runEnds)-1]
+	if lastRunEnd < int64(r.data.offset+r.data.length) {
+		return fmt.Errorf("arrow/array: last run end is %d but it should cover %d", lastRunEnd, r.data.offset+r.data.length)
+	}
+
+	if !full {
+		return nil
+	}
+
+	if runEnds[0] < 1 {
+		return fmt.Errorf("arrow/array: first run end must be greater than 0, got %d", runEnds[0])
+	}
+	for i := 1; i < len(runEnds); i++ {
+		if runEnds[i] <= runEnds[i-1] {
+			return fmt.Errorf("arrow/array: run end at position %d (%d) must be strictly greater than previous run end (%d)", i, runEnds[i], runEnds[i-1])
+		}
+	}
+	return nil
+}
+
+func runEndTypeLimit(id arrow.Type) int64 {
+	switch id {
+	case arrow.INT16:
+		return 1<<15 - 1
+	case arrow.INT32:
+		return math.MaxInt32
+	default:
+		return math.MaxInt64
+	}
+}
+
+func getRunEnds64(data arrow.ArrayData) []int64 {
+	switch data.DataType().ID() {
+	case arrow.INT16:
+		runEnds := arrow.Int16Traits.CastFromBytes(data.Buffers()[1].Bytes())
+		runEnds = runEnds[data.Offset() : data.Offset()+data.Len()]
+		out := make([]int64, len(runEnds))
+		for i, v := range runEnds {
+			out[i] = int64(v)
+		}
+		return out
+	case arrow.INT32:
+		runEnds := arrow.Int32Traits.CastFromBytes(data.Buffers()[1].Bytes())
+		runEnds = runEnds[data.Offset() : data.Offset()+data.Len()]
+		out := make([]int64, len(runEnds))
+		for i, v := range runEnds {
+			out[i] = int64(v)
+		}
+		return out
+	default:
+		runEnds := arrow.Int64Traits.CastFromBytes(data.Buffers()[1].Bytes())
+		return runEnds[data.Offset() : data.Offset()+data.Len()]
+	}
 }
 
 func (r *RunEndEncoded) GetOneForMarshal(i int) interface{} {

--- a/arrow/array/encoded_test.go
+++ b/arrow/array/encoded_test.go
@@ -29,6 +29,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func makeRunEndEncodedArrayRaw(t *testing.T, dt *arrow.RunEndEncodedType, logicalLength, nulls, offset int, buffers []*memory.Buffer, children []arrow.ArrayData) *array.RunEndEncoded {
+	t.Helper()
+	data := array.NewData(dt, logicalLength, buffers, children, nulls, offset)
+	arr := array.NewRunEndEncodedData(data)
+	data.Release()
+	return arr
+}
+
 var (
 	stringValues, _, _ = array.FromJSON(memory.DefaultAllocator, arrow.BinaryTypes.String, strings.NewReader(`["Hello", "World", null]`))
 	int32Values, _, _  = array.FromJSON(memory.DefaultAllocator, arrow.PrimitiveTypes.Int32, strings.NewReader(`[10, 20, 30]`))
@@ -74,6 +82,56 @@ func TestRLEFromRunEndsAndValues(t *testing.T) {
 	})
 	assert.PanicsWithError(t, "invalid: arrow/array: run ends array cannot contain nulls", func() {
 		array.NewRunEndEncodedArray(int32OnlyNull, int32Values, 3, 0)
+	})
+}
+
+func TestRunEndEncodedValidate(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	t.Run("valid array passes", func(t *testing.T) {
+		runEnds, _, _ := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[1, 3]`))
+		values, _, _ := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["a", "b"]`))
+		defer runEnds.Release()
+		defer values.Release()
+
+		arr := makeRunEndEncodedArrayRaw(t, arrow.RunEndEncodedOf(arrow.PrimitiveTypes.Int32, arrow.BinaryTypes.String), 3, 0, 0,
+			[]*memory.Buffer{nil}, []arrow.ArrayData{runEnds.Data(), values.Data()})
+		defer arr.Release()
+
+		assert.NoError(t, arr.Validate())
+		assert.NoError(t, arr.ValidateFull())
+	})
+
+	t.Run("last run end shorter than logical length fails Validate", func(t *testing.T) {
+		runEnds, _, _ := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[1, 2]`))
+		values, _, _ := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["a", "b"]`))
+		defer runEnds.Release()
+		defer values.Release()
+
+		arr := makeRunEndEncodedArrayRaw(t, arrow.RunEndEncodedOf(arrow.PrimitiveTypes.Int32, arrow.BinaryTypes.String), 3, 0, 0,
+			[]*memory.Buffer{nil}, []arrow.ArrayData{runEnds.Data(), values.Data()})
+		defer arr.Release()
+
+		err := arr.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "last run end")
+	})
+
+	t.Run("duplicate run ends pass Validate but fail ValidateFull", func(t *testing.T) {
+		runEnds, _, _ := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[2, 2]`))
+		values, _, _ := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["first", "second"]`))
+		defer runEnds.Release()
+		defer values.Release()
+
+		arr := makeRunEndEncodedArrayRaw(t, arrow.RunEndEncodedOf(arrow.PrimitiveTypes.Int32, arrow.BinaryTypes.String), 2, 0, 0,
+			[]*memory.Buffer{nil}, []arrow.ArrayData{runEnds.Data(), values.Data()})
+		defer arr.Release()
+
+		assert.NoError(t, arr.Validate())
+		err := arr.ValidateFull()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "strictly greater")
 	})
 }
 

--- a/arrow/array/encoded_test.go
+++ b/arrow/array/encoded_test.go
@@ -133,6 +133,45 @@ func TestRunEndEncodedValidate(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "strictly greater")
 	})
+
+	t.Run("unknown null counts without bitmaps still validate", func(t *testing.T) {
+		runEnds, _, _ := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[1, 3]`))
+		values, _, _ := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["a", "b"]`))
+		defer runEnds.Release()
+		defer values.Release()
+
+		runEndsData := runEnds.Data().(*array.Data).Copy()
+		runEndsData.SetNullN(array.UnknownNullCount)
+		defer runEndsData.Release()
+
+		valuesData := values.Data().(*array.Data).Copy()
+		defer valuesData.Release()
+
+		arr := makeRunEndEncodedArrayRaw(t, arrow.RunEndEncodedOf(arrow.PrimitiveTypes.Int32, arrow.BinaryTypes.String), 3, array.UnknownNullCount, 0,
+			[]*memory.Buffer{nil}, []arrow.ArrayData{runEndsData, valuesData})
+		defer arr.Release()
+
+		assert.NoError(t, arr.Validate())
+		assert.NoError(t, arr.ValidateFull())
+	})
+
+	t.Run("run ends with lazy null count fail Validate", func(t *testing.T) {
+		validity := memory.NewBufferBytes([]byte{0x01})
+		valuesBuf := memory.NewBufferBytes(arrow.Int32Traits.CastToBytes([]int32{1, 3}))
+		runEndsData := array.NewData(arrow.PrimitiveTypes.Int32, 2, []*memory.Buffer{validity, valuesBuf}, nil, array.UnknownNullCount, 0)
+		defer runEndsData.Release()
+
+		values, _, _ := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["a", "b"]`))
+		defer values.Release()
+
+		arr := makeRunEndEncodedArrayRaw(t, arrow.RunEndEncodedOf(arrow.PrimitiveTypes.Int32, arrow.BinaryTypes.String), 3, 0, 0,
+			[]*memory.Buffer{nil}, []arrow.ArrayData{runEndsData, values.Data()})
+		defer arr.Release()
+
+		err := arr.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "run ends array cannot contain nulls")
+	})
 }
 
 func TestRunLengthEncodedOffsetLength(t *testing.T) {

--- a/arrow/array/encoded_test.go
+++ b/arrow/array/encoded_test.go
@@ -134,6 +134,22 @@ func TestRunEndEncodedValidate(t *testing.T) {
 		assert.Contains(t, err.Error(), "strictly greater")
 	})
 
+	t.Run("top level ValidateFull catches duplicate run ends", func(t *testing.T) {
+		runEnds, _, _ := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[2, 2]`))
+		values, _, _ := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["first", "second"]`))
+		defer runEnds.Release()
+		defer values.Release()
+
+		arr := makeRunEndEncodedArrayRaw(t, arrow.RunEndEncodedOf(arrow.PrimitiveTypes.Int32, arrow.BinaryTypes.String), 2, 0, 0,
+			[]*memory.Buffer{nil}, []arrow.ArrayData{runEnds.Data(), values.Data()})
+		defer arr.Release()
+
+		assert.NoError(t, array.Validate(arr))
+		err := array.ValidateFull(arr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "strictly greater")
+	})
+
 	t.Run("unknown null counts without bitmaps still validate", func(t *testing.T) {
 		runEnds, _, _ := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[1, 3]`))
 		values, _, _ := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["a", "b"]`))

--- a/arrow/encoded/ree_utils.go
+++ b/arrow/encoded/ree_utils.go
@@ -125,6 +125,10 @@ func getRunEnds(arr arrow.ArrayData) func(int64) int64 {
 	}
 }
 
+func GetRunEnds(arr arrow.ArrayData) func(int64) int64 {
+	return getRunEnds(arr)
+}
+
 // MergedRuns is used to take two Run End Encoded arrays and iterate
 // them, finding the correct physical indices to correspond with the
 // runs.


### PR DESCRIPTION
## Summary
- add RunEndEncoded Validate and ValidateFull implementations
- validate parent and child invariants, logical coverage, and strict run-end monotonicity
- add regression tests for short coverage and duplicate run ends

## Why
Run-end encoded helpers already assume that run ends are strictly increasing and cover the logical range. Today malformed arrays can pass validation even when those invariants do not hold.

## Validation
- go test ./arrow/array ./arrow/encoded