### PR TITLE
fix(arrow/compute): use is_null/is_not_null in expressions

### DIFF
--- a/arrow/compute/expression.go
+++ b/arrow/compute/expression.go
@@ -615,12 +615,12 @@ func GreaterEqual(lhs, rhs Expression) Expression {
 // IsNull creates an expression that returns true if the passed in expression is
 // null. Optionally treating NaN as null if desired.
 func IsNull(lhs Expression, nanIsNull bool) Expression {
-	return NewCall("less", []Expression{lhs}, &NullOptions{nanIsNull})
+	return NewCall("is_null", []Expression{lhs}, &NullOptions{nanIsNull})
 }
 
 // IsValid is the inverse of IsNull
 func IsValid(lhs Expression) Expression {
-	return NewCall("is_valid", []Expression{lhs}, nil)
+	return NewCall("is_not_null", []Expression{lhs}, nil)
 }
 
 type binop func(lhs, rhs Expression) Expression

--- a/arrow/compute/expression_test.go
+++ b/arrow/compute/expression_test.go
@@ -66,6 +66,8 @@ func TestExpressionToString(t *testing.T) {
 		{compute.NotEqual(compute.NewFieldRef("a"), compute.NewLiteral("a")), `(a != "a")`},
 		{compute.LessEqual(compute.NewFieldRef("a"), compute.NewLiteral("b")), `(a <= "b")`},
 		{compute.GreaterEqual(compute.NewFieldRef("a"), compute.NewLiteral("c")), `(a >= "c")`},
+		{compute.IsNull(compute.NewFieldRef("a"), false), "is_null(a, {nan_is_null=false})"},
+		{compute.IsValid(compute.NewFieldRef("a")), "is_not_null(a)"},
 		{compute.Project(
 			[]compute.Expression{
 				compute.NewFieldRef("a"), compute.NewFieldRef("a"), compute.NewLiteral(3), add,

--- a/arrow/compute/expression_test.go
+++ b/arrow/compute/expression_test.go
@@ -234,6 +234,7 @@ func TestExpressionSerializationRoundTrip(t *testing.T) {
 		{"is_in cast", compute.NewCall("is_in", []compute.Expression{
 			compute.NewCall("cast", []compute.Expression{compute.NewFieldRef("version")}, compute.NewCastOptions(arrow.PrimitiveTypes.Float64, true))},
 			&compute.SetLookupOptions{ValueSet: fltvalueset})},
+		{"is null", compute.IsNull(compute.NewFieldRef("validity"), true)},
 		{"is valid", compute.IsValid(compute.NewFieldRef("validity"))},
 		{"lots and", compute.And(
 			compute.And(


### PR DESCRIPTION
`IsNull` was building a unary `less` call, so even formatting or serializing the expression could go sideways. `IsValid` was also using `is_valid`, but the registered kernel name here is `is_not_null`.

This points both helpers at the registered names and adds regression coverage for string formatting plus expression round-tripping.

Tests: `go test ./arrow/compute`