### PR TITLE
fix(arrow/ipc): reject NaN minSpaceSavings values

### DIFF
--- a/arrow/ipc/writer.go
+++ b/arrow/ipc/writer.go
@@ -486,7 +486,7 @@ func (w *recordEncoder) encode(p *Payload, rec arrow.RecordBatch) error {
 	}
 
 	if w.codec != -1 {
-		if w.minSpaceSavings < 0 || w.minSpaceSavings > 1 {
+		if math.IsNaN(w.minSpaceSavings) || w.minSpaceSavings < 0 || w.minSpaceSavings > 1 {
 			p.Release()
 			return fmt.Errorf("%w: minSpaceSavings not in range [0,1]. Provided %.05f",
 				arrow.ErrInvalid, w.minSpaceSavings)

--- a/arrow/ipc/writer_test.go
+++ b/arrow/ipc/writer_test.go
@@ -229,7 +229,7 @@ func TestWriteWithCompressionAndMinSavings(t *testing.T) {
 		payload.Release()
 		payload.body = payload.body[:0]
 
-		for _, outOfRange := range []float64{math.Nextafter(1.0, 2.0), math.Nextafter(0, -1)} {
+		for _, outOfRange := range []float64{math.Nextafter(1.0, 2.0), math.Nextafter(0, -1), math.NaN()} {
 			compressEncoder.minSpaceSavings = outOfRange
 			err := compressEncoder.encode(&payload, batch)
 			assert.ErrorIs(t, err, arrow.ErrInvalid)


### PR DESCRIPTION
`WithMinSpaceSavings` documents the accepted range as `[0, 1]`, but `NaN` slipped through because both comparisons against `NaN` are false.

This rejects `NaN` alongside the existing range checks and extends the validation test with that input.

Tests: `go test ./arrow/ipc`