### PR TITLE
fix(arrow/tensor): default nil dimension names to empty strings

### DIFF
--- a/arrow/tensor/tensor.go
+++ b/arrow/tensor/tensor.go
@@ -171,6 +171,10 @@ func New(data arrow.ArrayData, shape, strides []int64, names []string) Interface
 }
 
 func newTensor(dtype arrow.DataType, data arrow.ArrayData, shape, strides []int64, names []string) *tensorBase {
+	if names == nil {
+		names = make([]string, len(shape))
+	}
+
 	tb := tensorBase{
 		dtype:   dtype,
 		bw:      int64(dtype.(arrow.FixedWidthDataType).BitWidth()) / 8,

--- a/arrow/tensor/tensor_test.go
+++ b/arrow/tensor/tensor_test.go
@@ -164,3 +164,21 @@ func TestInvalidTensor(t *testing.T) {
 	})
 
 }
+
+func TestTensorWithNilDimensionNames(t *testing.T) {
+	bld := array.NewFloat64Builder(memory.DefaultAllocator)
+	defer bld.Release()
+	bld.AppendValues([]float64{1, 2}, nil)
+	arr := bld.NewFloat64Array()
+	defer arr.Release()
+
+	tsr := tensor.New(arr.Data(), []int64{2}, nil, nil)
+	defer tsr.Release()
+
+	if got, want := tsr.DimNames(), []string{""}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid dim-names: got=%v, want=%v", got, want)
+	}
+	if got := tsr.DimName(0); got != "" {
+		t.Fatalf("invalid dim-name[0]: got=%q, want empty string", got)
+	}
+}


### PR DESCRIPTION
The tensor constructors document that `nil` dimension names are treated as empty strings, but the shared constructor left the slice nil. That makes `DimName` panic on an otherwise valid tensor.

This fills in one empty name per dimension and adds coverage for both `DimNames` and `DimName`.

Tests: `go test ./arrow/tensor`