### PR TITLE
fix(arrow/scalar): allow null extension scalars to keep null storage

### DIFF
--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -421,10 +421,16 @@ func (e *Extension) Validate() (err error) {
 	}
 
 	if !e.Valid {
-		if e.Value != nil {
-			err = fmt.Errorf("null %s scalar has storage value", e.Type)
+		if e.Value == nil {
+			return nil
 		}
-		return
+		if e.Value.IsValid() {
+			return fmt.Errorf("null %s scalar has non-null storage value", e.Type)
+		}
+		if err = e.Value.Validate(); err != nil {
+			return fmt.Errorf("%s scalar fails validation for storage value: %w", e.Type, err)
+		}
+		return nil
 	}
 
 	switch {

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -102,6 +102,14 @@ func TestMakeNullExtensionScalar(t *testing.T) {
 	assert.True(t, arrow.TypeEqual(dt.StorageType(), ext.Value.DataType()))
 }
 
+func TestNullExtensionScalarValidateRejectsNonNullStorage(t *testing.T) {
+	sc := scalar.NewExtensionScalar(scalar.NewInt16Scalar(1), types.NewSmallintType())
+	sc.Valid = false
+
+	assert.ErrorContains(t, sc.Validate(), "non-null storage value")
+	assert.ErrorContains(t, sc.ValidateFull(), "non-null storage value")
+}
+
 func TestMakeScalarUint(t *testing.T) {
 	three := scalar.MakeScalar(uint(3))
 	assert.NoError(t, three.ValidateFull())

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -94,7 +94,12 @@ func checkMakeNullScalar(t *testing.T, dt arrow.DataType) scalar.Scalar {
 }
 
 func TestMakeNullExtensionScalar(t *testing.T) {
-	checkMakeNullScalar(t, types.NewSmallintType())
+	dt := types.NewSmallintType()
+	sc := checkMakeNullScalar(t, dt)
+	ext := sc.(*scalar.Extension)
+	require.NotNil(t, ext.Value)
+	assert.False(t, ext.Value.IsValid())
+	assert.True(t, arrow.TypeEqual(dt.StorageType(), ext.Value.DataType()))
 }
 
 func TestMakeScalarUint(t *testing.T) {

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal256"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/apache/arrow-go/v18/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -90,6 +91,10 @@ func checkMakeNullScalar(t *testing.T, dt arrow.DataType) scalar.Scalar {
 	assert.True(t, arrow.TypeEqual(s.DataType(), dt))
 	assert.False(t, s.IsValid())
 	return s
+}
+
+func TestMakeNullExtensionScalar(t *testing.T) {
+	checkMakeNullScalar(t, types.NewSmallintType())
 }
 
 func TestMakeScalarUint(t *testing.T) {


### PR DESCRIPTION
`MakeNullScalar` represents a null extension scalar with a null storage scalar. `Extension.Validate` rejected that factory-created shape even though it is the natural null representation.

This allows validated null storage for null extension scalars, still rejects non-null storage, and adds regression coverage for both cases.

Tests: `go test ./arrow/scalar`