### PR TITLE
fix(arrow/scalar): handle nil child values in run-end scalars

### DIFF
--- a/arrow/scalar/nested.go
+++ b/arrow/scalar/nested.go
@@ -754,6 +754,13 @@ func (s *RunEndEncoded) Release() {
 func (s *RunEndEncoded) value() interface{} { return s.Value.value() }
 
 func (s *RunEndEncoded) Validate() (err error) {
+	if s.Value == nil {
+		if !s.Valid {
+			return nil
+		}
+		return fmt.Errorf("%w: non-null run-end-encoded scalar has no value", arrow.ErrInvalid)
+	}
+
 	if err = s.Value.Validate(); err != nil {
 		return
 	}

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -1774,3 +1774,11 @@ func TestRunEndEncodedNullScalar(t *testing.T) {
 	assert.NoError(t, sc.Validate())
 	assert.NoError(t, sc.ValidateFull())
 }
+
+func TestRunEndEncodedScalarValidateRejectsMissingNonNullValue(t *testing.T) {
+	sc := scalar.MakeNullScalar(arrow.RunEndEncodedOf(arrow.PrimitiveTypes.Int16, arrow.BinaryTypes.String)).(*scalar.RunEndEncoded)
+	sc.Valid = true
+
+	assert.ErrorContains(t, sc.Validate(), "has no value")
+	assert.ErrorContains(t, sc.ValidateFull(), "has no value")
+}

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -1771,4 +1771,6 @@ func TestRunEndEncodedNullScalar(t *testing.T) {
 	assert.False(t, sc.IsValid())
 	assert.Truef(t, arrow.TypeEqual(dt, sc.DataType()), "expected: %s\ngot: %s", dt, sc.DataType())
 	assert.IsType(t, (*scalar.RunEndEncoded)(nil), sc)
+	assert.NoError(t, sc.Validate())
+	assert.NoError(t, sc.ValidateFull())
 }


### PR DESCRIPTION
`MakeNullScalar` creates a null run-end encoded scalar without a child value. `RunEndEncoded.Validate` dereferenced that value before checking nullness, so validation could panic.

This handles the missing child explicitly: null scalars are accepted, malformed non-null scalars still fail, and both paths are covered by tests.

Tests: `go test ./arrow/scalar`