### PR TITLE
fix(parquet/compress): allocate uncompressed output for short destinations

### DIFF
--- a/parquet/compress/compress.go
+++ b/parquet/compress/compress.go
@@ -165,10 +165,7 @@ func (nocodec) NewReader(r io.Reader) io.ReadCloser {
 }
 
 func (nocodec) Decode(dst, src []byte) []byte {
-	if dst != nil {
-		copy(dst, src)
-	}
-	return dst
+	return append(dst[:0], src...)
 }
 
 func (n nocodec) DecodeWithError(dst, src []byte) ([]byte, error) {
@@ -184,13 +181,11 @@ func (writerNopCloser) Close() error {
 }
 
 func (nocodec) Encode(dst, src []byte) []byte {
-	copy(dst, src)
-	return dst
+	return append(dst[:0], src...)
 }
 
 func (nocodec) EncodeLevel(dst, src []byte, _ int) []byte {
-	copy(dst, src)
-	return dst
+	return append(dst[:0], src...)
 }
 
 func (nocodec) NewWriter(w io.Writer) io.WriteCloser {

--- a/parquet/compress/compress_test.go
+++ b/parquet/compress/compress_test.go
@@ -120,6 +120,18 @@ func TestCompressDataOneShot(t *testing.T) {
 	}
 }
 
+func TestUncompressedCodecAllocatesDestination(t *testing.T) {
+	codec, err := compress.GetCodec(compress.Codecs.Uncompressed)
+	assert.NoError(t, err)
+	src := []byte("arrow")
+
+	assert.Equal(t, src, codec.Encode(nil, src))
+	assert.Equal(t, src, codec.Encode(make([]byte, 1), src))
+	assert.Equal(t, src, codec.EncodeLevel(nil, src, 0))
+	assert.Equal(t, src, codec.Decode(nil, src))
+	assert.Equal(t, src, codec.Decode(make([]byte, 1), src))
+}
+
 func TestGzipCompressBound(t *testing.T) {
 	codec, err := compress.GetCodec(compress.Codecs.Gzip)
 	assert.NoError(t, err)

--- a/parquet/compress/compress_test.go
+++ b/parquet/compress/compress_test.go
@@ -128,6 +128,7 @@ func TestUncompressedCodecAllocatesDestination(t *testing.T) {
 	assert.Equal(t, src, codec.Encode(nil, src))
 	assert.Equal(t, src, codec.Encode(make([]byte, 1), src))
 	assert.Equal(t, src, codec.EncodeLevel(nil, src, 0))
+	assert.Equal(t, src, codec.EncodeLevel(make([]byte, 1), src, 0))
 	assert.Equal(t, src, codec.Decode(nil, src))
 	assert.Equal(t, src, codec.Decode(make([]byte, 1), src))
 }


### PR DESCRIPTION
The codec contract allows a `nil` or undersized destination and expects the codec to allocate when needed. The uncompressed codec was just returning the unchanged destination, which could leave callers with empty or truncated output.

This switches `Encode`, `EncodeLevel`, and `Decode` to append-based copying and adds coverage for `nil` and undersized destinations.

Tests: `go test ./parquet/compress`