### PR TITLE
fix(parquet/metadata): reject malformed fixed-width statistics

### DIFF
--- a/parquet/metadata/statistics.go
+++ b/parquet/metadata/statistics.go
@@ -605,12 +605,35 @@ func (FixedLenByteArrayStatistics) cleanStat(minMax minmaxPairFixedLenByteArray)
 	return &minMax
 }
 
+func fixedStatByteWidth(typ parquet.Type) (int, bool) {
+	switch typ {
+	case parquet.Types.Boolean:
+		return 1, true
+	case parquet.Types.Int32, parquet.Types.Float:
+		return 4, true
+	case parquet.Types.Int64, parquet.Types.Double:
+		return 8, true
+	case parquet.Types.Int96:
+		return 12, true
+	default:
+		return 0, false
+	}
+}
+
+func validEncodedStat(descr *schema.Column, val []byte) bool {
+	if descr.PhysicalType() == parquet.Types.ByteArray {
+		return true
+	}
+	if descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+		return len(val) == int(descr.TypeLength())
+	}
+	width, ok := fixedStatByteWidth(descr.PhysicalType())
+	return ok && len(val) == width
+}
+
 func GetStatValue(typ parquet.Type, val []byte) interface{} {
-	width := typ.ByteSize()
-	if width > 0 && len(val) < width {
-		padded := make([]byte, width)
-		copy(padded, val)
-		val = padded
+	if width, ok := fixedStatByteWidth(typ); ok && len(val) != width {
+		return val
 	}
 
 	switch typ {

--- a/parquet/metadata/statistics.go
+++ b/parquet/metadata/statistics.go
@@ -606,6 +606,13 @@ func (FixedLenByteArrayStatistics) cleanStat(minMax minmaxPairFixedLenByteArray)
 }
 
 func GetStatValue(typ parquet.Type, val []byte) interface{} {
+	width := typ.ByteSize()
+	if width > 0 && len(val) < width {
+		padded := make([]byte, width)
+		copy(padded, val)
+		val = padded
+	}
+
 	switch typ {
 	case parquet.Types.Boolean:
 		return val[0] != 0

--- a/parquet/metadata/statistics_test.go
+++ b/parquet/metadata/statistics_test.go
@@ -859,16 +859,14 @@ func TestByteArrayStatisticsFromEncodedOwnsMinMax(t *testing.T) {
 	assert.Equal(t, "zzz", string(stats.Max()))
 }
 
-func TestTruncatedFixedWidthStatisticsAreZeroPadded(t *testing.T) {
+func TestMalformedFixedWidthStatisticsAreIgnored(t *testing.T) {
 	descr := schema.NewColumn(schema.NewInt32Node("i32", parquet.Repetitions.Required, -1), 0, 0)
 	stats := metadata.NewStatisticsFromEncoded(descr, memory.DefaultAllocator, 1,
 		&encodedStatProvider{min: []byte{0x34, 0x12}, max: []byte{0x78}}).(*metadata.Int32Statistics)
 
-	require.True(t, stats.HasMinMax())
-	assert.Equal(t, int32(0x1234), stats.Min())
-	assert.Equal(t, int32(0x78), stats.Max())
-	assert.Equal(t, int32(0x1234), metadata.GetStatValue(parquet.Types.Int32, []byte{0x34, 0x12}))
-	assert.Equal(t, false, metadata.GetStatValue(parquet.Types.Boolean, nil))
+	assert.False(t, stats.HasMinMax())
+	assert.Equal(t, []byte{0x34, 0x12}, metadata.GetStatValue(parquet.Types.Int32, []byte{0x34, 0x12}))
+	assert.Equal(t, []byte(nil), metadata.GetStatValue(parquet.Types.Boolean, nil))
 
 	for _, typ := range []parquet.Type{
 		parquet.Types.Boolean,
@@ -884,12 +882,15 @@ func TestTruncatedFixedWidthStatisticsAreZeroPadded(t *testing.T) {
 	}
 }
 
-func TestTruncatedFixedLenByteArrayStatisticsKeepTheirLength(t *testing.T) {
+func TestMalformedFixedLenByteArrayStatisticsAreIgnored(t *testing.T) {
 	descr := schema.NewColumn(schema.NewFixedLenByteArrayNode("flba", parquet.Repetitions.Required, 8, -1), 0, 0)
 	stats := metadata.NewStatisticsFromEncoded(descr, memory.DefaultAllocator, 1,
 		&encodedStatProvider{min: []byte("ab"), max: []byte("xy")}).(*metadata.FixedLenByteArrayStatistics)
 
-	require.True(t, stats.HasMinMax())
-	assert.Equal(t, parquet.FixedLenByteArray("ab"), stats.Min())
-	assert.Equal(t, parquet.FixedLenByteArray("xy"), stats.Max())
+	assert.False(t, stats.HasMinMax())
+}
+
+func TestGetStatValuePreservesByteArrays(t *testing.T) {
+	assert.Equal(t, []byte("ab"), metadata.GetStatValue(parquet.Types.ByteArray, []byte("ab")))
+	assert.Equal(t, []byte("xy"), metadata.GetStatValue(parquet.Types.FixedLenByteArray, []byte("xy")))
 }

--- a/parquet/metadata/statistics_test.go
+++ b/parquet/metadata/statistics_test.go
@@ -858,3 +858,38 @@ func TestByteArrayStatisticsFromEncodedOwnsMinMax(t *testing.T) {
 	assert.Equal(t, "aaa", string(stats.Min()))
 	assert.Equal(t, "zzz", string(stats.Max()))
 }
+
+func TestTruncatedFixedWidthStatisticsAreZeroPadded(t *testing.T) {
+	descr := schema.NewColumn(schema.NewInt32Node("i32", parquet.Repetitions.Required, -1), 0, 0)
+	stats := metadata.NewStatisticsFromEncoded(descr, memory.DefaultAllocator, 1,
+		&encodedStatProvider{min: []byte{0x34, 0x12}, max: []byte{0x78}}).(*metadata.Int32Statistics)
+
+	require.True(t, stats.HasMinMax())
+	assert.Equal(t, int32(0x1234), stats.Min())
+	assert.Equal(t, int32(0x78), stats.Max())
+	assert.Equal(t, int32(0x1234), metadata.GetStatValue(parquet.Types.Int32, []byte{0x34, 0x12}))
+	assert.Equal(t, false, metadata.GetStatValue(parquet.Types.Boolean, nil))
+
+	for _, typ := range []parquet.Type{
+		parquet.Types.Boolean,
+		parquet.Types.Int32,
+		parquet.Types.Int64,
+		parquet.Types.Int96,
+		parquet.Types.Float,
+		parquet.Types.Double,
+	} {
+		assert.NotPanics(t, func() {
+			metadata.GetStatValue(typ, []byte{1})
+		})
+	}
+}
+
+func TestTruncatedFixedLenByteArrayStatisticsKeepTheirLength(t *testing.T) {
+	descr := schema.NewColumn(schema.NewFixedLenByteArrayNode("flba", parquet.Repetitions.Required, 8, -1), 0, 0)
+	stats := metadata.NewStatisticsFromEncoded(descr, memory.DefaultAllocator, 1,
+		&encodedStatProvider{min: []byte("ab"), max: []byte("xy")}).(*metadata.FixedLenByteArrayStatistics)
+
+	require.True(t, stats.HasMinMax())
+	assert.Equal(t, parquet.FixedLenByteArray("ab"), stats.Min())
+	assert.Equal(t, parquet.FixedLenByteArray("xy"), stats.Max())
+}

--- a/parquet/metadata/statistics_types.gen.go
+++ b/parquet/metadata/statistics_types.gen.go
@@ -79,11 +79,16 @@ func NewInt32StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator, n
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		ret.min = ret.plainDecode(encodedMin)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -105,16 +110,6 @@ func (s *Int32Statistics) plainEncode(src int32) []byte {
 
 func (s *Int32Statistics) plainDecode(src []byte) int32 {
 	var buf [1]int32
-	width := s.descr.PhysicalType().ByteSize()
-	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
-		width = int(s.descr.TypeLength())
-	}
-	if len(src) < width {
-		padded := make([]byte, width)
-		copy(padded, src)
-		src = padded
-	}
-
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
 	decoder.(encoding.Int32Decoder).Decode(buf[:])
@@ -388,11 +383,16 @@ func NewInt64StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator, n
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		ret.min = ret.plainDecode(encodedMin)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -414,16 +414,6 @@ func (s *Int64Statistics) plainEncode(src int64) []byte {
 
 func (s *Int64Statistics) plainDecode(src []byte) int64 {
 	var buf [1]int64
-	width := s.descr.PhysicalType().ByteSize()
-	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
-		width = int(s.descr.TypeLength())
-	}
-	if len(src) < width {
-		padded := make([]byte, width)
-		copy(padded, src)
-		src = padded
-	}
-
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
 	decoder.(encoding.Int64Decoder).Decode(buf[:])
@@ -697,11 +687,16 @@ func NewInt96StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator, n
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		ret.min = ret.plainDecode(encodedMin)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -723,16 +718,6 @@ func (s *Int96Statistics) plainEncode(src parquet.Int96) []byte {
 
 func (s *Int96Statistics) plainDecode(src []byte) parquet.Int96 {
 	var buf [1]parquet.Int96
-	width := s.descr.PhysicalType().ByteSize()
-	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
-		width = int(s.descr.TypeLength())
-	}
-	if len(src) < width {
-		padded := make([]byte, width)
-		copy(padded, src)
-		src = padded
-	}
-
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
 	decoder.(encoding.Int96Decoder).Decode(buf[:])
@@ -984,11 +969,16 @@ func NewFloat32StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator,
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		ret.min = ret.plainDecode(encodedMin)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -1010,16 +1000,6 @@ func (s *Float32Statistics) plainEncode(src float32) []byte {
 
 func (s *Float32Statistics) plainDecode(src []byte) float32 {
 	var buf [1]float32
-	width := s.descr.PhysicalType().ByteSize()
-	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
-		width = int(s.descr.TypeLength())
-	}
-	if len(src) < width {
-		padded := make([]byte, width)
-		copy(padded, src)
-		src = padded
-	}
-
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
 	decoder.(encoding.Float32Decoder).Decode(buf[:])
@@ -1285,11 +1265,16 @@ func NewFloat64StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator,
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		ret.min = ret.plainDecode(encodedMin)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -1311,16 +1296,6 @@ func (s *Float64Statistics) plainEncode(src float64) []byte {
 
 func (s *Float64Statistics) plainDecode(src []byte) float64 {
 	var buf [1]float64
-	width := s.descr.PhysicalType().ByteSize()
-	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
-		width = int(s.descr.TypeLength())
-	}
-	if len(src) < width {
-		padded := make([]byte, width)
-		copy(padded, src)
-		src = padded
-	}
-
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
 	decoder.(encoding.Float64Decoder).Decode(buf[:])
@@ -1586,11 +1561,16 @@ func NewBooleanStatisticsFromEncoded(descr *schema.Column, mem memory.Allocator,
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		ret.min = ret.plainDecode(encodedMin)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -1612,16 +1592,6 @@ func (s *BooleanStatistics) plainEncode(src bool) []byte {
 
 func (s *BooleanStatistics) plainDecode(src []byte) bool {
 	var buf [1]bool
-	width := s.descr.PhysicalType().ByteSize()
-	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
-		width = int(s.descr.TypeLength())
-	}
-	if len(src) < width {
-		padded := make([]byte, width)
-		copy(padded, src)
-		src = padded
-	}
-
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
 	decoder.(encoding.BooleanDecoder).Decode(buf[:])
@@ -1952,13 +1922,18 @@ func NewByteArrayStatisticsFromEncoded(descr *schema.Column, mem memory.Allocato
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		// Copy into a statistics-owned buffer so the stored min does not alias the
 		// encoded metadata buffer; SetMinMax reuses this buffer on later updates.
 		ret.min = append(ret.min[:0], ret.plainDecode(encodedMin)...)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = append(ret.max[:0], ret.plainDecode(encodedMax)...)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -2274,13 +2249,18 @@ func NewFixedLenByteArrayStatisticsFromEncoded(descr *schema.Column, mem memory.
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		// Copy into a statistics-owned buffer so the stored min does not alias the
 		// encoded metadata buffer; SetMinMax reuses this buffer on later updates.
 		ret.min = append(ret.min[:0], ret.plainDecode(encodedMin)...)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = append(ret.max[:0], ret.plainDecode(encodedMax)...)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -2601,13 +2581,18 @@ func NewFloat16StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator,
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil {
+	encodedMax := encoded.GetMax()
+	if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+		(encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+		return ret
+	}
+
+	if encoded.IsSetMin() {
 		// Copy into a statistics-owned buffer so the stored min does not alias the
 		// encoded metadata buffer; SetMinMax reuses this buffer on later updates.
 		ret.min = append(ret.min[:0], ret.plainDecode(encodedMin)...)
 	}
-	encodedMax := encoded.GetMax()
-	if encodedMax != nil {
+	if encoded.IsSetMax() {
 		ret.max = append(ret.max[:0], ret.plainDecode(encodedMax)...)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -2629,16 +2614,6 @@ func (s *Float16Statistics) plainEncode(src parquet.FixedLenByteArray) []byte {
 
 func (s *Float16Statistics) plainDecode(src []byte) parquet.FixedLenByteArray {
 	var buf [1]parquet.FixedLenByteArray
-	width := s.descr.PhysicalType().ByteSize()
-	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
-		width = int(s.descr.TypeLength())
-	}
-	if len(src) < width {
-		padded := make([]byte, width)
-		copy(padded, src)
-		src = padded
-	}
-
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
 	decoder.(encoding.FixedLenByteArrayDecoder).Decode(buf[:])

--- a/parquet/metadata/statistics_types.gen.go
+++ b/parquet/metadata/statistics_types.gen.go
@@ -79,11 +79,11 @@ func NewInt32StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator, n
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		ret.min = ret.plainDecode(encodedMin)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -105,6 +105,15 @@ func (s *Int32Statistics) plainEncode(src int32) []byte {
 
 func (s *Int32Statistics) plainDecode(src []byte) int32 {
 	var buf [1]int32
+	width := s.descr.PhysicalType().ByteSize()
+	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+		width = int(s.descr.TypeLength())
+	}
+	if len(src) < width {
+		padded := make([]byte, width)
+		copy(padded, src)
+		src = padded
+	}
 
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
@@ -379,11 +388,11 @@ func NewInt64StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator, n
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		ret.min = ret.plainDecode(encodedMin)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -405,6 +414,15 @@ func (s *Int64Statistics) plainEncode(src int64) []byte {
 
 func (s *Int64Statistics) plainDecode(src []byte) int64 {
 	var buf [1]int64
+	width := s.descr.PhysicalType().ByteSize()
+	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+		width = int(s.descr.TypeLength())
+	}
+	if len(src) < width {
+		padded := make([]byte, width)
+		copy(padded, src)
+		src = padded
+	}
 
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
@@ -679,11 +697,11 @@ func NewInt96StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator, n
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		ret.min = ret.plainDecode(encodedMin)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -705,6 +723,15 @@ func (s *Int96Statistics) plainEncode(src parquet.Int96) []byte {
 
 func (s *Int96Statistics) plainDecode(src []byte) parquet.Int96 {
 	var buf [1]parquet.Int96
+	width := s.descr.PhysicalType().ByteSize()
+	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+		width = int(s.descr.TypeLength())
+	}
+	if len(src) < width {
+		padded := make([]byte, width)
+		copy(padded, src)
+		src = padded
+	}
 
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
@@ -957,11 +984,11 @@ func NewFloat32StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator,
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		ret.min = ret.plainDecode(encodedMin)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -983,6 +1010,15 @@ func (s *Float32Statistics) plainEncode(src float32) []byte {
 
 func (s *Float32Statistics) plainDecode(src []byte) float32 {
 	var buf [1]float32
+	width := s.descr.PhysicalType().ByteSize()
+	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+		width = int(s.descr.TypeLength())
+	}
+	if len(src) < width {
+		padded := make([]byte, width)
+		copy(padded, src)
+		src = padded
+	}
 
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
@@ -1249,11 +1285,11 @@ func NewFloat64StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator,
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		ret.min = ret.plainDecode(encodedMin)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -1275,6 +1311,15 @@ func (s *Float64Statistics) plainEncode(src float64) []byte {
 
 func (s *Float64Statistics) plainDecode(src []byte) float64 {
 	var buf [1]float64
+	width := s.descr.PhysicalType().ByteSize()
+	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+		width = int(s.descr.TypeLength())
+	}
+	if len(src) < width {
+		padded := make([]byte, width)
+		copy(padded, src)
+		src = padded
+	}
 
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
@@ -1541,11 +1586,11 @@ func NewBooleanStatisticsFromEncoded(descr *schema.Column, mem memory.Allocator,
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		ret.min = ret.plainDecode(encodedMin)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = ret.plainDecode(encodedMax)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -1567,6 +1612,15 @@ func (s *BooleanStatistics) plainEncode(src bool) []byte {
 
 func (s *BooleanStatistics) plainDecode(src []byte) bool {
 	var buf [1]bool
+	width := s.descr.PhysicalType().ByteSize()
+	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+		width = int(s.descr.TypeLength())
+	}
+	if len(src) < width {
+		padded := make([]byte, width)
+		copy(padded, src)
+		src = padded
+	}
 
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)
@@ -1898,13 +1952,13 @@ func NewByteArrayStatisticsFromEncoded(descr *schema.Column, mem memory.Allocato
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		// Copy into a statistics-owned buffer so the stored min does not alias the
 		// encoded metadata buffer; SetMinMax reuses this buffer on later updates.
 		ret.min = append(ret.min[:0], ret.plainDecode(encodedMin)...)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = append(ret.max[:0], ret.plainDecode(encodedMax)...)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -2220,13 +2274,13 @@ func NewFixedLenByteArrayStatisticsFromEncoded(descr *schema.Column, mem memory.
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		// Copy into a statistics-owned buffer so the stored min does not alias the
 		// encoded metadata buffer; SetMinMax reuses this buffer on later updates.
 		ret.min = append(ret.min[:0], ret.plainDecode(encodedMin)...)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = append(ret.max[:0], ret.plainDecode(encodedMax)...)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -2247,12 +2301,7 @@ func (s *FixedLenByteArrayStatistics) plainEncode(src parquet.FixedLenByteArray)
 }
 
 func (s *FixedLenByteArrayStatistics) plainDecode(src []byte) parquet.FixedLenByteArray {
-	var buf [1]parquet.FixedLenByteArray
-
-	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
-	decoder.SetData(1, src)
-	decoder.(encoding.FixedLenByteArrayDecoder).Decode(buf[:])
-	return buf[0]
+	return src
 }
 
 func (s *FixedLenByteArrayStatistics) minval(a, b parquet.FixedLenByteArray) parquet.FixedLenByteArray {
@@ -2552,13 +2601,13 @@ func NewFloat16StatisticsFromEncoded(descr *schema.Column, mem memory.Allocator,
 	}
 
 	encodedMin := encoded.GetMin()
-	if encodedMin != nil && len(encodedMin) > 0 {
+	if encodedMin != nil {
 		// Copy into a statistics-owned buffer so the stored min does not alias the
 		// encoded metadata buffer; SetMinMax reuses this buffer on later updates.
 		ret.min = append(ret.min[:0], ret.plainDecode(encodedMin)...)
 	}
 	encodedMax := encoded.GetMax()
-	if encodedMax != nil && len(encodedMax) > 0 {
+	if encodedMax != nil {
 		ret.max = append(ret.max[:0], ret.plainDecode(encodedMax)...)
 	}
 	ret.hasMinMax = encoded.IsSetMax() || encoded.IsSetMin()
@@ -2580,6 +2629,15 @@ func (s *Float16Statistics) plainEncode(src parquet.FixedLenByteArray) []byte {
 
 func (s *Float16Statistics) plainDecode(src []byte) parquet.FixedLenByteArray {
 	var buf [1]parquet.FixedLenByteArray
+	width := s.descr.PhysicalType().ByteSize()
+	if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+		width = int(s.descr.TypeLength())
+	}
+	if len(src) < width {
+		padded := make([]byte, width)
+		copy(padded, src)
+		src = padded
+	}
 
 	decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
 	decoder.SetData(1, src)

--- a/parquet/metadata/statistics_types.gen.go.tmpl
+++ b/parquet/metadata/statistics_types.gen.go.tmpl
@@ -86,7 +86,7 @@ func New{{.Name}}StatisticsFromEncoded(descr *schema.Column, mem memory.Allocato
   }
 
   encodedMin := encoded.GetMin()
-  if encodedMin != nil && len(encodedMin) > 0 {
+  if encodedMin != nil {
 {{- if or (eq .name "parquet.ByteArray") (eq .name "parquet.FixedLenByteArray")}}
     // Copy into a statistics-owned buffer so the stored min does not alias the
     // encoded metadata buffer; SetMinMax reuses this buffer on later updates.
@@ -96,7 +96,7 @@ func New{{.Name}}StatisticsFromEncoded(descr *schema.Column, mem memory.Allocato
 {{- end}}
   }
   encodedMax := encoded.GetMax()
-  if encodedMax != nil && len(encodedMax) > 0 {
+  if encodedMax != nil {
 {{- if or (eq .name "parquet.ByteArray") (eq .name "parquet.FixedLenByteArray")}}
     ret.max = append(ret.max[:0], ret.plainDecode(encodedMax)...)
 {{- else}}
@@ -127,10 +127,19 @@ func (s *{{.Name}}Statistics) plainEncode(src {{.name}}) []byte {
 }
 
 func (s *{{.Name}}Statistics) plainDecode(src []byte) {{.name}} {
-{{- if eq .Name "ByteArray"}}
+{{- if or (eq .Name "ByteArray") (eq .Name "FixedLenByteArray")}}
   return src
 {{- else}}
   var buf [1]{{.name}}
+  width := s.descr.PhysicalType().ByteSize()
+  if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
+    width = int(s.descr.TypeLength())
+  }
+  if len(src) < width {
+    padded := make([]byte, width)
+    copy(padded, src)
+    src = padded
+  }
 
   decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
   decoder.SetData(1, src)

--- a/parquet/metadata/statistics_types.gen.go.tmpl
+++ b/parquet/metadata/statistics_types.gen.go.tmpl
@@ -86,7 +86,13 @@ func New{{.Name}}StatisticsFromEncoded(descr *schema.Column, mem memory.Allocato
   }
 
   encodedMin := encoded.GetMin()
-  if encodedMin != nil {
+  encodedMax := encoded.GetMax()
+  if (encoded.IsSetMin() && !validEncodedStat(descr, encodedMin)) ||
+      (encoded.IsSetMax() && !validEncodedStat(descr, encodedMax)) {
+    return ret
+  }
+
+  if encoded.IsSetMin() {
 {{- if or (eq .name "parquet.ByteArray") (eq .name "parquet.FixedLenByteArray")}}
     // Copy into a statistics-owned buffer so the stored min does not alias the
     // encoded metadata buffer; SetMinMax reuses this buffer on later updates.
@@ -95,8 +101,7 @@ func New{{.Name}}StatisticsFromEncoded(descr *schema.Column, mem memory.Allocato
     ret.min = ret.plainDecode(encodedMin)
 {{- end}}
   }
-  encodedMax := encoded.GetMax()
-  if encodedMax != nil {
+  if encoded.IsSetMax() {
 {{- if or (eq .name "parquet.ByteArray") (eq .name "parquet.FixedLenByteArray")}}
     ret.max = append(ret.max[:0], ret.plainDecode(encodedMax)...)
 {{- else}}
@@ -131,16 +136,6 @@ func (s *{{.Name}}Statistics) plainDecode(src []byte) {{.name}} {
   return src
 {{- else}}
   var buf [1]{{.name}}
-  width := s.descr.PhysicalType().ByteSize()
-  if s.descr.PhysicalType() == parquet.Types.FixedLenByteArray {
-    width = int(s.descr.TypeLength())
-  }
-  if len(src) < width {
-    padded := make([]byte, width)
-    copy(padded, src)
-    src = padded
-  }
-
   decoder := encoding.NewDecoder(s.descr.PhysicalType(), parquet.Encodings.Plain, s.descr, s.mem)
   decoder.SetData(1, src)
   decoder.(encoding.{{if .logical}}{{.physical}}{{else}}{{.Name}}{{end}}Decoder).Decode(buf[:])


### PR DESCRIPTION
### Rationale for this change

Fixed-width Parquet statistics must use the exact PLAIN-encoded physical width. Padding a shorter value invents a different bound, while formatting the raw bytes can panic. Variable-length BYTE_ARRAY bounds should remain unchanged.

### What changes are included in this PR?

- Ignore min/max when a present fixed-width statistic does not match the declared physical width.
- Preserve variable-length BYTE_ARRAY values exactly as encoded.
- Return malformed scalar bytes unchanged from `GetStatValue` instead of padding or indexing past them.
- Regenerate the typed statistics implementation from its template.

### Are these changes tested?

Yes. Focused tests cover malformed numeric and FIXED_LEN_BYTE_ARRAY values, short scalar formatting, and BYTE_ARRAY preservation. The metadata and Parquet file test suites pass.