### PR TITLE
fix(arrow/array): validate list-view builder dimensions

### DIFF
--- a/arrow/array/list.go
+++ b/arrow/array/list.go
@@ -1332,7 +1332,42 @@ func (b *LargeListViewBuilder) NewLargeListViewArray() (a *LargeListView) {
 	return
 }
 
+func (b *baseListViewBuilder) validateDimensions() {
+	offsetCount, sizeCount := b.offsets.Len(), b.sizes.Len()
+	if offsetCount < b.length || sizeCount < b.length {
+		panic(fmt.Errorf("%w: arrow/array: list-view offset and size counts must be at least the list length (offsets=%d, sizes=%d, lists=%d)",
+			arrow.ErrInvalid, offsetCount, sizeCount, b.length))
+	}
+
+	valueLen := int64(b.values.Len())
+	for i := 0; i < b.length; i++ {
+		var offset, size int64
+		switch offsets := b.offsets.(type) {
+		case *Int32Builder:
+			offset = int64(offsets.Value(i))
+			size = int64(b.sizes.(*Int32Builder).Value(i))
+		case *Int64Builder:
+			offset = offsets.Value(i)
+			size = b.sizes.(*Int64Builder).Value(i)
+		}
+		if size < 0 {
+			panic(fmt.Errorf("%w: arrow/array: list-view size at index %d is negative: %d", arrow.ErrInvalid, i, size))
+		}
+		if size == 0 {
+			continue
+		}
+		if offset < 0 {
+			panic(fmt.Errorf("%w: arrow/array: list-view offset at index %d is negative: %d", arrow.ErrInvalid, i, offset))
+		}
+		if offset > valueLen || size > valueLen-offset {
+			panic(fmt.Errorf("%w: arrow/array: list-view range at index %d exceeds value length: %d + %d > %d",
+				arrow.ErrInvalid, i, offset, size, valueLen))
+		}
+	}
+}
+
 func (b *baseListViewBuilder) newData() (data *Data) {
+	b.validateDimensions()
 	values := b.values.NewArray()
 	defer values.Release()
 

--- a/arrow/array/list_test.go
+++ b/arrow/array/list_test.go
@@ -346,60 +346,6 @@ func TestListArrayBulkAppend(t *testing.T) {
 	}
 }
 
-func TestListViewBuilderRejectsInvalidBulkDimensions(t *testing.T) {
-	for _, large := range []bool{false, true} {
-		name := "list_view"
-		if large {
-			name = "large_list_view"
-		}
-		t.Run(name, func(t *testing.T) {
-			tests := []struct {
-				name      string
-				offsets   []int64
-				sizes     []int64
-				valueLen  int
-				panicText string
-			}{
-				{name: "missing offset", sizes: []int64{0}, panicText: "invalid: arrow/array: list-view offset and size counts must be at least the list length (offsets=0, sizes=1, lists=1)"},
-				{name: "missing size", offsets: []int64{0}, panicText: "invalid: arrow/array: list-view offset and size counts must be at least the list length (offsets=1, sizes=0, lists=1)"},
-				{name: "negative size", offsets: []int64{0}, sizes: []int64{-1}, panicText: "invalid: arrow/array: list-view size at index 0 is negative: -1"},
-				{name: "negative offset", offsets: []int64{-1}, sizes: []int64{1}, valueLen: 1, panicText: "invalid: arrow/array: list-view offset at index 0 is negative: -1"},
-				{name: "range exceeds values", offsets: []int64{1}, sizes: []int64{2}, valueLen: 2, panicText: "invalid: arrow/array: list-view range at index 0 exceeds value length: 1 + 2 > 2"},
-			}
-
-			for _, tt := range tests {
-				t.Run(tt.name, func(t *testing.T) {
-					mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-					defer mem.AssertSize(t, 0)
-
-					var b array.VarLenListLikeBuilder
-					if large {
-						lb := array.NewLargeListViewBuilder(mem, arrow.PrimitiveTypes.Int32)
-						lb.AppendValuesWithSizes(tt.offsets, tt.sizes, []bool{true})
-						b = lb
-					} else {
-						lb := array.NewListViewBuilder(mem, arrow.PrimitiveTypes.Int32)
-						offsets := make([]int32, len(tt.offsets))
-						sizes := make([]int32, len(tt.sizes))
-						for i := range tt.offsets {
-							offsets[i] = int32(tt.offsets[i])
-						}
-						for i := range tt.sizes {
-							sizes[i] = int32(tt.sizes[i])
-						}
-						lb.AppendValuesWithSizes(offsets, sizes, []bool{true})
-						b = lb
-					}
-					defer b.Release()
-					b.ValueBuilder().(*array.Int32Builder).AppendValues(make([]int32, tt.valueLen), nil)
-
-					assert.PanicsWithError(t, tt.panicText, func() { b.NewArray() })
-				})
-			}
-		})
-	}
-}
-
 func TestListViewArrayBulkAppend(t *testing.T) {
 	tests := []struct {
 		typeID  arrow.Type
@@ -479,6 +425,60 @@ func TestListViewArrayBulkAppend(t *testing.T) {
 			varr := arr.ListValues().(*array.Int32)
 			if got, want := varr.Int32Values(), vs; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got=%v, want=%v", got, want)
+			}
+		})
+	}
+}
+
+func TestListViewBuilderRejectsInvalidBulkDimensions(t *testing.T) {
+	for _, large := range []bool{false, true} {
+		name := "list_view"
+		if large {
+			name = "large_list_view"
+		}
+		t.Run(name, func(t *testing.T) {
+			tests := []struct {
+				name      string
+				offsets   []int64
+				sizes     []int64
+				valueLen  int
+				panicText string
+			}{
+				{name: "missing offset", sizes: []int64{0}, panicText: "invalid: arrow/array: list-view offset and size counts must be at least the list length (offsets=0, sizes=1, lists=1)"},
+				{name: "missing size", offsets: []int64{0}, panicText: "invalid: arrow/array: list-view offset and size counts must be at least the list length (offsets=1, sizes=0, lists=1)"},
+				{name: "negative size", offsets: []int64{0}, sizes: []int64{-1}, panicText: "invalid: arrow/array: list-view size at index 0 is negative: -1"},
+				{name: "negative offset", offsets: []int64{-1}, sizes: []int64{1}, valueLen: 1, panicText: "invalid: arrow/array: list-view offset at index 0 is negative: -1"},
+				{name: "range exceeds values", offsets: []int64{1}, sizes: []int64{2}, valueLen: 2, panicText: "invalid: arrow/array: list-view range at index 0 exceeds value length: 1 + 2 > 2"},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+					defer mem.AssertSize(t, 0)
+
+					var b array.VarLenListLikeBuilder
+					if large {
+						lb := array.NewLargeListViewBuilder(mem, arrow.PrimitiveTypes.Int32)
+						lb.AppendValuesWithSizes(tt.offsets, tt.sizes, []bool{true})
+						b = lb
+					} else {
+						lb := array.NewListViewBuilder(mem, arrow.PrimitiveTypes.Int32)
+						offsets := make([]int32, len(tt.offsets))
+						sizes := make([]int32, len(tt.sizes))
+						for i := range tt.offsets {
+							offsets[i] = int32(tt.offsets[i])
+						}
+						for i := range tt.sizes {
+							sizes[i] = int32(tt.sizes[i])
+						}
+						lb.AppendValuesWithSizes(offsets, sizes, []bool{true})
+						b = lb
+					}
+					defer b.Release()
+					b.ValueBuilder().(*array.Int32Builder).AppendValues(make([]int32, tt.valueLen), nil)
+
+					assert.PanicsWithError(t, tt.panicText, func() { b.NewArray() })
+				})
 			}
 		})
 	}

--- a/arrow/array/list_test.go
+++ b/arrow/array/list_test.go
@@ -346,6 +346,60 @@ func TestListArrayBulkAppend(t *testing.T) {
 	}
 }
 
+func TestListViewBuilderRejectsInvalidBulkDimensions(t *testing.T) {
+	for _, large := range []bool{false, true} {
+		name := "list_view"
+		if large {
+			name = "large_list_view"
+		}
+		t.Run(name, func(t *testing.T) {
+			tests := []struct {
+				name      string
+				offsets   []int64
+				sizes     []int64
+				valueLen  int
+				panicText string
+			}{
+				{name: "missing offset", sizes: []int64{0}, panicText: "invalid: arrow/array: list-view offset and size counts must be at least the list length (offsets=0, sizes=1, lists=1)"},
+				{name: "missing size", offsets: []int64{0}, panicText: "invalid: arrow/array: list-view offset and size counts must be at least the list length (offsets=1, sizes=0, lists=1)"},
+				{name: "negative size", offsets: []int64{0}, sizes: []int64{-1}, panicText: "invalid: arrow/array: list-view size at index 0 is negative: -1"},
+				{name: "negative offset", offsets: []int64{-1}, sizes: []int64{1}, valueLen: 1, panicText: "invalid: arrow/array: list-view offset at index 0 is negative: -1"},
+				{name: "range exceeds values", offsets: []int64{1}, sizes: []int64{2}, valueLen: 2, panicText: "invalid: arrow/array: list-view range at index 0 exceeds value length: 1 + 2 > 2"},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+					defer mem.AssertSize(t, 0)
+
+					var b array.VarLenListLikeBuilder
+					if large {
+						lb := array.NewLargeListViewBuilder(mem, arrow.PrimitiveTypes.Int32)
+						lb.AppendValuesWithSizes(tt.offsets, tt.sizes, []bool{true})
+						b = lb
+					} else {
+						lb := array.NewListViewBuilder(mem, arrow.PrimitiveTypes.Int32)
+						offsets := make([]int32, len(tt.offsets))
+						sizes := make([]int32, len(tt.sizes))
+						for i := range tt.offsets {
+							offsets[i] = int32(tt.offsets[i])
+						}
+						for i := range tt.sizes {
+							sizes[i] = int32(tt.sizes[i])
+						}
+						lb.AppendValuesWithSizes(offsets, sizes, []bool{true})
+						b = lb
+					}
+					defer b.Release()
+					b.ValueBuilder().(*array.Int32Builder).AppendValues(make([]int32, tt.valueLen), nil)
+
+					assert.PanicsWithError(t, tt.panicText, func() { b.NewArray() })
+				})
+			}
+		})
+	}
+}
+
 func TestListViewArrayBulkAppend(t *testing.T) {
 	tests := []struct {
 		typeID  arrow.Type


### PR DESCRIPTION
### Rationale for this change

ListViewBuilder.AppendValuesWithSizes can accept too few dimensions or ranges that do not fit within the child values. NewArray can then return an invalid ListView array that fails when read, sliced, or validated.

### What changes are included in this PR?

* Require enough offsets and sizes for every logical list.
* Reject negative sizes, negative offsets for non-empty ranges, and ranges beyond the child array.
* Apply the checks to both ListView and LargeListView builders while preserving valid extra offset capacity.

### Are these changes tested?

Yes. The tests cover missing offsets, missing sizes, negative sizes, negative offsets, and ranges beyond the child values for both offset widths. The full arrow/array package, assertion build, compute packages, IPC package, and CSV package also pass.