### PR TITLE
fix(arrow/array): validate list builder offsets

### DIFF
--- a/arrow/array/list.go
+++ b/arrow/array/list.go
@@ -557,7 +557,36 @@ func (b *LargeListBuilder) NewLargeListArray() (a *LargeList) {
 	return
 }
 
+func (b *baseListBuilder) validateOffsets() {
+	count := b.offsets.Len()
+	if count != b.length && count != b.length+1 {
+		panic(fmt.Errorf("%w: arrow/array: list offset count must equal list length or list length plus one (offsets=%d, lists=%d)",
+			arrow.ErrInvalid, count, b.length))
+	}
+	valueLen := int64(b.values.Len())
+	var previous int64
+	for i := 0; i < count; i++ {
+		var offset int64
+		switch offsets := b.offsets.(type) {
+		case *Int32Builder:
+			offset = int64(offsets.Value(i))
+		case *Int64Builder:
+			offset = offsets.Value(i)
+		}
+		if offset < 0 || offset > valueLen {
+			panic(fmt.Errorf("%w: arrow/array: list offset at index %d is out of bounds: %d not in [0, %d]",
+				arrow.ErrInvalid, i, offset, valueLen))
+		}
+		if i > 0 && offset < previous {
+			panic(fmt.Errorf("%w: arrow/array: list offsets are not monotonically non-decreasing at index %d: %d < %d",
+				arrow.ErrInvalid, i, offset, previous))
+		}
+		previous = offset
+	}
+}
+
 func (b *baseListBuilder) newData() (data *Data) {
+	b.validateOffsets()
 	if b.offsets.Len() != b.length+1 {
 		b.appendNextOffset()
 	}

--- a/arrow/array/list_test.go
+++ b/arrow/array/list_test.go
@@ -346,6 +346,55 @@ func TestListArrayBulkAppend(t *testing.T) {
 	}
 }
 
+func TestListBuilderRejectsInvalidBulkOffsets(t *testing.T) {
+	for _, large := range []bool{false, true} {
+		name := "list"
+		if large {
+			name = "large_list"
+		}
+		t.Run(name, func(t *testing.T) {
+			tests := []struct {
+				name      string
+				offsets   []int64
+				valueLen  int
+				panicText string
+			}{
+				{name: "too few offsets", offsets: nil, panicText: "invalid: arrow/array: list offset count must equal list length or list length plus one (offsets=0, lists=1)"},
+				{name: "too many offsets", offsets: []int64{0, 0, 0}, panicText: "invalid: arrow/array: list offset count must equal list length or list length plus one (offsets=3, lists=1)"},
+				{name: "negative offset", offsets: []int64{-1, 0}, panicText: "invalid: arrow/array: list offset at index 0 is out of bounds: -1 not in [0, 0]"},
+				{name: "non-monotonic offsets", offsets: []int64{1, 0}, valueLen: 1, panicText: "invalid: arrow/array: list offsets are not monotonically non-decreasing at index 1: 0 < 1"},
+				{name: "final offset exceeds values", offsets: []int64{0, 2}, valueLen: 1, panicText: "invalid: arrow/array: list offset at index 1 is out of bounds: 2 not in [0, 1]"},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+					defer mem.AssertSize(t, 0)
+
+					var b array.VarLenListLikeBuilder
+					if large {
+						lb := array.NewLargeListBuilder(mem, arrow.PrimitiveTypes.Int32)
+						lb.AppendValues(tt.offsets, []bool{true})
+						b = lb
+					} else {
+						lb := array.NewListBuilder(mem, arrow.PrimitiveTypes.Int32)
+						offsets := make([]int32, len(tt.offsets))
+						for i, offset := range tt.offsets {
+							offsets[i] = int32(offset)
+						}
+						lb.AppendValues(offsets, []bool{true})
+						b = lb
+					}
+					defer b.Release()
+					b.ValueBuilder().(*array.Int32Builder).AppendValues(make([]int32, tt.valueLen), nil)
+
+					assert.PanicsWithError(t, tt.panicText, func() { b.NewArray() })
+				})
+			}
+		})
+	}
+}
+
 func TestListViewArrayBulkAppend(t *testing.T) {
 	tests := []struct {
 		typeID  arrow.Type


### PR DESCRIPTION
### Rationale for this change

ListBuilder.AppendValues can accept malformed offset counts and ranges. NewArray then appends a final offset for any count mismatch and can return arrays with undersized, non-monotonic, or out-of-bounds offset buffers. Reading or validating those arrays can fail later.

### What changes are included in this PR?

* Require supplied offsets to contain either one entry per list or one entry per list plus the final offset.
* Reject negative, out-of-bounds, and non-monotonic offsets for List and LargeList builders.
* Continue allowing valid trailing child values that are not referenced by the list offsets.

### Are these changes tested?

Yes. The tests cover too few and too many offsets, negative offsets, non-monotonic offsets, and final offsets beyond the child array for both offset widths. The full arrow/array package, assertion build, compute packages, IPC package, and CSV package also pass.