### PR TITLE
fix(arrow/array): validate struct child lengths

### DIFF
--- a/arrow/array/struct.go
+++ b/arrow/array/struct.go
@@ -143,17 +143,18 @@ func NewStructData(data arrow.ArrayData) *Struct {
 func (a *Struct) NumField() int           { return len(a.fields) }
 func (a *Struct) Field(i int) arrow.Array { return a.fields[i] }
 
-func (a *Struct) Validate() error { return nil }
-
-func (a *Struct) ValidateFull() error {
-	for i, field := range a.fields {
-		if field.Len() < a.Len() {
-			return fmt.Errorf("%w: arrow/array: struct field %d length %d is smaller than struct length %d",
-				arrow.ErrInvalid, i, field.Len(), a.Len())
+func (a *Struct) Validate() error {
+	expectedLength := a.data.offset + a.data.length
+	for i, child := range a.data.childData {
+		if child.Len() < expectedLength {
+			return fmt.Errorf("%w: arrow/array: struct child array #%d has length smaller than expected for struct array (%d < %d)",
+				arrow.ErrInvalid, i, child.Len(), expectedLength)
 		}
 	}
 	return nil
 }
+
+func (a *Struct) ValidateFull() error { return a.Validate() }
 
 // ValueStr returns the string representation (as json) of the value at index i.
 func (a *Struct) ValueStr(i int) string {
@@ -234,14 +235,18 @@ func (a *Struct) setData(data *Data) {
 	a.fields = make([]arrow.Array, len(data.childData))
 	for i, child := range data.childData {
 		if data.offset != 0 || child.Len() != data.length {
-			end := int64(data.offset) + int64(data.length)
-			if data.offset >= 0 && end >= int64(data.offset) && end <= int64(child.Len()) {
-				sub := NewSliceData(child, int64(data.offset), end)
-				a.fields[i] = MakeFromData(sub)
-				sub.Release()
-			} else {
-				a.fields[i] = MakeFromData(child)
+			childLen := int64(child.Len())
+			start := max(int64(data.offset), int64(0))
+			if start > childLen {
+				start = childLen
 			}
+			end := max(int64(data.offset)+int64(data.length), start)
+			if end > childLen {
+				end = childLen
+			}
+			sub := NewSliceData(child, start, end)
+			a.fields[i] = MakeFromData(sub)
+			sub.Release()
 		} else {
 			a.fields[i] = MakeFromData(child)
 		}

--- a/arrow/array/struct.go
+++ b/arrow/array/struct.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -144,6 +145,9 @@ func (a *Struct) NumField() int           { return len(a.fields) }
 func (a *Struct) Field(i int) arrow.Array { return a.fields[i] }
 
 func (a *Struct) Validate() error {
+	if a.data.offset < 0 || a.data.length < 0 || int64(a.data.offset) > math.MaxInt64-int64(a.data.length) {
+		return fmt.Errorf("%w: arrow/array: struct offset and length overflow", arrow.ErrInvalid)
+	}
 	expectedLength := a.data.offset + a.data.length
 	for i, child := range a.data.childData {
 		if child.Len() < expectedLength {
@@ -240,7 +244,17 @@ func (a *Struct) setData(data *Data) {
 			if start > childLen {
 				start = childLen
 			}
-			end := max(int64(data.offset)+int64(data.length), start)
+			var end int64
+			offset, length := int64(data.offset), int64(data.length)
+			switch {
+			case length > 0 && offset > math.MaxInt64-length:
+				end = math.MaxInt64
+			case length < 0 && offset < math.MinInt64-length:
+				end = math.MinInt64
+			default:
+				end = offset + length
+			}
+			end = max(end, start)
 			if end > childLen {
 				end = childLen
 			}

--- a/arrow/array/struct.go
+++ b/arrow/array/struct.go
@@ -143,6 +143,18 @@ func NewStructData(data arrow.ArrayData) *Struct {
 func (a *Struct) NumField() int           { return len(a.fields) }
 func (a *Struct) Field(i int) arrow.Array { return a.fields[i] }
 
+func (a *Struct) Validate() error { return nil }
+
+func (a *Struct) ValidateFull() error {
+	for i, field := range a.fields {
+		if field.Len() < a.Len() {
+			return fmt.Errorf("%w: arrow/array: struct field %d length %d is smaller than struct length %d",
+				arrow.ErrInvalid, i, field.Len(), a.Len())
+		}
+	}
+	return nil
+}
+
 // ValueStr returns the string representation (as json) of the value at index i.
 func (a *Struct) ValueStr(i int) string {
 	if a.IsNull(i) {
@@ -222,9 +234,14 @@ func (a *Struct) setData(data *Data) {
 	a.fields = make([]arrow.Array, len(data.childData))
 	for i, child := range data.childData {
 		if data.offset != 0 || child.Len() != data.length {
-			sub := NewSliceData(child, int64(data.offset), int64(data.offset+data.length))
-			a.fields[i] = MakeFromData(sub)
-			sub.Release()
+			end := int64(data.offset) + int64(data.length)
+			if data.offset >= 0 && end >= int64(data.offset) && end <= int64(child.Len()) {
+				sub := NewSliceData(child, int64(data.offset), end)
+				a.fields[i] = MakeFromData(sub)
+				sub.Release()
+			} else {
+				a.fields[i] = MakeFromData(child)
+			}
 		} else {
 			a.fields[i] = MakeFromData(child)
 		}

--- a/arrow/array/struct_test.go
+++ b/arrow/array/struct_test.go
@@ -135,6 +135,26 @@ func TestStructArray(t *testing.T) {
 	}
 }
 
+func TestStructValidateFullRejectsShortField(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	dt := arrow.StructOf(
+		arrow.Field{Name: "a", Type: arrow.PrimitiveTypes.Int32},
+		arrow.Field{Name: "b", Type: arrow.PrimitiveTypes.Int32},
+	)
+	b := array.NewStructBuilder(mem, dt)
+	defer b.Release()
+	b.Append(true)
+	b.FieldBuilder(0).(*array.Int32Builder).Append(1)
+
+	arr := b.NewStructArray()
+	defer arr.Release()
+	assert.NoError(t, arr.Validate())
+	assert.ErrorIs(t, arr.ValidateFull(), arrow.ErrInvalid)
+	assert.ErrorIs(t, array.ValidateFull(arr), arrow.ErrInvalid)
+}
+
 func TestStructStringRoundTrip(t *testing.T) {
 	// 1. create array
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -615,18 +635,18 @@ func TestStructArrayUnmarshalJSONMissingFields(t *testing.T) {
 		name      string
 		jsonInput string
 		want      string
-		panic     bool
+		invalid   bool
 	}{
 		{
 			name:      "missing required field",
 			jsonInput: `[{"f2": 3, "f3": {"f3_1": "test"}}]`,
-			panic:     true,
+			invalid:   true,
 			want:      "",
 		},
 		{
 			name:      "missing optional fields",
 			jsonInput: `[{"f2": 3, "f3": {"f3_3": "test"}}]`,
-			panic:     false,
+			invalid:   false,
 			want:      `{[(null)] [3] {[(null)] [(null)] ["test"]}}`,
 		},
 	}
@@ -634,29 +654,8 @@ func TestStructArrayUnmarshalJSONMissingFields(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(
 			tc.name, func(t *testing.T) {
-
-				var val bool
-
 				sb := array.NewStructBuilder(pool, dtype)
 				defer sb.Release()
-
-				if tc.panic {
-					defer func() {
-						e := recover()
-						if e == nil {
-							t.Fatalf("this should have panicked, but did not; slice value %v", val)
-						}
-						if got, want := e.(string), "arrow/array: index out of range"; got != want {
-							t.Fatalf("invalid error. got=%q, want=%q", got, want)
-						}
-					}()
-				} else {
-					defer func() {
-						if e := recover(); e != nil {
-							t.Fatalf("unexpected panic: %v", e)
-						}
-					}()
-				}
 
 				err := sb.UnmarshalJSON([]byte(tc.jsonInput))
 				if err != nil {
@@ -665,6 +664,11 @@ func TestStructArrayUnmarshalJSONMissingFields(t *testing.T) {
 
 				arr := sb.NewArray().(*array.Struct)
 				defer arr.Release()
+				if tc.invalid {
+					require.ErrorIs(t, array.ValidateFull(arr), arrow.ErrInvalid)
+					return
+				}
+				require.NoError(t, array.ValidateFull(arr))
 
 				got := arr.String()
 				if got != tc.want {

--- a/arrow/array/struct_test.go
+++ b/arrow/array/struct_test.go
@@ -146,13 +146,21 @@ func TestStructValidateFullRejectsShortField(t *testing.T) {
 	b := array.NewStructBuilder(mem, dt)
 	defer b.Release()
 	b.Append(true)
+	b.Append(true)
 	b.FieldBuilder(0).(*array.Int32Builder).Append(1)
+	b.FieldBuilder(1).(*array.Int32Builder).AppendValues([]int32{2, 3}, nil)
 
 	arr := b.NewStructArray()
 	defer arr.Release()
-	assert.NoError(t, arr.Validate())
+	assert.ErrorIs(t, arr.Validate(), arrow.ErrInvalid)
 	assert.ErrorIs(t, arr.ValidateFull(), arrow.ErrInvalid)
 	assert.ErrorIs(t, array.ValidateFull(arr), arrow.ErrInvalid)
+
+	sliced := array.NewSlice(arr, 1, 2).(*array.Struct)
+	defer sliced.Release()
+	assert.Zero(t, sliced.Field(0).Len())
+	assert.ErrorIs(t, sliced.Validate(), arrow.ErrInvalid)
+	assert.ErrorIs(t, sliced.ValidateFull(), arrow.ErrInvalid)
 }
 
 func TestStructStringRoundTrip(t *testing.T) {

--- a/arrow/array/struct_test.go
+++ b/arrow/array/struct_test.go
@@ -17,6 +17,7 @@
 package array_test
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -161,6 +162,18 @@ func TestStructValidateFullRejectsShortField(t *testing.T) {
 	assert.Zero(t, sliced.Field(0).Len())
 	assert.ErrorIs(t, sliced.Validate(), arrow.ErrInvalid)
 	assert.ErrorIs(t, sliced.ValidateFull(), arrow.ErrInvalid)
+}
+
+func TestStructValidateRejectsOffsetLengthOverflow(t *testing.T) {
+	childData := array.NewData(arrow.PrimitiveTypes.Int32, 0, []*memory.Buffer{nil, nil}, nil, 0, 0)
+	defer childData.Release()
+	data := array.NewData(arrow.StructOf(arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int32}),
+		math.MaxInt, nil, []arrow.ArrayData{childData}, 0, 1)
+	defer data.Release()
+
+	arr := array.NewStructData(data)
+	defer arr.Release()
+	require.ErrorIs(t, arr.Validate(), arrow.ErrInvalid)
 }
 
 func TestStructStringRoundTrip(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

A struct child shorter than the parent extent produces an array that can panic when missing values are accessed. Structural validation in `arrow/array` is opt-in, so this should be reported by `Validate` and `ValidateFull` rather than by changing the established `StructBuilder` construction contract.

### What changes are included in this PR?

* Add `Validate` and `ValidateFull` support to `Struct`.
* Validate raw child data against the full `offset + length` extent, including sliced structs.
* Clamp constructed child views to available data so malformed arrays remain inspectable without substituting values from the wrong offset.
* Report short child fields with `arrow.ErrInvalid`.
* Preserve valid child-only builder usage and normal struct slicing behavior.

### Are these changes tested?

Yes. The tests cover direct and sliced short-child validation, update the missing-required-field case to use opt-in validation, and preserve the established `MapScalar` child-only builder path.

Validated with:

* `go test ./arrow/array ./arrow/scalar`
* `go test -tags assert ./arrow/array ./arrow/scalar`
