### PR TITLE
fix(arrow/scalar): reject negative array lengths

### DIFF
--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -794,6 +794,10 @@ func MakeArrayOfNull(dt arrow.DataType, length int, mem memory.Allocator) arrow.
 // MakeArrayFromScalar returns an array filled with the scalar value repeated length times.
 // Not yet implemented for nested types such as Struct, List, extension and so on.
 func MakeArrayFromScalar(sc Scalar, length int, mem memory.Allocator) (arrow.Array, error) {
+	if length < 0 {
+		return nil, fmt.Errorf("%w: array length must be non-negative, got %d", arrow.ErrInvalid, length)
+	}
+
 	if !sc.IsValid() {
 		return MakeArrayOfNull(sc.DataType(), length, mem), nil
 	}

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -1134,6 +1134,17 @@ func TestMakeArrayFromScalar(t *testing.T) {
 	}
 }
 
+func TestMakeArrayFromScalarRejectsNegativeLength(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	for _, sc := range []scalar.Scalar{scalar.NewInt32Scalar(1), scalar.ScalarNull} {
+		arr, err := scalar.MakeArrayFromScalar(sc, -1, mem)
+		require.ErrorIs(t, err, arrow.ErrInvalid)
+		assert.Nil(t, arr)
+	}
+}
+
 type OptionListTest struct {
 	FieldNames []string          `compute:"field_names"`
 	FieldNulls []bool            `compute:"field_null"`


### PR DESCRIPTION
### Rationale for this change

`MakeArrayFromScalar` accepts a signed length and returns an error, but negative lengths are not rejected consistently. For valid scalars, a negative length reaches buffer allocation and panics with a runtime slice-bounds error. For null scalars, it silently returns a corrupt array carrying a negative length.

### What changes are included in this PR?

* Reject negative lengths before either the null-scalar or valid-scalar path.
* Return an error wrapping `arrow.ErrInvalid` before allocating any buffers.

### Are these changes tested?

Yes. The regression test covers both valid and null scalars with a negative length and verifies that both return `arrow.ErrInvalid` without allocating memory.