### PR TITLE
fix(arrow/csv): respect timestamp timezones

### DIFF
--- a/arrow/csv/transformer.go
+++ b/arrow/csv/transformer.go
@@ -29,11 +29,11 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 )
 
-func (w *Writer) transformColToStringArr(typ arrow.DataType, col arrow.Array, stringsReplacer func(string) string) []string {
+func (w *Writer) transformColToStringArr(typ arrow.DataType, col arrow.Array, stringsReplacer func(string) string) ([]string, error) {
 	if w.customTypeConverter != nil {
 		result, handled := w.customTypeConverter(typ, col)
 		if handled {
-			return result
+			return result, nil
 		}
 	}
 
@@ -187,9 +187,13 @@ func (w *Writer) transformColToStringArr(typ arrow.DataType, col arrow.Array, st
 	case *arrow.TimestampType:
 		arr := col.(*array.Timestamp)
 		t := typ.(*arrow.TimestampType)
+		toTime, err := t.GetToTimeFunc()
+		if err != nil {
+			return nil, fmt.Errorf("arrow/csv: invalid timestamp timezone: %w", err)
+		}
 		for i := 0; i < arr.Len(); i++ {
 			if arr.IsValid(i) {
-				res[i] = arr.Value(i).ToTime(t.Unit).Format("2006-01-02 15:04:05.999999999")
+				res[i] = toTime(arr.Value(i)).Format("2006-01-02 15:04:05.999999999")
 			} else {
 				res[i] = w.nullValue
 			}
@@ -235,7 +239,12 @@ func (w *Writer) transformColToStringArr(typ arrow.DataType, col arrow.Array, st
 			var b bytes.Buffer
 			b.Write([]byte{'{'})
 			writer := csv.NewWriter(&b)
-			writer.Write(w.transformColToStringArr(list.DataType(), list, stringsReplacer))
+			values, err := w.transformColToStringArr(list.DataType(), list, stringsReplacer)
+			if err != nil {
+				list.Release()
+				return nil, err
+			}
+			writer.Write(values)
 			writer.Flush()
 			b.Truncate(b.Len() - 1)
 			b.Write([]byte{'}'})
@@ -285,5 +294,5 @@ func (w *Writer) transformColToStringArr(typ arrow.DataType, col arrow.Array, st
 	default:
 		panic(fmt.Errorf("arrow/csv: field has unsupported data type %s", typ.String()))
 	}
-	return res
+	return res, nil
 }

--- a/arrow/csv/writer.go
+++ b/arrow/csv/writer.go
@@ -84,7 +84,10 @@ func (w *Writer) Write(record arrow.RecordBatch) error {
 	}
 
 	for j, col := range record.Columns() {
-		rows := w.transformColToStringArr(w.schema.Field(j).Type, col, w.stringReplacer)
+		rows, err := w.transformColToStringArr(w.schema.Field(j).Type, col, w.stringReplacer)
+		if err != nil {
+			return err
+		}
 		for i, row := range rows {
 			recs[i][j] = row
 		}

--- a/arrow/csv/writer_test.go
+++ b/arrow/csv/writer_test.go
@@ -437,49 +437,6 @@ func BenchmarkWrite(b *testing.B) {
 	}
 }
 
-func TestCSVWriterUsesTimestampTimezone(t *testing.T) {
-	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	defer mem.AssertSize(t, 0)
-
-	timestampType := &arrow.TimestampType{Unit: arrow.Second, TimeZone: "America/New_York"}
-	builder := array.NewTimestampBuilder(mem, timestampType)
-	builder.Append(0)
-	values := builder.NewTimestampArray()
-	builder.Release()
-	defer values.Release()
-
-	schema := arrow.NewSchema([]arrow.Field{{Name: "timestamp", Type: timestampType}}, nil)
-	record := array.NewRecordBatch(schema, []arrow.Array{values}, 1)
-	defer record.Release()
-
-	var output bytes.Buffer
-	writer := csv.NewWriter(&output, schema)
-	require.NoError(t, writer.Write(record))
-	require.NoError(t, writer.Flush())
-	assert.Equal(t, "1969-12-31 19:00:00\n", output.String())
-}
-
-func TestCSVWriterRejectsInvalidTimestampTimezone(t *testing.T) {
-	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	defer mem.AssertSize(t, 0)
-
-	timestampType := &arrow.TimestampType{Unit: arrow.Second, TimeZone: "invalid/timezone"}
-	builder := array.NewTimestampBuilder(mem, timestampType)
-	builder.Append(0)
-	values := builder.NewTimestampArray()
-	builder.Release()
-	defer values.Release()
-
-	schema := arrow.NewSchema([]arrow.Field{{Name: "timestamp", Type: timestampType}}, nil)
-	record := array.NewRecordBatch(schema, []arrow.Array{values}, 1)
-	defer record.Release()
-
-	writer := csv.NewWriter(io.Discard, schema)
-	err := writer.Write(record)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "invalid timestamp timezone")
-}
-
 // TestParquetTestingCSVWriter tests that the CSV writer successfully convert arrow/parquet-testing files to CSV
 func TestParquetTestingCSVWriter(t *testing.T) {
 	dir := os.Getenv("PARQUET_TEST_DATA")
@@ -680,4 +637,47 @@ func TestCustomTypeConversion(t *testing.T) {
 
 	require.Equal(t, expected, buf.String())
 
+}
+
+func TestCSVWriterUsesTimestampTimezone(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	timestampType := &arrow.TimestampType{Unit: arrow.Second, TimeZone: "America/New_York"}
+	builder := array.NewTimestampBuilder(mem, timestampType)
+	builder.Append(0)
+	values := builder.NewTimestampArray()
+	builder.Release()
+	defer values.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "timestamp", Type: timestampType}}, nil)
+	record := array.NewRecordBatch(schema, []arrow.Array{values}, 1)
+	defer record.Release()
+
+	var output bytes.Buffer
+	writer := csv.NewWriter(&output, schema)
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Flush())
+	assert.Equal(t, "1969-12-31 19:00:00\n", output.String())
+}
+
+func TestCSVWriterRejectsInvalidTimestampTimezone(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	timestampType := &arrow.TimestampType{Unit: arrow.Second, TimeZone: "invalid/timezone"}
+	builder := array.NewTimestampBuilder(mem, timestampType)
+	builder.Append(0)
+	values := builder.NewTimestampArray()
+	builder.Release()
+	defer values.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "timestamp", Type: timestampType}}, nil)
+	record := array.NewRecordBatch(schema, []arrow.Array{values}, 1)
+	defer record.Release()
+
+	writer := csv.NewWriter(io.Discard, schema)
+	err := writer.Write(record)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid timestamp timezone")
 }

--- a/arrow/csv/writer_test.go
+++ b/arrow/csv/writer_test.go
@@ -437,6 +437,49 @@ func BenchmarkWrite(b *testing.B) {
 	}
 }
 
+func TestCSVWriterUsesTimestampTimezone(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	timestampType := &arrow.TimestampType{Unit: arrow.Second, TimeZone: "America/New_York"}
+	builder := array.NewTimestampBuilder(mem, timestampType)
+	builder.Append(0)
+	values := builder.NewTimestampArray()
+	builder.Release()
+	defer values.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "timestamp", Type: timestampType}}, nil)
+	record := array.NewRecordBatch(schema, []arrow.Array{values}, 1)
+	defer record.Release()
+
+	var output bytes.Buffer
+	writer := csv.NewWriter(&output, schema)
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Flush())
+	assert.Equal(t, "1969-12-31 19:00:00\n", output.String())
+}
+
+func TestCSVWriterRejectsInvalidTimestampTimezone(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	timestampType := &arrow.TimestampType{Unit: arrow.Second, TimeZone: "invalid/timezone"}
+	builder := array.NewTimestampBuilder(mem, timestampType)
+	builder.Append(0)
+	values := builder.NewTimestampArray()
+	builder.Release()
+	defer values.Release()
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "timestamp", Type: timestampType}}, nil)
+	record := array.NewRecordBatch(schema, []arrow.Array{values}, 1)
+	defer record.Release()
+
+	writer := csv.NewWriter(io.Discard, schema)
+	err := writer.Write(record)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid timestamp timezone")
+}
+
 // TestParquetTestingCSVWriter tests that the CSV writer successfully convert arrow/parquet-testing files to CSV
 func TestParquetTestingCSVWriter(t *testing.T) {
 	dir := os.Getenv("PARQUET_TEST_DATA")


### PR DESCRIPTION
### Rationale for this change

Timestamp arrays can declare a timezone, but the CSV writer formats every value directly in UTC. This produces the wrong local timestamp and also lets invalid timezone declarations pass silently.

### What changes are included in this PR?

* Use the timestamp type conversion function so values are formatted in the declared timezone.
* Return invalid timezone errors from Writer.Write.
* Propagate conversion errors from nested list values.

### Are these changes tested?

Yes. The tests verify epoch formatting in America/New_York and rejection of an invalid timezone. All CSV tests and the assertion build pass with the required Parquet test data.