### PR TITLE
fix(parquet/pqarrow): calculate large decimal widths

### DIFF
--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -246,7 +246,7 @@ func DecimalSize(precision int32) int32 {
 	if precision <= 76 {
 		return byteblock[precision]
 	}
-	return int32(math.Ceil(float64(precision)/8.0)*math.Log2(10) + 1)
+	return int32(math.Ceil((float64(precision)*math.Log2(10) + 1) / 8))
 }
 
 func repFromNullable(isnullable bool) parquet.Repetition {

--- a/parquet/pqarrow/schema_test.go
+++ b/parquet/pqarrow/schema_test.go
@@ -524,7 +524,7 @@ func TestConvertArrowDecimals(t *testing.T) {
 	arrowFields = append(arrowFields, arrow.Field{Name: "decimal_20_4", Type: &arrow.Decimal128Type{Precision: 20, Scale: 4}})
 
 	parquetFields = append(parquetFields, schema.Must(schema.NewPrimitiveNodeLogical("decimal_77_4", parquet.Repetitions.Required,
-		schema.NewDecimalLogicalType(77, 4), parquet.Types.FixedLenByteArray, 34, -1)))
+		schema.NewDecimalLogicalType(77, 4), parquet.Types.FixedLenByteArray, 33, -1)))
 	arrowFields = append(arrowFields, arrow.Field{Name: "decimal_77_4", Type: &arrow.Decimal128Type{Precision: 77, Scale: 4}})
 
 	arrowSchema := arrow.NewSchema(arrowFields, nil)
@@ -535,6 +535,19 @@ func TestConvertArrowDecimals(t *testing.T) {
 	assert.True(t, parquetSchema.Equals(result))
 	for i := 0; i < parquetSchema.NumColumns(); i++ {
 		assert.Truef(t, parquetSchema.Column(i).Equals(result.Column(i)), "Column %d didn't match: %s", i, parquetSchema.Column(i).Name())
+	}
+}
+
+func TestDecimalSizeAboveDecimal256Precision(t *testing.T) {
+	for _, tt := range []struct {
+		precision int32
+		want      int32
+	}{
+		{precision: 77, want: 33},
+		{precision: 80, want: 34},
+		{precision: 100, want: 42},
+	} {
+		assert.Equal(t, tt.want, pqarrow.DecimalSize(tt.precision))
 	}
 }
 


### PR DESCRIPTION
### Rationale for this change

`DecimalSize` uses a lookup table through precision 76 and a formula above that range. The fallback applied `ceil` before multiplying by `log2(10)`, producing widths larger than the documented minimum. For example, precision 77 returned 34 bytes instead of 33.

### What changes are included in this PR?

Apply the documented two-complement width formula as `ceil((precision * log2(10) + 1) / 8)` for precisions above 76, and correct the existing precision-77 schema fixture.

### Are these changes tested?

Yes. Regression cases cover precisions 77, 80, and 100. The full `parquet/pqarrow` package passes.