### PR TITLE
fix(parquet/schema): reject invalid fixed lengths

### DIFF
--- a/parquet/schema/node.go
+++ b/parquet/schema/node.go
@@ -319,10 +319,13 @@ func (p *PrimitiveNode) Equals(rhs Node) bool {
 // to store the values in this column.
 func (p *PrimitiveNode) PhysicalType() parquet.Type { return p.physicalType }
 
-// SetTypeLength will change the type length of the node, has no effect if the
-// physical type is not FixedLength Byte Array
+// SetTypeLength will change the type length of the node, and has no effect if the
+// physical type is not FixedLength Byte Array. It panics if length is not positive.
 func (p *PrimitiveNode) SetTypeLength(length int) {
 	if p.PhysicalType() == parquet.Types.FixedLenByteArray {
+		if length <= 0 {
+			panic("parquet: fixed length byte array length must be positive")
+		}
 		p.typeLen = length
 	}
 }

--- a/parquet/schema/schema_test.go
+++ b/parquet/schema/schema_test.go
@@ -191,6 +191,20 @@ func (p *PrimitiveNodeTestSuite) TestEquals() {
 	p.False(flba1.Equals(flba5))
 }
 
+func (p *PrimitiveNodeTestSuite) TestSetTypeLengthRejectsInvalidLength() {
+	node := schema.NewFixedLenByteArrayNode("value", parquet.Repetitions.Required, 4, -1)
+
+	for _, length := range []int{0, -1} {
+		p.PanicsWithValue("parquet: fixed length byte array length must be positive", func() {
+			node.SetTypeLength(length)
+		})
+		p.Equal(4, node.TypeLength())
+	}
+
+	other := schema.NewInt32Node("value", parquet.Repetitions.Required, -1)
+	p.NotPanics(func() { other.SetTypeLength(0) })
+}
+
 func (p *PrimitiveNodeTestSuite) TestPhysicalLogicalMapping() {
 	tests := []struct {
 		typ       parquet.Type


### PR DESCRIPTION
### Rationale for this change

Fixed-length byte-array constructors reject non-positive widths, but `PrimitiveNode.SetTypeLength` allowed an existing valid node to be mutated to zero or a negative width. The invalid node could then be serialized or passed to encoders.

### What changes are included in this PR?

* Reject non-positive widths when mutating fixed-length byte-array nodes.
* Leave non-fixed-width primitive nodes unchanged, preserving the existing no-op behavior.
* Document the panic contract on the setter.

### Are these changes tested?

Yes. The regression test covers zero and negative widths, verifies that failed mutations preserve the previous width, and checks the existing no-op behavior for other physical types. The full `parquet/schema` package passes.