### PR TITLE
fix(tmpl): report generated output write errors

### DIFF
--- a/arrow/_tools/tmpl/main.go
+++ b/arrow/_tools/tmpl/main.go
@@ -114,7 +114,9 @@ func main() {
 	}
 
 	in.In = readData(*dataArg)
-	process(in, specs)
+	if err := process(in, specs); err != nil {
+		errExit("%s", err)
+	}
 }
 
 func mustReadAll(path string) []byte {
@@ -148,7 +150,7 @@ var funcs = template.FuncMap{
 	"upper": strings.ToUpper,
 }
 
-func process(data interface{}, specs []pathSpec) {
+func process(data interface{}, specs []pathSpec) error {
 	for _, spec := range specs {
 		var (
 			t   *template.Template
@@ -178,8 +180,11 @@ func process(data interface{}, specs []pathSpec) {
 			}
 		}
 
-		os.WriteFile(spec.out, generated, fileMode(spec.in))
+		if err := os.WriteFile(spec.out, generated, fileMode(spec.in)); err != nil {
+			return fmt.Errorf("error writing generated output %q: %w", spec.out, err)
+		}
 	}
+	return nil
 }
 
 var (

--- a/arrow/_tools/tmpl/main_test.go
+++ b/arrow/_tools/tmpl/main_test.go
@@ -17,8 +17,27 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestProcessReturnsOutputWriteError(t *testing.T) {
+	dir := t.TempDir()
+	tmpl := filepath.Join(dir, "input.txt.tmpl")
+	if err := os.WriteFile(tmpl, []byte("generated"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := process(nil, []pathSpec{{in: tmpl, out: dir}})
+	if err == nil {
+		t.Fatal("process returned nil for an unwritable output path")
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Errorf("error %q does not contain output path %q", err, dir)
+	}
+}
 
 func TestStripComments(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What changed

Check the final `os.WriteFile` result when generating template output and return the failure to `main` for reporting.

## Why

The generator previously exited successfully when the output could not be written, for example when the output path was a directory. That could leave stale generated files in place while making the generation step appear successful.

The new regression test uses a directory as the output target and verifies that `process` returns an error containing the failed path.

## Validation

`go test -vet=off ./arrow/_tools/tmpl`
