### PR TITLE
fix(arrow/scalar): use duration type for units

### DIFF
--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -482,6 +482,16 @@ func TestDurationScalarBasics(t *testing.T) {
 	assert.False(t, scalar.Equals(tsNull, tsVal2))
 }
 
+func TestDurationScalarUnitConversions(t *testing.T) {
+	s := scalar.NewDurationScalar(1, arrow.FixedWidthTypes.Duration_s)
+	assert.Equal(t, arrow.Second, s.Unit())
+	assert.Equal(t, "1s", s.String())
+
+	converted, err := s.CastTo(arrow.FixedWidthTypes.Duration_ms)
+	require.NoError(t, err)
+	assert.Equal(t, arrow.Duration(1000), converted.(*scalar.Duration).Value)
+}
+
 func TestMonthIntervalScalarBasics(t *testing.T) {
 	typ1 := arrow.FixedWidthTypes.MonthInterval
 	typ2 := arrow.FixedWidthTypes.MonthInterval

--- a/arrow/scalar/temporal.go
+++ b/arrow/scalar/temporal.go
@@ -73,7 +73,7 @@ func (s *Duration) equals(rhs Scalar) bool {
 }
 
 func (s *Duration) Unit() arrow.TimeUnit {
-	return s.DataType().(*arrow.TimestampType).Unit
+	return s.DataType().(*arrow.DurationType).Unit
 }
 func (s *Duration) Data() []byte {
 	return (*[arrow.DurationSizeBytes]byte)(unsafe.Pointer(&s.Value))[:]


### PR DESCRIPTION
## What changed

Read a duration scalar's unit from `arrow.DurationType` instead of asserting it is a timestamp type.

## Why

Valid duration scalars carry `*arrow.DurationType`. The previous assertion to `*arrow.TimestampType` panicked whenever `Unit` was called, including through string formatting and duration unit conversion.

The regression test covers direct unit access, string formatting, and seconds-to-milliseconds conversion.

## Validation

`go test ./arrow/scalar`
