### PR TITLE
fix(arrow/array): validate union child upper bound

### DIFF
--- a/arrow/array/union.go
+++ b/arrow/array/union.go
@@ -801,7 +801,7 @@ func (b *unionBuilder) NumChildren() int {
 }
 
 func (b *unionBuilder) Child(idx int) Builder {
-	if idx < 0 || idx > len(b.children) {
+	if idx < 0 || idx >= len(b.children) {
 		panic("arrow/array: invalid child index for union builder")
 	}
 	return b.children[idx]

--- a/arrow/array/union_test.go
+++ b/arrow/array/union_test.go
@@ -42,6 +42,41 @@ func int32ArrFromSlice(offsets ...int32) arrow.Array {
 	return array.MakeFromData(data)
 }
 
+func TestUnionBuilderChildBounds(t *testing.T) {
+	fields := []arrow.Field{{Name: "value", Type: arrow.PrimitiveTypes.Int32}}
+	codes := []arrow.UnionTypeCode{0}
+	tests := []struct {
+		name string
+		new  func() array.UnionBuilder
+	}{
+		{
+			name: "dense",
+			new: func() array.UnionBuilder {
+				return array.NewDenseUnionBuilder(memory.DefaultAllocator, arrow.DenseUnionOf(fields, codes))
+			},
+		},
+		{
+			name: "sparse",
+			new: func() array.UnionBuilder {
+				return array.NewSparseUnionBuilder(memory.DefaultAllocator, arrow.SparseUnionOf(fields, codes))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := tt.new()
+			defer builder.Release()
+
+			for _, index := range []int{-1, len(fields)} {
+				assert.PanicsWithValue(t, "arrow/array: invalid child index for union builder", func() {
+					builder.Child(index)
+				})
+			}
+		})
+	}
+}
+
 func TestUnionSliceEquals(t *testing.T) {
 	unionFields := []arrow.Field{
 		{Name: "u0", Type: arrow.PrimitiveTypes.Int32, Nullable: true},


### PR DESCRIPTION
## What changed

Reject a union child index equal to the number of children.

## Why

The previous bounds check allowed `idx == len(children)` through, causing a generic runtime index panic instead of the intended Arrow validation panic.

The regression test covers both the negative and upper bounds for dense and sparse union builders.

## Validation

`go test ./arrow/array`
