### PR TITLE
fix(parquet/pqarrow): propagate level builder errors

### DIFF
--- a/parquet/pqarrow/encode_arrow.go
+++ b/parquet/pqarrow/encode_arrow.go
@@ -126,6 +126,11 @@ func newArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *Sch
 	isNullable = nullableRoot(manifest, schemaField)
 
 	builders := make([]*multipathLevelBuilder, 0)
+	releaseBuilders := func() {
+		for _, bldr := range builders {
+			bldr.Release()
+		}
+	}
 	for values < size {
 		chunk := data.Chunk(chunkIdx)
 		available := int64(chunk.Len() - int(chunkOffset))
@@ -134,17 +139,22 @@ func newArrowColumnWriter(data *arrow.Chunked, offset, size int64, manifest *Sch
 		// the chunk offset will be 0 here except for possibly the first chunk
 		// because of the above advancing logic
 		arrToWrite := array.NewSlice(chunk, chunkOffset, chunkOffset+chunkWriteSize)
-		defer arrToWrite.Release()
 
 		if arrToWrite.Len() > 0 {
 			bldr, err := newMultipathLevelBuilder(arrToWrite, isNullable)
+			arrToWrite.Release()
 			if err != nil {
-				return arrowColumnWriter{}, nil
+				releaseBuilders()
+				return arrowColumnWriter{}, err
 			}
 			if leafCount != bldr.leafCount() {
+				bldr.Release()
+				releaseBuilders()
 				return arrowColumnWriter{}, fmt.Errorf("data type leaf_count != builder leaf_count: %d - %d", leafCount, bldr.leafCount())
 			}
 			builders = append(builders, bldr)
+		} else {
+			arrToWrite.Release()
 		}
 
 		if chunkWriteSize == available {

--- a/parquet/pqarrow/encode_dictionary_test.go
+++ b/parquet/pqarrow/encode_dictionary_test.go
@@ -72,10 +72,12 @@ func TestWriteColumnChunkedPropagatesLevelBuilderError(t *testing.T) {
 		parquet.NewWriterProperties(parquet.WithAllocator(mem)),
 		pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem)))
 	require.NoError(t, err)
+	require.NoError(t, writer.NewRowGroupChecked())
 
 	err = writer.WriteColumnChunked(values, 0, int64(values.Len()))
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, arrow.ErrNotImplemented))
+	require.NoError(t, writer.WriteColumnData(valid))
 	require.NoError(t, writer.Close())
 }
 

--- a/parquet/pqarrow/encode_dictionary_test.go
+++ b/parquet/pqarrow/encode_dictionary_test.go
@@ -21,6 +21,7 @@ package pqarrow_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -38,6 +39,45 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+func TestWriteColumnChunkedPropagatesLevelBuilderError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	dictType := &arrow.DictionaryType{IndexType: arrow.PrimitiveTypes.Int32, ValueType: arrow.BinaryTypes.String}
+	validIndices, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[0]`))
+	require.NoError(t, err)
+	defer validIndices.Release()
+	validDictionary, _, err := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`["valid"]`))
+	require.NoError(t, err)
+	defer validDictionary.Release()
+	valid := array.NewDictionaryArray(dictType, validIndices, validDictionary)
+	defer valid.Release()
+
+	invalidIndices, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Int32, strings.NewReader(`[0]`))
+	require.NoError(t, err)
+	defer invalidIndices.Release()
+	invalidDictionary, _, err := array.FromJSON(mem, arrow.BinaryTypes.String, strings.NewReader(`[null]`))
+	require.NoError(t, err)
+	defer invalidDictionary.Release()
+	invalid := array.NewDictionaryArray(dictType, invalidIndices, invalidDictionary)
+	defer invalid.Release()
+
+	values := arrow.NewChunked(dictType, []arrow.Array{valid, invalid})
+	defer values.Release()
+	schema := arrow.NewSchema([]arrow.Field{{Name: "values", Type: dictType, Nullable: true}}, nil)
+
+	var output bytes.Buffer
+	writer, err := pqarrow.NewFileWriter(schema, &output,
+		parquet.NewWriterProperties(parquet.WithAllocator(mem)),
+		pqarrow.NewArrowWriterProperties(pqarrow.WithAllocator(mem)))
+	require.NoError(t, err)
+
+	err = writer.WriteColumnChunked(values, 0, int64(values.Len()))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, arrow.ErrNotImplemented))
+	require.NoError(t, writer.Close())
+}
 
 func (ps *ParquetIOTestSuite) TestSingleColumnOptionalDictionaryWrite() {
 	for _, dt := range fullTypeList {

--- a/parquet/pqarrow/path_builder.go
+++ b/parquet/pqarrow/path_builder.go
@@ -536,6 +536,7 @@ func newMultipathLevelBuilder(arr arrow.Array, fieldNullable bool) (*multipathLe
 		builder:   pathBuilder{nullableInParent: fieldNullable, paths: make([]pathInfo, 0), refCount: utils.NewRefCount(1)},
 	}
 	if err := ret.builder.Visit(arr); err != nil {
+		ret.builder.Release()
 		return nil, err
 	}
 	arr.Data().Retain()


### PR DESCRIPTION
## Summary

- return errors from multipath level builder construction instead of reporting a successful column write
- release builders created for earlier chunks when a later chunk fails
- release partially initialized builder state on visitor errors
- leave the physical column position unchanged after builder construction fails

## Testing

- `go test ./parquet/pqarrow`

The regression test uses a valid dictionary chunk followed by a dictionary containing a null, which reaches the previously swallowed error path, verifies checked allocator cleanup, and successfully retries the same physical column with supported data.