### PR TITLE
fix(parquet): reject short page writes

### DIFF
--- a/parquet/file/page_writer.go
+++ b/parquet/file/page_writer.go
@@ -337,6 +337,9 @@ func (pw *serializedPageWriter) WriteDictionaryPage(page *DictionaryPage) (int64
 	if err != nil {
 		return 0, err
 	}
+	if written != len(data) {
+		return int64(written), io.ErrShortWrite
+	}
 
 	written += headerSize
 
@@ -399,6 +402,9 @@ func (pw *serializedPageWriter) WriteDataPage(page DataPage) (int64, error) {
 	written, err := pw.sink.Write(data)
 	if err != nil {
 		return int64(written), err
+	}
+	if written != len(data) {
+		return int64(written), io.ErrShortWrite
 	}
 	written += headerSize
 

--- a/parquet/file/page_writer.go
+++ b/parquet/file/page_writer.go
@@ -334,9 +334,6 @@ func (pw *serializedPageWriter) WriteDictionaryPage(page *DictionaryPage) (int64
 	if err != nil {
 		return 0, err
 	}
-	if written != len(data) {
-		return int64(written), io.ErrShortWrite
-	}
 
 	written += headerSize
 	if pw.dictPageOffset == 0 {
@@ -399,9 +396,6 @@ func (pw *serializedPageWriter) WriteDataPage(page DataPage) (int64, error) {
 	written, err := pw.sink.Write(data)
 	if err != nil {
 		return int64(written), err
-	}
-	if written != len(data) {
-		return int64(written), io.ErrShortWrite
 	}
 	written += headerSize
 	if pw.pageOrdinal == 0 {

--- a/parquet/file/page_writer.go
+++ b/parquet/file/page_writer.go
@@ -320,9 +320,6 @@ func (pw *serializedPageWriter) WriteDictionaryPage(page *DictionaryPage) (int64
 	pageHdr.DataPageHeaderV2 = nil
 
 	startPos := pw.sink.Tell()
-	if pw.dictPageOffset == 0 {
-		pw.dictPageOffset = int64(startPos)
-	}
 
 	if pw.metaEncryptor != nil {
 		if err := pw.updateEncryption(encryption.DictPageHeaderModule); err != nil {
@@ -342,6 +339,9 @@ func (pw *serializedPageWriter) WriteDictionaryPage(page *DictionaryPage) (int64
 	}
 
 	written += headerSize
+	if pw.dictPageOffset == 0 {
+		pw.dictPageOffset = int64(startPos)
+	}
 
 	pw.totalUncompressed += int64(uncompressed + headerSize)
 	pw.totalCompressed = int64(written)
@@ -386,9 +386,6 @@ func (pw *serializedPageWriter) WriteDataPage(page DataPage) (int64, error) {
 	}
 
 	startPos := pw.sink.Tell()
-	if pw.pageOrdinal == 0 {
-		pw.dataPageOffset = int64(startPos)
-	}
 
 	if pw.metaEncryptor != nil {
 		if err := pw.updateEncryption(encryption.DataPageHeaderModule); err != nil {
@@ -407,6 +404,9 @@ func (pw *serializedPageWriter) WriteDataPage(page DataPage) (int64, error) {
 		return int64(written), io.ErrShortWrite
 	}
 	written += headerSize
+	if pw.pageOrdinal == 0 {
+		pw.dataPageOffset = int64(startPos)
+	}
 
 	// collect page index
 	if pw.columnIndexBuilder != nil {

--- a/parquet/file/page_writer_internal_test.go
+++ b/parquet/file/page_writer_internal_test.go
@@ -68,7 +68,7 @@ func TestSerializedPageWriterRejectsShortWrites(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sink := &shortPageSink{data: data}
+			sink := &shortPageSink{data: data, pos: 17}
 			writer, err := NewPageWriter(sink, compress.Codecs.Uncompressed,
 				compress.DefaultCompressionLevel, nil, -1, -1, memory.DefaultAllocator, false, nil, nil)
 			require.NoError(t, err)
@@ -78,7 +78,10 @@ func TestSerializedPageWriterRejectsShortWrites(t *testing.T) {
 			written, err := tt.write(writer, buf)
 			require.True(t, errors.Is(err, io.ErrShortWrite))
 			require.EqualValues(t, len(data)-1, written)
-			require.Zero(t, writer.(*serializedPageWriter).NumValues())
+			serialized := writer.(*serializedPageWriter)
+			require.Zero(t, serialized.NumValues())
+			require.Zero(t, serialized.DictionaryPageOffset())
+			require.Zero(t, serialized.DataPageoffset())
 		})
 	}
 }

--- a/parquet/file/page_writer_internal_test.go
+++ b/parquet/file/page_writer_internal_test.go
@@ -42,6 +42,9 @@ func (s *shortPageSink) Write(p []byte) (int, error) {
 		n--
 	}
 	s.pos += int64(n)
+	if n != len(p) {
+		return n, io.ErrShortWrite
+	}
 	return n, nil
 }
 
@@ -64,17 +67,20 @@ func TestSerializedPageWriterRejectsShortWrites(t *testing.T) {
 	data := []byte("page body")
 
 	tests := []struct {
-		name  string
-		write func(PageWriter, *memory.Buffer) (int64, error)
+		name        string
+		wantWritten int64
+		write       func(PageWriter, *memory.Buffer) (int64, error)
 	}{
 		{
-			name: "dictionary page",
+			name:        "dictionary page",
+			wantWritten: 0,
 			write: func(writer PageWriter, data *memory.Buffer) (int64, error) {
 				return writer.WriteDictionaryPage(NewDictionaryPage(data, 1, parquet.Encodings.Plain))
 			},
 		},
 		{
-			name: "data page",
+			name:        "data page",
+			wantWritten: int64(len(data) - 1),
 			write: func(writer PageWriter, data *memory.Buffer) (int64, error) {
 				return writer.WriteDataPage(NewDataPageV1(data, 1, parquet.Encodings.Plain,
 					parquet.Encodings.RLE, parquet.Encodings.RLE, int32(data.Len())))
@@ -93,7 +99,7 @@ func TestSerializedPageWriterRejectsShortWrites(t *testing.T) {
 			defer buf.Release()
 			written, err := tt.write(writer, buf)
 			require.True(t, errors.Is(err, io.ErrShortWrite))
-			require.EqualValues(t, len(data)-1, written)
+			require.Equal(t, tt.wantWritten, written)
 			serialized := writer.(*serializedPageWriter)
 			require.Zero(t, serialized.NumValues())
 			require.Zero(t, serialized.DictionaryPageOffset())

--- a/parquet/file/page_writer_internal_test.go
+++ b/parquet/file/page_writer_internal_test.go
@@ -29,19 +29,35 @@ import (
 )
 
 type shortPageSink struct {
-	data []byte
-	pos  int64
+	data        []byte
+	pos         int64
+	headerShort bool
 }
 
 func (s *shortPageSink) Tell() int64 { return s.pos }
 
 func (s *shortPageSink) Write(p []byte) (int, error) {
 	n := len(p)
-	if bytes.Equal(p, s.data) {
+	if s.headerShort || bytes.Equal(p, s.data) {
 		n--
 	}
 	s.pos += int64(n)
 	return n, nil
+}
+
+func TestSerializedPageWriterRejectsShortHeaderWrites(t *testing.T) {
+	sink := &shortPageSink{headerShort: true, pos: 17}
+	writer, err := NewPageWriter(sink, compress.Codecs.Uncompressed,
+		compress.DefaultCompressionLevel, nil, -1, -1, memory.DefaultAllocator, false, nil, nil)
+	require.NoError(t, err)
+
+	buf := memory.NewBufferBytes([]byte("page body"))
+	defer buf.Release()
+	_, err = writer.WriteDictionaryPage(NewDictionaryPage(buf, 1, parquet.Encodings.Plain))
+	require.ErrorIs(t, err, io.ErrShortWrite)
+	serialized := writer.(*serializedPageWriter)
+	require.Zero(t, serialized.NumValues())
+	require.Zero(t, serialized.DictionaryPageOffset())
 }
 
 func TestSerializedPageWriterRejectsShortWrites(t *testing.T) {

--- a/parquet/file/page_writer_internal_test.go
+++ b/parquet/file/page_writer_internal_test.go
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/compress"
+	"github.com/stretchr/testify/require"
+)
+
+type shortPageSink struct {
+	data []byte
+	pos  int64
+}
+
+func (s *shortPageSink) Tell() int64 { return s.pos }
+
+func (s *shortPageSink) Write(p []byte) (int, error) {
+	n := len(p)
+	if bytes.Equal(p, s.data) {
+		n--
+	}
+	s.pos += int64(n)
+	return n, nil
+}
+
+func TestSerializedPageWriterRejectsShortWrites(t *testing.T) {
+	data := []byte("page body")
+
+	tests := []struct {
+		name  string
+		write func(PageWriter, *memory.Buffer) (int64, error)
+	}{
+		{
+			name: "dictionary page",
+			write: func(writer PageWriter, data *memory.Buffer) (int64, error) {
+				return writer.WriteDictionaryPage(NewDictionaryPage(data, 1, parquet.Encodings.Plain))
+			},
+		},
+		{
+			name: "data page",
+			write: func(writer PageWriter, data *memory.Buffer) (int64, error) {
+				return writer.WriteDataPage(NewDataPageV1(data, 1, parquet.Encodings.Plain,
+					parquet.Encodings.RLE, parquet.Encodings.RLE, int32(data.Len())))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := &shortPageSink{data: data}
+			writer, err := NewPageWriter(sink, compress.Codecs.Uncompressed,
+				compress.DefaultCompressionLevel, nil, -1, -1, memory.DefaultAllocator, false, nil, nil)
+			require.NoError(t, err)
+
+			buf := memory.NewBufferBytes(data)
+			defer buf.Release()
+			written, err := tt.write(writer, buf)
+			require.True(t, errors.Is(err, io.ErrShortWrite))
+			require.EqualValues(t, len(data)-1, written)
+			require.Zero(t, writer.(*serializedPageWriter).NumValues())
+		})
+	}
+}

--- a/parquet/internal/thrift/helpers.go
+++ b/parquet/internal/thrift/helpers.go
@@ -76,12 +76,23 @@ func (t *Serializer) Serialize(msg thrift.TStruct, w io.Writer, enc encryption.E
 	}
 
 	if enc == nil {
-		return w.Write(b)
+		n, err := w.Write(b)
+		if err != nil {
+			return n, err
+		}
+		if n != len(b) {
+			return n, io.ErrShortWrite
+		}
+		return n, nil
 	}
 
 	var cipherBuf bytes.Buffer
 	cipherBuf.Grow(enc.CiphertextSizeDelta() + len(b))
 	enc.Encrypt(&cipherBuf, b)
+	expected := cipherBuf.Len()
 	n, err := cipherBuf.WriteTo(w)
+	if err == nil && int(n) != expected {
+		err = io.ErrShortWrite
+	}
 	return int(n), err
 }

--- a/parquet/internal/thrift/helpers.go
+++ b/parquet/internal/thrift/helpers.go
@@ -76,23 +76,12 @@ func (t *Serializer) Serialize(msg thrift.TStruct, w io.Writer, enc encryption.E
 	}
 
 	if enc == nil {
-		n, err := w.Write(b)
-		if err != nil {
-			return n, err
-		}
-		if n != len(b) {
-			return n, io.ErrShortWrite
-		}
-		return n, nil
+		return w.Write(b)
 	}
 
 	var cipherBuf bytes.Buffer
 	cipherBuf.Grow(enc.CiphertextSizeDelta() + len(b))
 	enc.Encrypt(&cipherBuf, b)
-	expected := cipherBuf.Len()
 	n, err := cipherBuf.WriteTo(w)
-	if err == nil && int(n) != expected {
-		err = io.ErrShortWrite
-	}
 	return int(n), err
 }


### PR DESCRIPTION
## Summary

- return `io.ErrShortWrite` when a direct dictionary or data page body write accepts fewer bytes than requested
- avoid updating page counters and indexes after an incomplete body write
- cover both direct page paths with a short-writing sink

## Testing

- `go test ./parquet/file`