### PR TITLE
fix(arrow/compute): support casting between extension types

### DIFF
--- a/arrow/compute/cast.go
+++ b/arrow/compute/cast.go
@@ -555,6 +555,37 @@ func CastFromExtension(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.Exec
 	return nil
 }
 
+// CastToExtension casts an extension array to another extension type by
+// casting the input's storage to the target's storage type and wrapping
+// the result as the target extension type. Re-typing between extension
+// types that share a storage type is zero-copy since the inner storage
+// cast is then a no-op.
+func CastToExtension(ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult) error {
+	opts := ctx.State.(kernels.CastState)
+
+	toType, ok := opts.ToType.(arrow.ExtensionType)
+	if !ok {
+		return fmt.Errorf("%w: cast target %s is not an extension type", arrow.ErrInvalid, opts.ToType)
+	}
+
+	arr := batch.Values[0].Array.MakeArray().(array.ExtensionArray)
+	defer arr.Release()
+
+	castOpts := CastOptions(opts)
+	castOpts.ToType = toType.StorageType()
+	storage, err := CastArray(ctx.Ctx, arr.Storage(), &castOpts)
+	if err != nil {
+		return err
+	}
+	defer storage.Release()
+
+	wrapped := array.NewExtensionArrayWithStorage(toType, storage)
+	defer wrapped.Release()
+
+	out.TakeOwnership(wrapped.Data())
+	return nil
+}
+
 func CastList[SrcOffsetT, DestOffsetT int32 | int64](ctx *exec.KernelCtx, batch *exec.ExecSpan, out *exec.ExecResult) error {
 	var (
 		opts       = ctx.State.(kernels.CastState)
@@ -722,10 +753,12 @@ func initCastTable() {
 	addCastFuncs(getTemporalCasts())
 	addCastFuncs(getNestedCasts())
 
-	nullToExt := newCastFunction("cast_extension", arrow.EXTENSION)
-	nullToExt.AddNewTypeCast(arrow.NULL, []exec.InputType{exec.NewExactInput(arrow.Null)},
+	castExt := newCastFunction("cast_extension", arrow.EXTENSION)
+	castExt.AddNewTypeCast(arrow.NULL, []exec.InputType{exec.NewExactInput(arrow.Null)},
 		kernels.OutputTargetType, kernels.CastFromNull, exec.NullComputedNoPrealloc, exec.MemNoPrealloc)
-	castTable[arrow.EXTENSION] = nullToExt
+	castExt.AddNewTypeCast(arrow.EXTENSION, []exec.InputType{exec.NewIDInput(arrow.EXTENSION)},
+		kernels.OutputTargetType, CastToExtension, exec.NullComputedNoPrealloc, exec.MemNoPrealloc)
+	castTable[arrow.EXTENSION] = castExt
 }
 
 func getCastFunction(to arrow.DataType) (*castFunction, error) {

--- a/arrow/compute/cast_test.go
+++ b/arrow/compute/cast_test.go
@@ -401,6 +401,8 @@ func (c *CastSuite) TestCanCast() {
 	canCast(types.NewSmallintType(), []arrow.DataType{arrow.PrimitiveTypes.Int16})
 	canCast(types.NewSmallintType(), numericTypes) // any cast which is valid for storage is supported
 	canCast(arrow.Null, []arrow.DataType{types.NewSmallintType()})
+	// extension -> extension is a cast between the storage types
+	canCast(types.NewSmallintType(), []arrow.DataType{types.NewParametric1Type(1)})
 
 	canCast(arrow.FixedWidthTypes.Date32, []arrow.DataType{arrow.BinaryTypes.String, arrow.BinaryTypes.LargeString})
 	canCast(arrow.FixedWidthTypes.Date64, []arrow.DataType{arrow.BinaryTypes.String, arrow.BinaryTypes.LargeString})
@@ -3744,6 +3746,97 @@ func (c *CastSuite) TestExtensionTypeToIntDowncast() {
 		opts.AllowIntOverflow = true
 		c.checkCastOpts(smallint, arrow.PrimitiveTypes.Uint8,
 			`[0, null, -1, 1, 3]`, `[0, null, 255, 1, 3]`, *opts)
+	})
+}
+
+func (c *CastSuite) extArrayFromJSON(dt arrow.ExtensionType, data string) arrow.Array {
+	storage, _, err := array.FromJSON(c.mem, dt.StorageType(), strings.NewReader(data))
+	c.Require().NoError(err)
+	defer storage.Release()
+	return array.NewExtensionArrayWithStorage(dt, storage)
+}
+
+func (c *CastSuite) TestExtensionToExtension() {
+	var (
+		param1   = types.NewParametric1Type(1)  // storage int32
+		param2   = types.NewParametric1Type(2)  // storage int32, differing metadata
+		smallint = types.NewSmallintType()      // storage int16
+		viewExt  = types.NewStringViewExtType() // storage string_view
+		ctx      = compute.WithAllocator(context.Background(), c.mem)
+	)
+
+	c.Run("same storage type is zero-copy", func() {
+		src := c.extArrayFromJSON(param1, `[1, 2, null, 4]`)
+		defer src.Release()
+
+		out, err := compute.CastArray(ctx, src, compute.SafeCastOptions(param2))
+		c.Require().NoError(err)
+		defer out.Release()
+
+		c.Truef(arrow.TypeEqual(param2, out.DataType()), "expected %s, got %s", param2, out.DataType())
+		c.Require().Len(out.Data().Buffers(), len(src.Data().Buffers()))
+		for i := range out.Data().Buffers() {
+			assertBufferSame(c.T(), out, src, i)
+		}
+		assertArraysEqual(c.T(), src.(array.ExtensionArray).Storage(), out.(array.ExtensionArray).Storage())
+	})
+
+	c.Run("storage cast int32 to int16", func() {
+		src := c.extArrayFromJSON(param1, `[0, null, 100, -5]`)
+		defer src.Release()
+		exp := c.extArrayFromJSON(smallint, `[0, null, 100, -5]`)
+		defer exp.Release()
+
+		checkCast(c.T(), src, exp, *compute.DefaultCastOptions(true))
+	})
+
+	c.Run("storage cast options are propagated", func() {
+		src := c.extArrayFromJSON(param1, `[0, null, 100000]`)
+		defer src.Release()
+
+		opts := compute.SafeCastOptions(smallint)
+		checkCastFails(c.T(), src, *opts)
+
+		opts.AllowIntOverflow = true
+		exp := c.extArrayFromJSON(smallint, `[0, null, -31072]`)
+		defer exp.Release()
+		checkCast(c.T(), src, exp, *opts)
+	})
+
+	c.Run("all null", func() {
+		src := c.extArrayFromJSON(param1, `[null, null, null]`)
+		defer src.Release()
+
+		out, err := compute.CastArray(ctx, src, compute.SafeCastOptions(smallint))
+		c.Require().NoError(err)
+		defer out.Release()
+
+		c.Equal(3, out.Len())
+		c.Equal(3, out.NullN())
+	})
+
+	c.Run("sliced input", func() {
+		src := c.extArrayFromJSON(param1, `[1, 2, null, 4, 5]`)
+		defer src.Release()
+		sliced := array.NewSlice(src, 1, 4)
+		defer sliced.Release()
+		exp := c.extArrayFromJSON(smallint, `[2, null, 4]`)
+		defer exp.Release()
+
+		out, err := compute.CastArray(ctx, sliced, compute.SafeCastOptions(smallint))
+		c.Require().NoError(err)
+		defer out.Release()
+
+		assertArraysEqual(c.T(), exp, out)
+	})
+
+	c.Run("unsupported storage cast", func() {
+		src := c.extArrayFromJSON(viewExt, `["1", "2"]`)
+		defer src.Release()
+
+		_, err := compute.CastArray(ctx, src, compute.SafeCastOptions(param1))
+		c.ErrorIs(err, arrow.ErrNotImplemented)
+		c.ErrorContains(err, "no kernel matching input types (string_view)")
 	})
 }
 

--- a/arrow/compute/internal/kernels/cast.go
+++ b/arrow/compute/internal/kernels/cast.go
@@ -100,9 +100,8 @@ func GetZeroCastKernel(inID arrow.Type, inType exec.InputType, out exec.OutputTy
 	return k
 }
 
-// GetCommonCastKernels returns the list of kernels common to all types
-// such as casting from null or from Extension types of the appropriate
-// underlying type.
+// GetCommonCastKernels returns the list of kernels common to all cast
+// target types, currently only the kernel for casting from null.
 func GetCommonCastKernels(outID arrow.Type, outType exec.OutputType) (out []exec.ScalarKernel) {
 	out = make([]exec.ScalarKernel, 0, 2)
 


### PR DESCRIPTION
Casts are dispatched on the target type, and the cast function registered for extension targets only accepted NULL inputs. Casting an extension array to a different extension type therefore failed with "function 'cast_extension' has no kernel matching input types" even when the cast between the two storage types is well defined, while the reverse direction (extension input, concrete target) has always been handled by the generic `CastFromExtension` unwrap kernel.

Register a generic extension -> extension kernel that unwraps the input array, casts its storage to the target's storage type honoring the caller's cast options, and rewraps the result as the target extension type. Re-typing between extension types that share a storage type is zero-copy since the inner storage cast is then a no-op.

Also correct the `GetCommonCastKernels` doc comment, which claimed to return kernels for casting from extension types; it only ever returned the cast-from-null kernel.
