### PR TITLE
fix(parquet/file): close file on OpenParquetFile errors

### DIFF
--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -103,10 +103,7 @@ func OpenParquetFile(filename string, memoryMap bool, opts ...ReadOption) (*Read
 func newParquetReaderFromFile(source readerAtSeekerCloser, opts ...ReadOption) (*Reader, error) {
 	rdr, err := NewParquetReader(source, opts...)
 	if err != nil {
-		if closeErr := source.Close(); closeErr != nil {
-			return nil, errors.Join(err, closeErr)
-		}
-		return nil, err
+		return nil, errors.Join(err, source.Close())
 	}
 	return rdr, nil
 }

--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -103,7 +103,10 @@ func OpenParquetFile(filename string, memoryMap bool, opts ...ReadOption) (*Read
 func newParquetReaderFromFile(source readerAtSeekerCloser, opts ...ReadOption) (*Reader, error) {
 	rdr, err := NewParquetReader(source, opts...)
 	if err != nil {
-		return nil, errors.Join(err, source.Close())
+		if closeErr := source.Close(); closeErr != nil {
+			return nil, errors.Join(err, closeErr)
+		}
+		return nil, err
 	}
 	return rdr, nil
 }

--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -42,6 +42,11 @@ var (
 	errInconsistentFileMetadata = errors.New("parquet: file is smaller than indicated metadata size")
 )
 
+type readerAtSeekerCloser interface {
+	parquet.ReaderAtSeeker
+	io.Closer
+}
+
 // Reader is the main interface for reading a parquet file
 type Reader struct {
 	r                 parquet.ReaderAtSeeker
@@ -78,7 +83,7 @@ func WithMetadata(m *metadata.FileMetaData) ReadOption {
 // then the default ReaderProperties will be used. The WithMetadata option can be used to provide
 // a FileMetaData object rather than reading the file metadata from the file.
 func OpenParquetFile(filename string, memoryMap bool, opts ...ReadOption) (*Reader, error) {
-	var source parquet.ReaderAtSeeker
+	var source readerAtSeekerCloser
 
 	var err error
 	if memoryMap {
@@ -92,9 +97,13 @@ func OpenParquetFile(filename string, memoryMap bool, opts ...ReadOption) (*Read
 			return nil, err
 		}
 	}
+	return newParquetReaderFromFile(source, opts...)
+}
+
+func newParquetReaderFromFile(source readerAtSeekerCloser, opts ...ReadOption) (*Reader, error) {
 	rdr, err := NewParquetReader(source, opts...)
 	if err != nil {
-		return nil, errors.Join(err, source.(io.Closer).Close())
+		return nil, errors.Join(err, source.Close())
 	}
 	return rdr, nil
 }

--- a/parquet/file/file_reader.go
+++ b/parquet/file/file_reader.go
@@ -92,7 +92,11 @@ func OpenParquetFile(filename string, memoryMap bool, opts ...ReadOption) (*Read
 			return nil, err
 		}
 	}
-	return NewParquetReader(source, opts...)
+	rdr, err := NewParquetReader(source, opts...)
+	if err != nil {
+		return nil, errors.Join(err, source.(io.Closer).Close())
+	}
+	return rdr, nil
 }
 
 // NewParquetReader returns a FileReader instance that reads a parquet file which can be read from r.

--- a/parquet/file/file_reader_mmap.go
+++ b/parquet/file/file_reader_mmap.go
@@ -23,11 +23,10 @@ import (
 	"errors"
 	"io"
 
-	"github.com/apache/arrow-go/v18/parquet"
 	"golang.org/x/exp/mmap"
 )
 
-func mmapOpen(filename string) (parquet.ReaderAtSeeker, error) {
+func mmapOpen(filename string) (readerAtSeekerCloser, error) {
 	rdr, err := mmap.Open(filename)
 	if err != nil {
 		return nil, err

--- a/parquet/file/file_reader_mmap_windows.go
+++ b/parquet/file/file_reader_mmap_windows.go
@@ -19,12 +19,8 @@
 
 package file
 
-import (
-	"errors"
+import "errors"
 
-	"github.com/apache/arrow-go/v18/parquet"
-)
-
-func mmapOpen(_ string) (parquet.ReaderAtSeeker, error) {
+func mmapOpen(_ string) (readerAtSeekerCloser, error) {
 	return nil, errors.New("mmap not implemented on windows")
 }

--- a/parquet/file/open_file_internal_test.go
+++ b/parquet/file/open_file_internal_test.go
@@ -19,6 +19,7 @@ package file
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,12 +27,23 @@ import (
 
 type closeTrackingReader struct {
 	*bytes.Reader
-	closed bool
+	closed   bool
+	closeErr error
 }
 
 func (r *closeTrackingReader) Close() error {
 	r.closed = true
-	return nil
+	return r.closeErr
+}
+
+func TestOpenParquetFileJoinsSourceCloseErrors(t *testing.T) {
+	closeErr := errors.New("close failed")
+	source := &closeTrackingReader{Reader: bytes.NewReader([]byte("invalid")), closeErr: closeErr}
+	rdr, err := newParquetReaderFromFile(source)
+	require.Error(t, err)
+	require.Nil(t, rdr)
+	require.ErrorIs(t, err, closeErr)
+	require.True(t, source.closed)
 }
 
 func TestOpenParquetFileClosesSourceOnError(t *testing.T) {

--- a/parquet/file/open_file_internal_test.go
+++ b/parquet/file/open_file_internal_test.go
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package file
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type closeTrackingReader struct {
+	*bytes.Reader
+	closed bool
+}
+
+func (r *closeTrackingReader) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestOpenParquetFileClosesSourceOnError(t *testing.T) {
+	source := &closeTrackingReader{Reader: bytes.NewReader([]byte("invalid"))}
+	rdr, err := newParquetReaderFromFile(source)
+	require.Error(t, err)
+	require.Nil(t, rdr)
+	require.True(t, source.closed)
+}


### PR DESCRIPTION
### Rationale for this change

`OpenParquetFile` opens a file or mmap before constructing the reader. If initialization fails while parsing metadata, the function returned without closing that owned source.

### What changes are included in this PR?

Require the internally opened source to implement `ReaderAt`, `Seeker`, and `Closer`, then close it when `NewParquetReader` fails. Preserve a simultaneous close failure with `errors.Join`.

### Are these changes tested?

Yes. A close-tracking regression test verifies that malformed input closes the owned source, and the mmap signature cross-compiles on Windows.

`go test ./parquet/file -run TestOpenParquetFileClosesSourceOnError`

### Are there any user-facing changes?

Invalid files still return an error, but their file descriptor or mmap is released promptly.