### PR TITLE
fix(parquet/metadata): reject negative row-group indices in Subset

### DIFF
--- a/parquet/metadata/file.go
+++ b/parquet/metadata/file.go
@@ -425,7 +425,7 @@ func (f *FileMetaData) AppendRowGroups(other *FileMetaData) error {
 // row groups by index
 func (f *FileMetaData) Subset(rowGroups []int) (*FileMetaData, error) {
 	for _, i := range rowGroups {
-		if i < len(f.RowGroups) {
+		if i >= 0 && i < len(f.RowGroups) {
 			continue
 		}
 		return nil, fmt.Errorf("parquet: this file only has %d row groups, but requested a subset including row group: %d", len(f.RowGroups), i)

--- a/parquet/metadata/metadata_test.go
+++ b/parquet/metadata/metadata_test.go
@@ -236,6 +236,12 @@ func TestBuildAccess(t *testing.T) {
 	sub, err := faccessor.Subset([]int{2, 0})
 	require.NoError(t, err)
 	assert.True(t, faccessor1.Equals(sub))
+
+	for _, rowGroups := range [][]int{{-1}, {0, -1}} {
+		sub, err := faccessor.Subset(rowGroups)
+		require.Error(t, err)
+		assert.Nil(t, sub)
+	}
 }
 
 func TestV1VersionMetadata(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

`FileMetaData.Subset` checked only the upper bound. Negative indices passed validation and later caused a runtime bounds panic despite the method having an error return.

### What changes are included in this PR?

Reject indices below zero as well as indices at or above the row-group count.

### Are these changes tested?

Yes. Regression cases cover an isolated negative index and mixed valid/invalid input.

`go test ./parquet/metadata`

### Are there any user-facing changes?

Negative selections now return an error instead of panicking.