### PR TITLE
fix(parquet/metadata): return schema initialization errors

### DIFF
--- a/parquet/metadata/file.go
+++ b/parquet/metadata/file.go
@@ -317,7 +317,9 @@ func NewFileMetaData(data []byte, fileDecryptor encryption.FileDecryptor) (*File
 		FileDecryptor: fileDecryptor,
 	}
 
-	f.initSchema()
+	if err := f.initSchema(); err != nil {
+		return nil, err
+	}
 	f.initColumnOrders()
 
 	return f, nil

--- a/parquet/metadata/file_internal_test.go
+++ b/parquet/metadata/file_internal_test.go
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package metadata
+
+import (
+	"bytes"
+	"testing"
+
+	format "github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet"
+	"github.com/apache/arrow-go/v18/parquet/internal/thrift"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFileMetaDataReturnsSchemaErrors(t *testing.T) {
+	fileMeta := format.NewFileMetaData()
+	var buf bytes.Buffer
+	_, err := thrift.NewThriftSerializer().Serialize(fileMeta, &buf, nil)
+	require.NoError(t, err)
+
+	meta, err := NewFileMetaData(buf.Bytes(), nil)
+	require.Error(t, err)
+	require.Nil(t, meta)
+}

--- a/parquet/metadata/page_index_internal_test.go
+++ b/parquet/metadata/page_index_internal_test.go
@@ -72,17 +72,6 @@ func constructFakeMetadata(rowGroupRanges []PageIndexRanges) *FileMetaData {
 	return meta
 }
 
-func TestNewFileMetaDataReturnsSchemaErrors(t *testing.T) {
-	fileMeta := format.NewFileMetaData()
-	var buf bytes.Buffer
-	_, err := thrift.NewThriftSerializer().Serialize(fileMeta, &buf, nil)
-	require.NoError(t, err)
-
-	meta, err := NewFileMetaData(buf.Bytes(), nil)
-	require.Error(t, err)
-	assert.Nil(t, meta)
-}
-
 // validates that determinePagteIndexRangesInRowGroup selects the expected
 // file offsets and sizes or returns false when the row group doesn't have
 // a page index

--- a/parquet/metadata/page_index_internal_test.go
+++ b/parquet/metadata/page_index_internal_test.go
@@ -72,6 +72,17 @@ func constructFakeMetadata(rowGroupRanges []PageIndexRanges) *FileMetaData {
 	return meta
 }
 
+func TestNewFileMetaDataReturnsSchemaErrors(t *testing.T) {
+	fileMeta := format.NewFileMetaData()
+	var buf bytes.Buffer
+	_, err := thrift.NewThriftSerializer().Serialize(fileMeta, &buf, nil)
+	require.NoError(t, err)
+
+	meta, err := NewFileMetaData(buf.Bytes(), nil)
+	require.Error(t, err)
+	assert.Nil(t, meta)
+}
+
 // validates that determinePagteIndexRangesInRowGroup selects the expected
 // file offsets and sizes or returns false when the row group doesn't have
 // a page index


### PR DESCRIPTION
### Rationale for this change

`NewFileMetaData` discarded the error from `initSchema` and immediately initialized column orders. When malformed metadata could not produce a schema, this could dereference the unset schema and panic.

### What changes are included in this PR?

Return the schema initialization error before touching column orders.

### Are these changes tested?

Yes. A regression test serializes invalid schema metadata and verifies an error with no result.

`go test ./parquet/metadata -run TestNewFileMetaDataReturnsSchemaErrors`

### Are there any user-facing changes?

Malformed metadata now returns its schema error instead of potentially panicking.