### PR TITLE
fix(arrow/array): always release JSON reader builder

### DIFF
--- a/arrow/array/json_reader.go
+++ b/arrow/array/json_reader.go
@@ -146,9 +146,13 @@ func (r *JSONReader) Release() {
 	if r.refs.Add(-1) == 0 {
 		if r.cur != nil {
 			r.cur.Release()
-			r.bldr.Release()
-			r.r = nil
+			r.cur = nil
 		}
+		if r.bldr != nil {
+			r.bldr.Release()
+			r.bldr = nil
+		}
+		r.r = nil
 	}
 }
 

--- a/arrow/array/json_reader_release_error_test.go
+++ b/arrow/array/json_reader_release_error_test.go
@@ -32,8 +32,9 @@ func TestJSONReaderReleaseBuilderAfterPartialReadError(t *testing.T) {
 		{Name: "value", Type: arrow.PrimitiveTypes.Int64},
 	}, nil)
 
-	// The first value allocates builder buffers, then the duplicate key leaves
-	// the reader with no current record batch and a partially populated builder.
+	// The first value allocates builder buffers. Rejecting the duplicate key then
+	// fails before a record batch is created, leaving cur nil while the builder
+	// still owns those buffers.
 	rdr := array.NewJSONReader(
 		strings.NewReader(`{"value": 1, "value": 2}`),
 		schema,

--- a/arrow/array/json_reader_release_error_test.go
+++ b/arrow/array/json_reader_release_error_test.go
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package array_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONReaderReleaseBuilderAfterPartialReadError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "value", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	// The first value allocates builder buffers, then the duplicate key leaves
+	// the reader with no current record batch and a partially populated builder.
+	rdr := array.NewJSONReader(
+		strings.NewReader(`{"value": 1, "value": 2}`),
+		schema,
+		array.WithAllocator(mem),
+	)
+	require.False(t, rdr.Next())
+	require.Error(t, rdr.Err())
+
+	rdr.Release()
+	mem.AssertSize(t, 0)
+}

--- a/arrow/array/json_reader_test.go
+++ b/arrow/array/json_reader_test.go
@@ -95,6 +95,38 @@ func TestJSONReaderAll(t *testing.T) {
 	assert.False(t, rdr.Next())
 }
 
+func TestJSONReaderReleaseBuilder(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "value", Type: arrow.PrimitiveTypes.Int64},
+	}, nil)
+
+	tests := []struct {
+		name    string
+		input   string
+		consume bool
+	}{
+		{name: "before reading", input: `{"value": 1}`},
+		{name: "after empty input", consume: true},
+		{name: "after reaching EOF", input: `{"value": 1}`, consume: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+			rdr := array.NewJSONReader(strings.NewReader(tt.input), schema, array.WithAllocator(mem))
+
+			if tt.consume {
+				for rdr.Next() {
+				}
+				require.NoError(t, rdr.Err())
+			}
+
+			rdr.Release()
+			mem.AssertSize(t, 0)
+		})
+	}
+}
+
 func TestJSONReaderChunked(t *testing.T) {
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "region", Type: arrow.BinaryTypes.String, Nullable: true},

--- a/arrow/array/json_reader_test.go
+++ b/arrow/array/json_reader_test.go
@@ -95,38 +95,6 @@ func TestJSONReaderAll(t *testing.T) {
 	assert.False(t, rdr.Next())
 }
 
-func TestJSONReaderReleaseBuilder(t *testing.T) {
-	schema := arrow.NewSchema([]arrow.Field{
-		{Name: "value", Type: arrow.PrimitiveTypes.Int64},
-	}, nil)
-
-	tests := []struct {
-		name    string
-		input   string
-		consume bool
-	}{
-		{name: "before reading", input: `{"value": 1}`},
-		{name: "after empty input", consume: true},
-		{name: "after reaching EOF", input: `{"value": 1}`, consume: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-			rdr := array.NewJSONReader(strings.NewReader(tt.input), schema, array.WithAllocator(mem))
-
-			if tt.consume {
-				for rdr.Next() {
-				}
-				require.NoError(t, rdr.Err())
-			}
-
-			rdr.Release()
-			mem.AssertSize(t, 0)
-		})
-	}
-}
-
 func TestJSONReaderChunked(t *testing.T) {
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "region", Type: arrow.BinaryTypes.String, Nullable: true},


### PR DESCRIPTION
## What changed

Release the JSON reader record builder whenever the final reader reference is released, independently of whether a current record batch exists.

## Why

The builder release was nested under the current-record check. A decode error can leave `cur` nil while the builder still owns buffers from values parsed before the error, so releasing the reader did not free those buffers.

The regression test parses an object far enough to allocate builder storage, triggers a duplicate-key error before a record batch is produced, and verifies with a checked allocator that `Release` frees the partial builder state.

## Testing

- `go test ./arrow/array`
- `go test -race ./arrow/array -run TestJSONReaderReleaseBuilderAfterPartialReadError`
