### PR TITLE
fix(arrow/flight/flightsql): avoid double-retaining parameter readers

### DIFF
--- a/arrow/flight/flightsql/client.go
+++ b/arrow/flight/flightsql/client.go
@@ -1422,7 +1422,6 @@ func (p *PreparedStatement) SetParameters(binding arrow.RecordBatch) {
 // PreparedStatement.
 func (p *PreparedStatement) SetRecordReader(binding array.RecordReader) {
 	p.clearParameters()
-	binding.Retain()
 	p.streamBinding = binding
 	p.streamBinding.Retain()
 }

--- a/arrow/flight/flightsql/client_test.go
+++ b/arrow/flight/flightsql/client_test.go
@@ -43,6 +43,21 @@ type mockGrpcClientStream struct {
 	mock.Mock
 }
 
+type referenceCountingReader struct {
+	array.RecordReader
+	refs int
+}
+
+func (r *referenceCountingReader) Retain() {
+	r.refs++
+	r.RecordReader.Retain()
+}
+
+func (r *referenceCountingReader) Release() {
+	r.refs--
+	r.RecordReader.Release()
+}
+
 func (m *mockGrpcClientStream) Header() (metadata.MD, error)  { panic("unimplemented") }
 func (m *mockGrpcClientStream) Trailer() metadata.MD          { panic("unimplemented") }
 func (m *mockGrpcClientStream) CloseSend() error              { return m.Called().Error(0) }
@@ -566,7 +581,6 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteReaderBinding() {
 
 	prepared, err := s.sqlClient.Prepare(context.TODO(), query, s.callOpts...)
 	s.NoError(err)
-	defer prepared.Close(context.TODO(), s.callOpts...)
 
 	s.Equal(string(prepared.Handle()), "query")
 
@@ -575,13 +589,19 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteReaderBinding() {
 	s.NoError(err)
 	defer rec.Release()
 
-	rdr, err := array.NewRecordReader(rec.Schema(), []arrow.RecordBatch{rec, rec, rec})
+	baseReader, err := array.NewRecordReader(rec.Schema(), []arrow.RecordBatch{rec, rec, rec})
 	s.NoError(err)
+	rdr := &referenceCountingReader{RecordReader: baseReader, refs: 1}
+	defer rdr.Release()
 	prepared.SetRecordReader(rdr)
+	s.Equal(2, rdr.refs)
 
 	info, err := prepared.Execute(context.TODO(), s.callOpts...)
 	s.NoError(err)
 	s.Equal(&emptyFlightInfo, info)
+
+	s.NoError(prepared.Close(context.TODO(), s.callOpts...))
+	s.Equal(1, rdr.refs)
 }
 
 func (s *FlightSqlClientSuite) TestPreparedStatementClose() {

--- a/arrow/flight/flightsql/client_test.go
+++ b/arrow/flight/flightsql/client_test.go
@@ -43,21 +43,6 @@ type mockGrpcClientStream struct {
 	mock.Mock
 }
 
-type referenceCountingReader struct {
-	array.RecordReader
-	refs int
-}
-
-func (r *referenceCountingReader) Retain() {
-	r.refs++
-	r.RecordReader.Retain()
-}
-
-func (r *referenceCountingReader) Release() {
-	r.refs--
-	r.RecordReader.Release()
-}
-
 func (m *mockGrpcClientStream) Header() (metadata.MD, error)  { panic("unimplemented") }
 func (m *mockGrpcClientStream) Trailer() metadata.MD          { panic("unimplemented") }
 func (m *mockGrpcClientStream) CloseSend() error              { return m.Called().Error(0) }
@@ -581,6 +566,7 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteReaderBinding() {
 
 	prepared, err := s.sqlClient.Prepare(context.TODO(), query, s.callOpts...)
 	s.NoError(err)
+	defer prepared.Close(context.TODO(), s.callOpts...)
 
 	s.Equal(string(prepared.Handle()), "query")
 
@@ -589,19 +575,13 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteReaderBinding() {
 	s.NoError(err)
 	defer rec.Release()
 
-	baseReader, err := array.NewRecordReader(rec.Schema(), []arrow.RecordBatch{rec, rec, rec})
+	rdr, err := array.NewRecordReader(rec.Schema(), []arrow.RecordBatch{rec, rec, rec})
 	s.NoError(err)
-	rdr := &referenceCountingReader{RecordReader: baseReader, refs: 1}
-	defer rdr.Release()
 	prepared.SetRecordReader(rdr)
-	s.Equal(2, rdr.refs)
 
 	info, err := prepared.Execute(context.TODO(), s.callOpts...)
 	s.NoError(err)
 	s.Equal(&emptyFlightInfo, info)
-
-	s.NoError(prepared.Close(context.TODO(), s.callOpts...))
-	s.Equal(1, rdr.refs)
 }
 
 func (s *FlightSqlClientSuite) TestPreparedStatementClose() {

--- a/arrow/flight/flightsql/prepared_statement_reader_lifecycle_test.go
+++ b/arrow/flight/flightsql/prepared_statement_reader_lifecycle_test.go
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flightsql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreparedStatementReleasesRecordReaderBindingOnce(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	}, nil)
+
+	rec, _, err := array.RecordFromJSON(mem, schema, strings.NewReader(`[{"id": 1}]`))
+	require.NoError(t, err)
+
+	rdr, err := array.NewRecordReader(schema, []arrow.RecordBatch{rec})
+	require.NoError(t, err)
+
+	prepared := flightsql.NewPreparedStatement(&flightsql.Client{}, nil)
+	prepared.SetRecordReader(rdr)
+
+	// Drop the caller-owned references. Replacing the binding must release the
+	// single reference retained by the prepared statement and free the record.
+	rdr.Release()
+	rec.Release()
+	prepared.SetParameters(nil)
+
+	mem.AssertSize(t, 0)
+}


### PR DESCRIPTION
## What changed

Remove the duplicate retain in `PreparedStatement.SetRecordReader`.

## Why

The setter retained the supplied reader twice, while parameter replacement and statement close released it only once. This left one reference permanently owned by the statement.

The regression test binds an allocator-backed record reader, drops the caller-owned references, then replaces the binding. The statement's single release must free the record buffers; the previous double retain leaves them allocated.

## Testing

- `go test ./arrow/flight/flightsql`
- `go test -race ./arrow/flight/flightsql -run TestPreparedStatementReleasesRecordReaderBindingOnce`
