### PR TITLE
fix(arrow): return an owned slice from Schema.FieldsByName

### DIFF
--- a/arrow/schema.go
+++ b/arrow/schema.go
@@ -220,7 +220,7 @@ func (sc *Schema) FieldsByName(n string) ([]Field, bool) {
 		return nil, ok
 	}
 	if len(indices) == 1 {
-		return sc.fields[indices[0] : indices[0]+1], ok
+		return []Field{sc.fields[indices[0]]}, ok
 	} else if len(indices) > 1 {
 		fields := make([]Field, 0, len(indices))
 		for _, v := range indices {

--- a/arrow/schema_test.go
+++ b/arrow/schema_test.go
@@ -336,6 +336,19 @@ func TestSchema(t *testing.T) {
 	}
 }
 
+func TestSchemaFieldsByNameReturnsCopy(t *testing.T) {
+	schema := NewSchema([]Field{{Name: "id", Type: PrimitiveTypes.Int64}}, nil)
+	fields, ok := schema.FieldsByName("id")
+	if !ok {
+		t.Fatal("field not found")
+	}
+	fields[0].Name = "changed"
+
+	if got, want := schema.Field(0).Name, "id"; got != want {
+		t.Fatalf("schema field mutated through returned slice: got %q, want %q", got, want)
+	}
+}
+
 func TestSchemaAddField(t *testing.T) {
 	s := NewSchema([]Field{
 		{Name: "f1", Type: PrimitiveTypes.Int32},


### PR DESCRIPTION
## Problem

For a unique name match, `Schema.FieldsByName` returned a one-element slice backed by the schema’s internal field storage. Mutating the returned element could therefore mutate the schema. The duplicate-name path and `Schema.Fields` already returned owned slices.

## Change

Return a new one-element slice for the unique-match path, making ownership consistent across all successful `FieldsByName` results.

## Coverage

The regression test mutates the returned field and verifies that the original schema remains unchanged.

## Validation

`go test ./arrow`