### PR TITLE
fix(flight): accept case-insensitive authorization schemes

### DIFF
--- a/arrow/flight/basic_auth_flight_test.go
+++ b/arrow/flight/basic_auth_flight_test.go
@@ -173,6 +173,17 @@ func TestErrorAuths(t *testing.T) {
 			t.Fatalf("unexpected schema: got %q, want %q", got, want)
 		}
 	})
+
+	t.Run("lowercase bearer scheme", func(t *testing.T) {
+		ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("authorization", "bearer "+validBearer))
+		result, err := client.GetSchema(ctx, &flight.FlightDescriptor{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := string(result.Schema), "carebears"; got != want {
+			t.Fatalf("unexpected schema: got %q, want %q", got, want)
+		}
+	})
 }
 
 func TestBasicAuthHelpers(t *testing.T) {

--- a/arrow/flight/server_auth.go
+++ b/arrow/flight/server_auth.go
@@ -160,7 +160,7 @@ func createServerBearerTokenUnaryInterceptor(validator BasicAuthValidator) grpc.
 			}
 		}
 
-		if scheme != bearerTokenPrefix || credential == "" {
+		if !strings.EqualFold(scheme, bearerTokenPrefix) || credential == "" {
 			return nil, status.Error(codes.Unauthenticated, "must authenticate first")
 		}
 
@@ -191,7 +191,7 @@ func createServerBearerTokenStreamInterceptor(validator BasicAuthValidator) grpc
 		}
 
 		if strings.HasSuffix(info.FullMethod, "/Handshake") {
-			if scheme == basicAuthPrefix {
+			if strings.EqualFold(scheme, basicAuthPrefix) {
 				val, err := base64.RawStdEncoding.DecodeString(credential)
 				if err != nil {
 					val, err = base64.StdEncoding.DecodeString(credential)
@@ -217,7 +217,7 @@ func createServerBearerTokenStreamInterceptor(validator BasicAuthValidator) grpc
 			return status.Errorf(codes.Unauthenticated, "only Basic Auth implemented")
 		}
 
-		if scheme == bearerTokenPrefix {
+		if strings.EqualFold(scheme, bearerTokenPrefix) {
 			identity, err := validator.IsValid(credential)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Problem

Flight authentication compared the `Basic` and `Bearer` authorization schemes case-sensitively, even though HTTP authentication scheme names are case-insensitive. Valid clients using forms such as `bearer` were rejected.

## Change

Use `strings.EqualFold` for scheme matching in both Basic and Bearer authentication paths. Credential bytes remain untouched and case-sensitive.

## Coverage

The regression test sends a lowercase Bearer scheme through the Flight server and verifies successful authentication.

## Validation

`go test ./arrow/flight`