### PR TITLE
fix(parquet): report initialized row-group columns correctly

### DIFF
--- a/parquet/file/file_writer_test.go
+++ b/parquet/file/file_writer_test.go
@@ -1474,8 +1474,8 @@ func TestRowGroupClosePropagatesMetadataFinishError(t *testing.T) {
 	rgw, err := writer.AppendRowGroupChecked()
 	require.NoError(t, err)
 
-	require.ErrorContains(t, rgw.Close(), "only -1 out of 1 columns are initialized")
-	require.ErrorContains(t, writer.Close(), "only -1 out of 1 columns are initialized")
+	require.ErrorContains(t, rgw.Close(), "only 0 out of 1 columns are initialized")
+	require.ErrorContains(t, writer.Close(), "only 0 out of 1 columns are initialized")
 }
 
 func TestFlushWithFooterKeepsPageIndexBuilderAppendable(t *testing.T) {

--- a/parquet/metadata/metadata_test.go
+++ b/parquet/metadata/metadata_test.go
@@ -75,6 +75,23 @@ func assertStatsSet(t *testing.T, m *metadata.ColumnChunkMetaData) {
 	assert.True(t, ok)
 }
 
+func TestRowGroupFinishReportsInitializedColumnCount(t *testing.T) {
+	fields := schema.FieldList{
+		schema.NewInt32Node("first", parquet.Repetitions.Required, -1),
+		schema.NewInt32Node("second", parquet.Repetitions.Required, -1),
+	}
+	root, err := schema.NewGroupNode("schema", parquet.Repetitions.Required, fields, -1)
+	require.NoError(t, err)
+	builder := metadata.NewFileMetadataBuilder(schema.NewSchema(root), parquet.NewWriterProperties(), nil)
+	rowGroup := builder.AppendRowGroup()
+
+	err = rowGroup.Finish(0, 0)
+	require.EqualError(t, err, "parquet: only 0 out of 2 columns are initialized")
+	rowGroup.NextColumnChunk()
+	err = rowGroup.Finish(0, 0)
+	require.EqualError(t, err, "parquet: only 1 out of 2 columns are initialized")
+}
+
 func assertStats(t *testing.T, m *metadata.ColumnChunkMetaData) metadata.TypedStatistics {
 	s, err := m.Statistics()
 	assert.NoError(t, err)

--- a/parquet/metadata/row_group.go
+++ b/parquet/metadata/row_group.go
@@ -187,7 +187,7 @@ func (r *RowGroupMetaDataBuilder) NextColumnChunk() *ColumnChunkMetaDataBuilder 
 // being written. e.g. first row group should be 0, second is 1, and so on...
 func (r *RowGroupMetaDataBuilder) Finish(_ int64, ordinal int16) error {
 	if r.nextCol != r.NumColumns() {
-		return fmt.Errorf("parquet: only %d out of %d columns are initialized", r.nextCol-1, r.schema.NumColumns())
+		return fmt.Errorf("parquet: only %d out of %d columns are initialized", r.nextCol, r.schema.NumColumns())
 	}
 
 	var (


### PR DESCRIPTION
## Problem

`RowGroupMetaDataBuilder.nextCol` already represents the number of initialized columns. The incomplete-row-group error subtracted one from it, reporting `-1` before any column was initialized and remaining off by one afterward.

## Change

Report `nextCol` directly in the diagnostic. This changes only the error count; row-group construction behavior is unchanged.

## Coverage

The regression test checks the messages with zero and one initialized columns in a two-column schema.

## Validation

`go test ./parquet/metadata`