### PR TITLE
fix(parquet): serialize column chunk file offsets

### DIFF
--- a/parquet/metadata/column_chunk.go
+++ b/parquet/metadata/column_chunk.go
@@ -372,6 +372,7 @@ func (c *ColumnChunkMetaDataBuilder) Finish(info ChunkMetaInfo, hasDict, dictFal
 	} else {
 		c.fileOffset = info.DataPageOffset
 	}
+	c.chunk.FileOffset = c.fileOffset
 
 	c.chunk.MetaData.NumValues = info.NumValues
 	if info.IndexPageOffset >= 0 {

--- a/parquet/metadata/metadata_test.go
+++ b/parquet/metadata/metadata_test.go
@@ -138,9 +138,11 @@ func TestBuildAccess(t *testing.T) {
 		rg1Col1, err := rg1Access.ColumnChunk(0)
 		assert.NoError(t, err)
 		assert.Equal(t, rg1Access.FileOffset(), rg1Col1.DictionaryPageOffset())
+		assert.Equal(t, rg1Col1.DictionaryPageOffset(), rg1Col1.FileOffset())
 
 		rg1Col2, err := rg1Access.ColumnChunk(1)
 		assert.NoError(t, err)
+		assert.Equal(t, rg1Col2.DictionaryPageOffset(), rg1Col2.FileOffset())
 		assertStatsSet(t, rg1Col1)
 		assertStatsSet(t, rg1Col2)
 		assert.Equal(t, statsInt.Min, assertStats(t, rg1Col1).EncodeMin())
@@ -178,6 +180,7 @@ func TestBuildAccess(t *testing.T) {
 		rg2Col1, err := rg2Access.ColumnChunk(0)
 		assert.NoError(t, err)
 		assert.Equal(t, rg2Access.FileOffset(), rg2Col1.DataPageOffset())
+		assert.Equal(t, rg2Col1.DataPageOffset(), rg2Col1.FileOffset())
 
 		rg2Col2, err := rg2Access.ColumnChunk(1)
 		assert.NoError(t, err)

--- a/parquet/pqarrow/file_writer_test.go
+++ b/parquet/pqarrow/file_writer_test.go
@@ -172,7 +172,7 @@ func TestFileWriterTotalBytes(t *testing.T) {
 
 	// Verify total bytes & compressed bytes are correct
 	assert.Equal(t, int64(332), writer.TotalCompressedBytes())
-	assert.Equal(t, int64(783), writer.TotalBytesWritten())
+	assert.Equal(t, int64(786), writer.TotalBytesWritten())
 }
 
 func TestFileWriterTotalBytesBuffered(t *testing.T) {
@@ -206,7 +206,7 @@ func TestFileWriterTotalBytesBuffered(t *testing.T) {
 
 	// Verify total bytes & compressed bytes are correct
 	assert.Equal(t, int64(482), writer.TotalCompressedBytes())
-	assert.Equal(t, int64(1115), writer.TotalBytesWritten())
+	assert.Equal(t, int64(1120), writer.TotalBytesWritten())
 }
 
 func TestWriteOnClosedFileWriter(t *testing.T) {


### PR DESCRIPTION
Fixes #891

## Problem

`ColumnChunkMetaDataBuilder.Finish` computed the first page offset for internal row-group metadata but did not copy it to the serialized Thrift `ColumnChunk.FileOffset` field. Serialized metadata therefore reported the default zero value even when the chunk started elsewhere.

## Change

Populate `ColumnChunk.FileOffset` from the computed first page offset:

- dictionary page offset when a dictionary page is present
- data page offset otherwise

## Coverage

The metadata round-trip test verifies dictionary and non-dictionary column chunks before and after serialization.

## Validation

`go test ./parquet/metadata`