### PR TITLE
fix(parquet/variant): preserve metadata keys when cloning

### DIFF
--- a/parquet/variant/variant.go
+++ b/parquet/variant/variant.go
@@ -168,15 +168,18 @@ func NewMetadata(data []byte) (Metadata, error) {
 
 // Clone creates a deep copy of the metadata.
 func (m *Metadata) Clone() Metadata {
-	keys := make([][]byte, len(m.keys))
-	for i, key := range m.keys {
-		keys[i] = bytes.Clone(key)
+	clone := Metadata{data: bytes.Clone(m.data)}
+	if len(clone.data) > 0 && len(m.keys) > 0 {
+		if err := clone.loadDictionary(clone.OffsetSize()); err == nil {
+			return clone
+		}
 	}
 
-	return Metadata{
-		data: bytes.Clone(m.data),
-		keys: keys,
+	clone.keys = make([][]byte, len(m.keys))
+	for i, key := range m.keys {
+		clone.keys[i] = bytes.Clone(key)
 	}
+	return clone
 }
 
 func (m *Metadata) loadDictionary(offsetSz uint8) error {

--- a/parquet/variant/variant.go
+++ b/parquet/variant/variant.go
@@ -168,12 +168,14 @@ func NewMetadata(data []byte) (Metadata, error) {
 
 // Clone creates a deep copy of the metadata.
 func (m *Metadata) Clone() Metadata {
+	keys := make([][]byte, len(m.keys))
+	for i, key := range m.keys {
+		keys[i] = bytes.Clone(key)
+	}
+
 	return Metadata{
 		data: bytes.Clone(m.data),
-		// shallow copy of the values, but the slice is copied
-		// more efficient, and nothing should be mutating the keys
-		// so it's probably safe, but something we should keep in mind
-		keys: slices.Clone(m.keys),
+		keys: keys,
 	}
 }
 

--- a/parquet/variant/variant_test.go
+++ b/parquet/variant/variant_test.go
@@ -160,6 +160,17 @@ func TestMetadataCloneOwnsKeys(t *testing.T) {
 	assert.Equal(t, "key", key)
 	assert.Equal(t, []uint32{0}, clone.IdFor("key"))
 	assert.Equal(t, clonedBytes, clone.Bytes())
+
+	copy(metadata.Bytes()[keyOffset:], "key")
+	clone = metadata.Clone()
+	copy(clone.Bytes()[keyOffset:], "bad")
+	key, err = clone.KeyAt(0)
+	require.NoError(t, err)
+	assert.Equal(t, "bad", key)
+	assert.Equal(t, []uint32{0}, clone.IdFor("bad"))
+	key, err = metadata.KeyAt(0)
+	require.NoError(t, err)
+	assert.Equal(t, "key", key)
 }
 
 func loadVariant(t *testing.T, test string) variant.Value {

--- a/parquet/variant/variant_test.go
+++ b/parquet/variant/variant_test.go
@@ -17,6 +17,7 @@
 package variant_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -136,6 +137,29 @@ func TestMetadataEmptyKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, key)
 	assert.Equal(t, []uint32{0}, metadata.IdFor(""))
+}
+
+func TestMetadataCloneOwnsKeys(t *testing.T) {
+	var b variant.Builder
+	start := b.Offset()
+	fields := []variant.FieldEntry{b.NextField(start, "key")}
+	require.NoError(t, b.AppendNull())
+	require.NoError(t, b.FinishObject(start, fields))
+	value, err := b.Build()
+	require.NoError(t, err)
+
+	metadata := value.Metadata()
+	clone := metadata.Clone()
+	clonedBytes := bytes.Clone(clone.Bytes())
+	keyOffset := bytes.Index(metadata.Bytes(), []byte("key"))
+	require.NotEqual(t, -1, keyOffset)
+	copy(metadata.Bytes()[keyOffset:], "bad")
+
+	key, err := clone.KeyAt(0)
+	require.NoError(t, err)
+	assert.Equal(t, "key", key)
+	assert.Equal(t, []uint32{0}, clone.IdFor("key"))
+	assert.Equal(t, clonedBytes, clone.Bytes())
 }
 
 func loadVariant(t *testing.T, test string) variant.Value {

--- a/parquet/variant/variant_test.go
+++ b/parquet/variant/variant_test.go
@@ -148,12 +148,14 @@ func TestMetadataCloneOwnsKeys(t *testing.T) {
 	value, err := b.Build()
 	require.NoError(t, err)
 
-	metadata := value.Metadata()
+	metadataBytes := bytes.Clone(value.Metadata().Bytes())
+	metadata, err := variant.NewMetadata(metadataBytes)
+	require.NoError(t, err)
 	clone := metadata.Clone()
 	clonedBytes := bytes.Clone(clone.Bytes())
-	keyOffset := bytes.Index(metadata.Bytes(), []byte("key"))
+	keyOffset := bytes.Index(metadataBytes, []byte("key"))
 	require.NotEqual(t, -1, keyOffset)
-	copy(metadata.Bytes()[keyOffset:], "bad")
+	copy(metadataBytes[keyOffset:], "bad")
 
 	key, err := clone.KeyAt(0)
 	require.NoError(t, err)
@@ -161,7 +163,7 @@ func TestMetadataCloneOwnsKeys(t *testing.T) {
 	assert.Equal(t, []uint32{0}, clone.IdFor("key"))
 	assert.Equal(t, clonedBytes, clone.Bytes())
 
-	copy(metadata.Bytes()[keyOffset:], "key")
+	copy(metadataBytes[keyOffset:], "key")
 	clone = metadata.Clone()
 	copy(clone.Bytes()[keyOffset:], "bad")
 	key, err = clone.KeyAt(0)


### PR DESCRIPTION
### Rationale for this change

Cloning Variant metadata copies the key slice headers, but the keys can still point into the original metadata buffer. Mutating the source bytes can then change lookups on the clone.

### What changes are included in this PR?

Clone the metadata bytes and rebuild the parsed key slices against the cloned buffer so KeyAt and IdFor do not depend on the source.

### Are these changes tested?

- `go test ./parquet/variant`
- Added coverage for source-byte mutation and cloned key lookups.

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.