### PR TITLE
fix(arrow/util): release protobuf enum dictionaries

### DIFF
--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -359,6 +359,7 @@ func (pdr protobufDictReflection) getDataType() arrow.DataType {
 func (pdr protobufDictReflection) getDictValues(mem memory.Allocator) arrow.Array {
 	enumValues := pdr.descriptor.Enum().Values()
 	bldr := array.NewStringBuilder(mem)
+	defer bldr.Release()
 	for i := 0; i < enumValues.Len(); i++ {
 		bldr.Append(string(enumValues.Get(i).Name()))
 	}
@@ -823,7 +824,9 @@ func (f ProtobufMessageFieldReflection) AppendValueOrNull(b array.Builder, mem m
 	case arrow.DICTIONARY:
 		pdr := f.asDictionary()
 		db := b.(*array.BinaryDictionaryBuilder)
-		err := db.InsertStringDictValues(pdr.getDictValues(mem).(*array.String))
+		dictValues := pdr.getDictValues(mem).(*array.String)
+		err := db.InsertStringDictValues(dictValues)
+		dictValues.Release()
 		if err != nil {
 			return err
 		}

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -497,6 +497,24 @@ func TestAppendValueOrNull(t *testing.T) {
 	assert.EqualErrorf(t, got, want, "Error is: %v, want: %v", got, want)
 }
 
+func TestAppendEnumReleasesDictionaryValues(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	pmr := NewProtobufMessageReflection(AllTheTypesNoAnyFixture().msg)
+	var enumField *ProtobufMessageFieldReflection
+	for i := range pmr.fields {
+		if pmr.fields[i].Type.ID() == arrow.DICTIONARY {
+			enumField = &pmr.fields[i]
+			break
+		}
+	}
+	require.NotNil(t, enumField)
+
+	bldr := array.NewDictionaryBuilder(mem, enumField.Type.(*arrow.DictionaryType))
+	require.NoError(t, enumField.AppendValueOrNull(bldr, mem))
+	bldr.Release()
+	mem.AssertSize(t, 0)
+}
+
 func TestGetMapKeyRejectsUnsupportedType(t *testing.T) {
 	_, err := getMapKey(reflect.ValueOf(struct{}{}))
 	require.Error(t, err)


### PR DESCRIPTION
## What changed

Release the temporary string builder and array used to initialize protobuf enum dictionaries.

## Why

`InsertStringDictValues` copies values from its input. The temporary builder and array remained owned by the conversion path and leaked after each enum append.

## Testing

- `go test ./arrow/util`
- Added checked-allocator coverage for enum conversion