### PR TITLE
fix(arrow/util): release protobuf record builders

### DIFF
--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -665,6 +665,9 @@ func (msg ProtobufMessageReflection) Record(mem memory.Allocator) arrow.RecordBa
 	}
 
 	schema := msg.Schema()
+	if schema.NumFields() == 0 {
+		return array.NewRecordBatch(schema, nil, 1)
+	}
 
 	recordBuilder := array.NewRecordBuilder(mem, schema)
 	defer recordBuilder.Release()

--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -667,22 +667,13 @@ func (msg ProtobufMessageReflection) Record(mem memory.Allocator) arrow.RecordBa
 	schema := msg.Schema()
 
 	recordBuilder := array.NewRecordBuilder(mem, schema)
+	defer recordBuilder.Release()
 
-	var fieldNames []string
 	for i, f := range msg.fields {
 		f.AppendValueOrNull(recordBuilder.Field(i), mem)
-		fieldNames = append(fieldNames, f.name())
 	}
 
-	var arrays []arrow.Array
-	for _, bldr := range recordBuilder.Fields() {
-		a := bldr.NewArray()
-		arrays = append(arrays, a)
-	}
-
-	structArray, _ := array.NewStructArray(arrays, fieldNames)
-
-	return array.RecordFromStructArray(structArray, schema)
+	return recordBuilder.NewRecordBatch()
 }
 
 // NewProtobufMessageReflection initialises a ProtobufMessageReflection

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -228,6 +228,7 @@ func CheckSchema(t *testing.T, pmr *ProtobufMessageReflection, want string) {
 
 func CheckRecord(t *testing.T, pmr *ProtobufMessageReflection, jsonStr string) {
 	rec := pmr.Record(nil)
+	defer rec.Release()
 	got, err := json.Marshal(rec)
 	assert.NoError(t, err)
 	assert.JSONEq(t, jsonStr, string(got), "got: %s\nwant: %s", got, jsonStr)
@@ -351,6 +352,14 @@ func TestRecordFromProtobuf(t *testing.T) {
 	pmr = NewProtobufMessageReflection(f.msg, WithExclusionPolicy(onlyEnum), WithEnumHandler(EnumNumber))
 	jsonStr = `[ { "enum":1 } ]`
 	CheckRecord(t, pmr, jsonStr)
+}
+
+func TestRecordReleasesConstructionBuffers(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	pmr := NewProtobufMessageReflection(AllTheTypesNoAnyFixture().msg, WithEnumHandler(EnumNumber))
+	rec := pmr.Record(mem)
+	rec.Release()
+	mem.AssertSize(t, 0)
 }
 
 func TestNullRecordFromProtobuf(t *testing.T) {

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -484,6 +484,17 @@ func TestExcludedNested(t *testing.T) {
 	CheckRecord(t, pmr, jsonStr)
 }
 
+func TestRecordReturnsOneRowForZeroFieldSchema(t *testing.T) {
+	excludeAll := func(*ProtobufFieldReflection) bool { return true }
+	pmr := NewProtobufMessageReflection(&util_message.AllTheTypesNoAny{}, WithExclusionPolicy(excludeAll))
+
+	rec := pmr.Record(memory.DefaultAllocator)
+	require.NotNil(t, rec)
+	defer rec.Release()
+	require.EqualValues(t, 1, rec.NumRows())
+	require.EqualValues(t, 0, rec.NumCols())
+}
+
 type testProtobufReflection struct {
 	ProtobufFieldReflection
 }


### PR DESCRIPTION
## What changed

Construct protobuf records through `RecordBuilder.NewRecordBatch` and release the builder after ownership transfers to the returned record. Record test helpers now release returned batches as well.

## Why

The manual conversion retained the record builder, each temporary field array, and the intermediate struct array. Releasing the returned record did not release those extra references.

## Testing

- `go test ./arrow/util`
- Added checked-allocator coverage for the complete record lifecycle