### PR TITLE
test(arrow/util): cover zero-field protobuf records

### DIFF
--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type Fixture struct {
@@ -371,6 +372,25 @@ func TestRecordReleasesConstructionBuffers(t *testing.T) {
 	rec := pmr.Record(mem)
 	rec.Release()
 	mem.AssertSize(t, 0)
+}
+
+func TestRecordWithAllFieldsExcluded(t *testing.T) {
+	pmr := NewProtobufMessageReflection(AllTheTypesNoAnyFixture().msg,
+		WithExclusionPolicy(func(*ProtobufFieldReflection) bool { return true }))
+	rec := pmr.Record(nil)
+	defer rec.Release()
+
+	assert.EqualValues(t, 1, rec.NumRows())
+	assert.Zero(t, rec.NumCols())
+}
+
+func TestRecordFromEmptyMessage(t *testing.T) {
+	pmr := NewProtobufMessageReflection(&emptypb.Empty{})
+	rec := pmr.Record(nil)
+	defer rec.Release()
+
+	assert.EqualValues(t, 1, rec.NumRows())
+	assert.Zero(t, rec.NumCols())
 }
 
 func TestNullRecordFromProtobuf(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

The zero-field record behavior is already present on main. When protobuf reflection produces a schema with no fields, one protobuf message still becomes one record with zero columns.

### What changes are included in this PR?

Add regression coverage for empty protobuf messages and exclusion policies that remove every field. This PR is test-only.

### Are these changes tested?

- `go test ./arrow/util`

### Are there any user-facing changes?

No. This PR only adds regression coverage. The zero-field record behavior is already present on main.