### PR TITLE
fix(arrow/util): handle invalid protobuf Any values

### DIFF
--- a/arrow/util/protobuf_reflect.go
+++ b/arrow/util/protobuf_reflect.go
@@ -194,11 +194,17 @@ type ProtobufMessageReflection struct {
 
 func (psr ProtobufMessageReflection) unmarshallAny() ProtobufMessageReflection {
 	if psr.descriptor.FullName() == "google.protobuf.Any" && psr.rValue.IsValid() {
-		for psr.rValue.Type().Kind() == reflect.Ptr {
-			psr.rValue = reflect.Indirect(psr.rValue)
+		if !psr.message.IsValid() {
+			return psr
 		}
-		fieldValueAsAny, _ := psr.rValue.Interface().(anypb.Any)
-		msg, _ := fieldValueAsAny.UnmarshalNew()
+		fieldValueAsAny, ok := psr.message.Interface().(*anypb.Any)
+		if !ok {
+			return psr
+		}
+		msg, err := fieldValueAsAny.UnmarshalNew()
+		if err != nil {
+			return psr
+		}
 
 		v := reflect.ValueOf(msg)
 		for v.Kind() == reflect.Ptr {

--- a/arrow/util/protobuf_reflect_test.go
+++ b/arrow/util/protobuf_reflect_test.go
@@ -349,6 +349,22 @@ func TestMapSchemaDoesNotDependOnValues(t *testing.T) {
 	require.True(t, withValuesSchema.Equal(emptySchema))
 }
 
+func TestMalformedAnyUsesPhysicalFields(t *testing.T) {
+	msg := util_message.AllTheTypes{
+		Any: &anypb.Any{TypeUrl: "invalid.example/missing", Value: []byte{1, 2, 3}},
+	}
+
+	pmr := NewProtobufMessageReflection(&msg)
+	anyFields := pmr.Schema().Field(17).Type.(*arrow.StructType).Fields()
+	require.Len(t, anyFields, 2)
+	assert.Equal(t, "type_url", anyFields[0].Name)
+	assert.Equal(t, "value", anyFields[1].Name)
+
+	rec := pmr.Record(nil)
+	defer rec.Release()
+	assert.EqualValues(t, 1, rec.NumRows())
+}
+
 func TestRecordFromProtobuf(t *testing.T) {
 	f := AllTheTypesFixture()
 


### PR DESCRIPTION
### Rationale for this change

An unknown protobuf Any type URL or invalid payload can leave the unpacked message nil. The schema conversion path then dereferences it instead of preserving the physical Any fields.

### What changes are included in this PR?

Handle unpacking errors and fall back to reflecting type_url and value. Avoid copying protobuf message state during conversion.

### Are these changes tested?

- `go test ./arrow/util`
- go vet ./arrow/util
- Added malformed Any schema and record coverage.

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.