### PR TITLE
fix(parquet_reader): propagate statistics decoding errors

### DIFF
--- a/parquet/cmd/parquet_reader/main.go
+++ b/parquet/cmd/parquet_reader/main.go
@@ -261,7 +261,11 @@ func main() {
 
 			if !config.NoMetadata {
 				fmt.Println("Column", c)
-				if set, _ := chunkMeta.StatsSet(); set {
+				set, err := chunkMeta.StatsSet()
+				if err != nil {
+					log.Fatalf("unable to read statistics for column=%d: %s", c, err)
+				}
+				if set {
 					stats, err := chunkMeta.Statistics()
 					if err != nil {
 						log.Fatal(err)

--- a/parquet/cmd/parquet_reader/main.go
+++ b/parquet/cmd/parquet_reader/main.go
@@ -61,6 +61,24 @@ func printUsage(fs *flag.FlagSet) {
 	})
 }
 
+type columnChunkStats interface {
+	StatsSet() (bool, error)
+	Statistics() (metadata.TypedStatistics, error)
+}
+
+func readColumnStats(chunkMeta columnChunkStats) (metadata.TypedStatistics, bool, error) {
+	set, err := chunkMeta.StatsSet()
+	if err != nil {
+		return nil, false, err
+	}
+	if !set {
+		return nil, false, nil
+	}
+
+	stats, err := chunkMeta.Statistics()
+	return stats, true, err
+}
+
 func main() {
 	var config struct {
 		ColumnIndexes         bool
@@ -261,15 +279,11 @@ func main() {
 
 			if !config.NoMetadata {
 				fmt.Println("Column", c)
-				set, err := chunkMeta.StatsSet()
+				stats, set, err := readColumnStats(chunkMeta)
 				if err != nil {
 					log.Fatalf("unable to read statistics for column=%d: %s", c, err)
 				}
 				if set {
-					stats, err := chunkMeta.Statistics()
-					if err != nil {
-						log.Fatal(err)
-					}
 					fmt.Printf(" Values: %d", chunkMeta.NumValues())
 					if stats.HasMinMax() {
 						fmt.Printf(", Min: %v, Max: %v",

--- a/parquet/cmd/parquet_reader/main_test.go
+++ b/parquet/cmd/parquet_reader/main_test.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/parquet/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+type columnChunkStatsStub struct {
+	set           bool
+	stats         metadata.TypedStatistics
+	statsSetErr   error
+	statisticsErr error
+}
+
+func (s *columnChunkStatsStub) StatsSet() (bool, error) {
+	return s.set, s.statsSetErr
+}
+
+func (s *columnChunkStatsStub) Statistics() (metadata.TypedStatistics, error) {
+	return s.stats, s.statisticsErr
+}
+
+func TestReadColumnStatsReturnsStatsSetError(t *testing.T) {
+	wantErr := errors.New("malformed statistics")
+	reader := &columnChunkStatsStub{statsSetErr: wantErr}
+
+	stats, set, err := readColumnStats(reader)
+
+	require.ErrorIs(t, err, wantErr)
+	require.False(t, set)
+	require.Nil(t, stats)
+}
+
+func TestReadColumnStatsReturnsStatisticsError(t *testing.T) {
+	wantErr := errors.New("statistics could not be decoded")
+	reader := &columnChunkStatsStub{set: true, statisticsErr: wantErr}
+
+	stats, set, err := readColumnStats(reader)
+
+	require.ErrorIs(t, err, wantErr)
+	require.True(t, set)
+	require.Nil(t, stats)
+}


### PR DESCRIPTION
### Rationale for this change

The parquet_reader command currently treats errors while decoding column statistics as if statistics were absent. This hides malformed metadata from users inspecting a file.

### What changes are included in this PR?

Propagate the decoding error and include the affected column index in the message.

### Are these changes tested?

- `go test ./parquet/cmd/parquet_reader`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.