### PR TITLE
fix(parquet): restore Arrow duration units from schema metadata

### DIFF
--- a/parquet/pqarrow/schema.go
+++ b/parquet/pqarrow/schema.go
@@ -1224,6 +1224,11 @@ func applyOriginalStorageMetadata(origin arrow.Field, inferred *SchemaField) (mo
 			inferred.Field.Type = origin.Type
 		}
 		modified = true
+	case arrow.DURATION:
+		if inferred.Field.Type.ID() == arrow.INT64 {
+			inferred.Field.Type = origin.Type
+			modified = true
+		}
 	case arrow.LARGE_STRING, arrow.LARGE_BINARY:
 		inferred.Field.Type = origin.Type
 		modified = true

--- a/parquet/pqarrow/schema_test.go
+++ b/parquet/pqarrow/schema_test.go
@@ -166,6 +166,39 @@ func TestGetOriginSchemaBase64(t *testing.T) {
 	}
 }
 
+func TestRestoreDurationFromStoredSchema(t *testing.T) {
+	pqNode := schema.MustPrimitive(schema.NewPrimitiveNode(
+		"duration", parquet.Repetitions.Optional, parquet.Types.Int64, -1, -1,
+	))
+	pqSchema := schema.NewSchema(schema.MustGroup(schema.NewGroupNode(
+		"schema", parquet.Repetitions.Required, schema.FieldList{pqNode}, -1,
+	)))
+
+	for _, unit := range []arrow.TimeUnit{
+		arrow.Second,
+		arrow.Millisecond,
+		arrow.Microsecond,
+		arrow.Nanosecond,
+	} {
+		t.Run(unit.String(), func(t *testing.T) {
+			origin := arrow.NewSchema([]arrow.Field{{
+				Name:     "duration",
+				Type:     &arrow.DurationType{Unit: unit},
+				Nullable: true,
+			}}, nil)
+			serialized := flight.SerializeSchema(origin, memory.DefaultAllocator)
+			kv := metadata.NewKeyValueMetadata()
+			kv.Append("ARROW:schema", base64.StdEncoding.EncodeToString(serialized))
+
+			got, err := pqarrow.FromParquet(pqSchema, nil, kv)
+			require.NoError(t, err)
+			require.Equal(t, 1, got.NumFields())
+			assert.True(t, arrow.TypeEqual(origin.Field(0).Type, got.Field(0).Type),
+				"expected %s, got %s", origin.Field(0).Type, got.Field(0).Type)
+		})
+	}
+}
+
 func TestGetOriginSchemaUnregisteredExtension(t *testing.T) {
 	uuidType := extensions.NewUUIDType()
 	md := arrow.NewMetadata([]string{"PARQUET:field_id"}, []string{"-1"})


### PR DESCRIPTION
### Rationale for this change

Parquet stores durations as unannotated INT64 because it has no duration logical type. When stored Arrow schema metadata says the original field was a duration, the reader currently keeps the inferred int64 type and loses the unit.

### What changes are included in this PR?

Restore the original duration type when the stored origin type is a duration and Parquet inference produced int64. Keep the change limited to this schema restoration case.

### Are these changes tested?

- `go test ./parquet/pqarrow -run TestRestoreDurationFromStoredSchema -count=1`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.