### PR TITLE
fix(array): compare sparse union slices at relative offsets

### DIFF
--- a/arrow/array/union.go
+++ b/arrow/array/union.go
@@ -471,8 +471,8 @@ func arraySparseUnionApproxEqual(l, r *SparseUnion, opt equalOption) bool {
 		}
 
 		childNum := childIDs[typeID]
-		eq := sliceApproxEqual(l.children[childNum], int64(i+l.data.offset), int64(i+l.data.offset+1),
-			r.children[childNum], int64(i+r.data.offset), int64(i+r.data.offset+1), opt)
+		eq := sliceApproxEqual(l.children[childNum], int64(i), int64(i+1),
+			r.children[childNum], int64(i), int64(i+1), opt)
 		if !eq {
 			return false
 		}

--- a/arrow/array/union_test.go
+++ b/arrow/array/union_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -149,6 +150,38 @@ func TestUnionSliceEquals(t *testing.T) {
 
 	checkUnion(batch.Column(0))
 	checkUnion(batch.Column(1))
+}
+
+func TestSparseUnionApproxEqualSlicesWithDifferentOffsets(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	leftChild, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Float64, strings.NewReader(`[0, 1, 2, 3, 4]`))
+	require.NoError(t, err)
+	defer leftChild.Release()
+	rightChild, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Float64, strings.NewReader(`[1, 2, 3, 4, 5]`))
+	require.NoError(t, err)
+	defer rightChild.Release()
+	leftIDs, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Int8, strings.NewReader(`[0, 0, 0, 0, 0]`))
+	require.NoError(t, err)
+	defer leftIDs.Release()
+	rightIDs, _, err := array.FromJSON(mem, arrow.PrimitiveTypes.Int8, strings.NewReader(`[0, 0, 0, 0, 0]`))
+	require.NoError(t, err)
+	defer rightIDs.Release()
+
+	left, err := array.NewSparseUnionFromArrays(leftIDs, []arrow.Array{leftChild})
+	require.NoError(t, err)
+	defer left.Release()
+	right, err := array.NewSparseUnionFromArrays(rightIDs, []arrow.Array{rightChild})
+	require.NoError(t, err)
+	defer right.Release()
+
+	leftSlice := array.NewSlice(left, 1, 3)
+	defer leftSlice.Release()
+	rightSlice := array.NewSlice(right, 0, 2)
+	defer rightSlice.Release()
+
+	assert.True(t, array.ApproxEqual(leftSlice, rightSlice))
 }
 
 func TestSparseUnionGetFlattenedField(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

SparseUnion.setData already slices each child using the parent union offset. ApproxEqual adds that offset again, so sliced unions can compare the wrong child values or hit invalid slice bounds.

### What changes are included in this PR?

Compare each selected child at its relative i:i+1 position, matching exact equality and the representation used by sparse unions.

### Are these changes tested?

- `go test ./arrow/array -run TestSparseUnionApproxEqualSlicesWithDifferentOffsets -count=1`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.