### PR TITLE
fix(arrow/scalar): preserve binary cast target types

### DIFF
--- a/arrow/scalar/binary.go
+++ b/arrow/scalar/binary.go
@@ -73,7 +73,7 @@ func (b *Binary) CastTo(to arrow.DataType) (Scalar, error) {
 
 	switch to.ID() {
 	case arrow.BINARY:
-		return NewBinaryScalar(b.Value, b.Type), nil
+		return NewBinaryScalar(b.Value, to), nil
 	case arrow.LARGE_BINARY:
 		return NewLargeBinaryScalar(b.Value), nil
 	case arrow.STRING:

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -198,6 +198,29 @@ func TestBinaryScalarValidateErrors(t *testing.T) {
 	assert.Error(t, sc.ValidateFull())
 }
 
+func TestBinaryScalarCastToBinaryUsesTargetType(t *testing.T) {
+	buf := memory.NewBufferBytes([]byte("abc"))
+	defer buf.Release()
+
+	scalars := []scalar.BinaryScalar{
+		scalar.NewBinaryScalar(buf, arrow.BinaryTypes.Binary),
+		scalar.NewLargeBinaryScalar(buf),
+		scalar.NewFixedSizeBinaryScalar(buf, &arrow.FixedSizeBinaryType{ByteWidth: 3}),
+	}
+	for _, src := range scalars {
+		t.Run(src.DataType().Name(), func(t *testing.T) {
+			defer src.Release()
+
+			got, err := src.CastTo(arrow.BinaryTypes.Binary)
+			require.NoError(t, err)
+			defer got.(scalar.Releasable).Release()
+			assert.IsType(t, &scalar.Binary{}, got)
+			assert.True(t, arrow.TypeEqual(arrow.BinaryTypes.Binary, got.DataType()))
+			assert.Equal(t, []byte("abc"), got.(scalar.BinaryScalar).Data())
+		})
+	}
+}
+
 func TestStringMakeScalar(t *testing.T) {
 	assertMakeScalar(t, scalar.NewStringScalar("three"), "three")
 	assertParseScalar(t, arrow.BinaryTypes.String, "three", scalar.NewStringScalar("three"))


### PR DESCRIPTION
### Rationale for this change

Binary.CastTo returns a binary scalar with the source type. This is incorrect when a large binary or fixed-size binary scalar is cast to ordinary binary.

### What changes are included in this PR?

Use the requested target type for the result and cover binary, large binary, and fixed-size binary sources.

### Are these changes tested?

- `go test ./arrow/scalar`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.