### PR TITLE
fix(arrow/scalar): support boolean identity casts

### DIFF
--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -174,6 +174,10 @@ func (s *Boolean) String() string {
 }
 
 func (s *Boolean) CastTo(dt arrow.DataType) (Scalar, error) {
+	if arrow.TypeEqual(s.DataType(), dt) {
+		return s, nil
+	}
+
 	if !s.Valid {
 		return MakeNullScalar(dt), nil
 	}

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -186,6 +186,20 @@ func TestBinaryScalarBasics(t *testing.T) {
 	assert.True(t, scalar.Equals(value2, value3))
 }
 
+func TestBooleanScalarIdentityCast(t *testing.T) {
+	for _, value := range []bool{false, true} {
+		src := scalar.NewBooleanScalar(value)
+		got, err := src.CastTo(arrow.FixedWidthTypes.Boolean)
+		require.NoError(t, err)
+		assert.Same(t, src, got)
+	}
+
+	null := scalar.MakeNullScalar(arrow.FixedWidthTypes.Boolean)
+	got, err := null.CastTo(arrow.FixedWidthTypes.Boolean)
+	require.NoError(t, err)
+	assert.Same(t, null, got)
+}
+
 func TestBinaryScalarValidateErrors(t *testing.T) {
 	sc := scalar.NewBinaryScalar(memory.NewBufferBytes([]byte("xxx")), arrow.BinaryTypes.Binary)
 	sc.Valid = false


### PR DESCRIPTION
### Rationale for this change

Boolean scalars support casts to numeric and string types, but an identity cast to bool currently returns an error.

### What changes are included in this PR?

Handle the identity case before the other conversions. Cover both valid and null Boolean scalars.

### Are these changes tested?

- `go test ./arrow/scalar`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.