### PR TITLE
fix(arrow/tensor): validate typed constructor data

### DIFF
--- a/arrow/tensor/tensor.go
+++ b/arrow/tensor/tensor.go
@@ -171,6 +171,10 @@ func New(data arrow.ArrayData, shape, strides []int64, names []string) Interface
 }
 
 func newTensor(dtype arrow.DataType, data arrow.ArrayData, shape, strides []int64, names []string) *tensorBase {
+	if !arrow.TypeEqual(dtype, data.DataType()) {
+		panic(fmt.Errorf("arrow/tensor: data type mismatch: got %s, want %s", data.DataType(), dtype))
+	}
+
 	if names == nil {
 		names = make([]string, len(shape))
 	}

--- a/arrow/tensor/tensor_test.go
+++ b/arrow/tensor/tensor_test.go
@@ -165,6 +165,29 @@ func TestInvalidTensor(t *testing.T) {
 
 }
 
+func TestTypedTensorRejectsMismatchedDataType(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	bld := array.NewInt64Builder(mem)
+	bld.Append(1)
+	arr := bld.NewInt64Array()
+	bld.Release()
+	defer arr.Release()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected a panic")
+		}
+		if got := fmt.Sprint(r); got != "arrow/tensor: data type mismatch: got int64, want int8" {
+			t.Fatalf("unexpected panic: %s", got)
+		}
+	}()
+
+	tensor.NewInt8(arr.Data(), []int64{1}, nil, nil)
+}
+
 func TestTensorWithNilDimensionNames(t *testing.T) {
 	bld := array.NewFloat64Builder(memory.DefaultAllocator)
 	defer bld.Release()


### PR DESCRIPTION
### Rationale for this change

Typed tensor constructors interpret the backing buffer according to the requested tensor type without checking the input array type. A mismatched array can therefore be reinterpreted as a different tensor type.

### What changes are included in this PR?

Validate the input data type before retaining it and add coverage for a rejected mismatched constructor.

### Are these changes tested?

- `go test ./arrow/tensor`

### Are there any user-facing changes?

Yes. Typed tensor constructors now reject input data with a different type instead of reinterpreting its buffer.