### PR TITLE
fix(arrow/scalar): apply timestamp zones when casting to dates

### DIFF
--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -496,6 +496,19 @@ func TestTimestampScalarsCasting(t *testing.T) {
 	tms, err = scalar.NewDate32Scalar(arrow.Date32(1024)).CastTo(arrow.FixedWidthTypes.Timestamp_ms)
 	assert.NoError(t, err)
 	assert.True(t, scalar.Equals(tms, scalar.NewTimestampScalar(arrow.Timestamp(1024*millisInDay), arrow.FixedWidthTypes.Timestamp_ms)))
+
+	negativeDate32, err := scalar.NewTimestampScalar(-1, arrow.FixedWidthTypes.Timestamp_ms).CastTo(arrow.FixedWidthTypes.Date32)
+	assert.NoError(t, err)
+	assert.Equal(t, arrow.Date32(-1), negativeDate32.(*scalar.Date32).Value)
+
+	negativeDate64, err := scalar.NewTimestampScalar(-1, arrow.FixedWidthTypes.Timestamp_ms).CastTo(arrow.FixedWidthTypes.Date64)
+	assert.NoError(t, err)
+	assert.Equal(t, arrow.Date64(-millisInDay), negativeDate64.(*scalar.Date64).Value)
+
+	localTimestamp := &arrow.TimestampType{Unit: arrow.Millisecond, TimeZone: "America/Los_Angeles"}
+	localDate, err := scalar.NewTimestampScalar(0, localTimestamp).CastTo(arrow.FixedWidthTypes.Date32)
+	assert.NoError(t, err)
+	assert.Equal(t, arrow.Date32(-1), localDate.(*scalar.Date32).Value)
 }
 
 func TestDurationScalarBasics(t *testing.T) {

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -509,6 +509,10 @@ func TestTimestampScalarsCasting(t *testing.T) {
 	localDate, err := scalar.NewTimestampScalar(0, localTimestamp).CastTo(arrow.FixedWidthTypes.Date32)
 	assert.NoError(t, err)
 	assert.Equal(t, arrow.Date32(-1), localDate.(*scalar.Date32).Value)
+
+	localDate64, err := scalar.NewTimestampScalar(0, localTimestamp).CastTo(arrow.FixedWidthTypes.Date64)
+	assert.NoError(t, err)
+	assert.Equal(t, arrow.Date64(-millisInDay), localDate64.(*scalar.Date64).Value)
 }
 
 func TestDurationScalarBasics(t *testing.T) {

--- a/arrow/scalar/temporal.go
+++ b/arrow/scalar/temporal.go
@@ -103,6 +103,18 @@ type IntervalScalar interface {
 
 const millisecondsInDay = (time.Hour * 24) / time.Millisecond
 
+func timestampDate(s *Timestamp) (time.Time, error) {
+	timestampType := s.DataType().(*arrow.TimestampType)
+	toTime, err := timestampType.GetToTimeFunc()
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	tm := toTime(s.Value)
+	year, month, day := tm.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC), nil
+}
+
 func castTemporal(from TemporalScalar, to arrow.DataType) (Scalar, error) {
 	if arrow.TypeEqual(from.DataType(), to) {
 		return from, nil
@@ -148,25 +160,15 @@ func castTemporal(from TemporalScalar, to arrow.DataType) (Scalar, error) {
 		case *arrow.TimestampType:
 			return NewTimestampScalar(arrow.Timestamp(arrow.ConvertTimestampValue(s.Unit(), to.Unit, int64(s.Value))), to), nil
 		case *arrow.Date32Type:
-			timestampType := s.DataType().(*arrow.TimestampType)
-			toTime, err := timestampType.GetToTimeFunc()
+			tm, err := timestampDate(s)
 			if err != nil {
 				return nil, err
-			}
-			tm := toTime(s.Value)
-			if _, offset := tm.Zone(); offset != 0 {
-				tm = tm.Add(time.Duration(offset) * time.Second).UTC()
 			}
 			return NewDate32Scalar(arrow.Date32FromTime(tm)), nil
 		case *arrow.Date64Type:
-			timestampType := s.DataType().(*arrow.TimestampType)
-			toTime, err := timestampType.GetToTimeFunc()
+			tm, err := timestampDate(s)
 			if err != nil {
 				return nil, err
-			}
-			tm := toTime(s.Value)
-			if _, offset := tm.Zone(); offset != 0 {
-				tm = tm.Add(time.Duration(offset) * time.Second).UTC()
 			}
 			return NewDate64Scalar(arrow.Date64FromTime(tm)), nil
 		}

--- a/arrow/scalar/temporal.go
+++ b/arrow/scalar/temporal.go
@@ -148,11 +148,27 @@ func castTemporal(from TemporalScalar, to arrow.DataType) (Scalar, error) {
 		case *arrow.TimestampType:
 			return NewTimestampScalar(arrow.Timestamp(arrow.ConvertTimestampValue(s.Unit(), to.Unit, int64(s.Value))), to), nil
 		case *arrow.Date32Type:
-			millis := arrow.ConvertTimestampValue(s.Unit(), arrow.Millisecond, int64(s.Value))
-			return NewDate32Scalar(arrow.Date32(millis / int64(millisecondsInDay))), nil
+			timestampType := s.DataType().(*arrow.TimestampType)
+			toTime, err := timestampType.GetToTimeFunc()
+			if err != nil {
+				return nil, err
+			}
+			tm := toTime(s.Value)
+			if _, offset := tm.Zone(); offset != 0 {
+				tm = tm.Add(time.Duration(offset) * time.Second).UTC()
+			}
+			return NewDate32Scalar(arrow.Date32FromTime(tm)), nil
 		case *arrow.Date64Type:
-			millis := arrow.ConvertTimestampValue(s.Unit(), arrow.Millisecond, int64(s.Value))
-			return NewDate64Scalar(arrow.Date64(millis - millis%int64(millisecondsInDay))), nil
+			timestampType := s.DataType().(*arrow.TimestampType)
+			toTime, err := timestampType.GetToTimeFunc()
+			if err != nil {
+				return nil, err
+			}
+			tm := toTime(s.Value)
+			if _, offset := tm.Zone(); offset != 0 {
+				tm = tm.Add(time.Duration(offset) * time.Second).UTC()
+			}
+			return NewDate64Scalar(arrow.Date64FromTime(tm)), nil
 		}
 	case TimeScalar:
 		var value int64


### PR DESCRIPTION
### Rationale for this change

Timestamp-to-Date32 and timestamp-to-Date64 casts use integer arithmetic that truncates negative values and ignores the timestamp timezone.

### What changes are included in this PR?

Convert timestamps through the timestamp type's time semantics and reuse the date normalization used by the compute cast path. Add regression coverage around the Unix epoch and a named timezone.

### Are these changes tested?

- `go test ./arrow/scalar`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.