### PR TITLE
fix(arrow/scalar): format extension values from storage scalars

### DIFF
--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -473,11 +473,10 @@ func (s *Extension) String() string {
 	if !s.Valid {
 		return "null"
 	}
-	val, err := s.CastTo(arrow.BinaryTypes.String)
-	if err != nil {
+	if s.Value == nil {
 		return "..."
 	}
-	return string(val.(*String).Value.Bytes())
+	return s.Value.String()
 }
 
 func NewExtensionScalar(storage Scalar, typ arrow.DataType) *Extension {

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -110,6 +110,11 @@ func TestNullExtensionScalarValidateRejectsNonNullStorage(t *testing.T) {
 	assert.ErrorContains(t, sc.ValidateFull(), "non-null storage value")
 }
 
+func TestExtensionScalarStringUsesStorageValue(t *testing.T) {
+	sc := scalar.NewExtensionScalar(scalar.NewInt16Scalar(42), types.NewSmallintType())
+	assert.Equal(t, "42", sc.String())
+}
+
 func TestMakeScalarUint(t *testing.T) {
 	three := scalar.MakeScalar(uint(3))
 	assert.NoError(t, three.ValidateFull())


### PR DESCRIPTION
### Rationale for this change

Extension.String tries to cast the extension scalar to utf8, but Extension.CastTo only accepts the same extension type. Valid extension scalars therefore return three dots.

### What changes are included in this PR?

Use the storage scalar's string representation for valid extension values and keep null extensions formatted as null.

### Are these changes tested?

- `go test ./arrow/scalar`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.