### PR TITLE
fix(arrow/scalar): release partial children after failed struct conversion

### DIFF
--- a/arrow/scalar/parse.go
+++ b/arrow/scalar/parse.go
@@ -134,6 +134,17 @@ func ToScalar(val interface{}, mem memory.Allocator) (Scalar, error) {
 	case reflect.Struct:
 		scalars := make([]Scalar, 0, v.Type().NumField())
 		fields := make([]string, 0, v.Type().NumField())
+		success := false
+		defer func() {
+			if success {
+				return
+			}
+			for _, child := range scalars {
+				if releasable, ok := child.(Releasable); ok {
+					releasable.Release()
+				}
+			}
+		}()
 		for i := 0; i < v.Type().NumField(); i++ {
 			fld := v.Type().Field(i)
 			tag := fld.Tag.Get("compute")
@@ -156,7 +167,12 @@ func ToScalar(val interface{}, mem memory.Allocator) (Scalar, error) {
 			fields = append(fields, "_type_name")
 		}
 
-		return NewStructScalarWithNames(scalars, fields)
+		out, err := NewStructScalarWithNames(scalars, fields)
+		if err != nil {
+			return nil, err
+		}
+		success = true
+		return out, nil
 	case reflect.Slice:
 		return createListScalar(v, mem)
 	default:

--- a/arrow/scalar/parse.go
+++ b/arrow/scalar/parse.go
@@ -140,6 +140,17 @@ func ToScalar(val interface{}, mem memory.Allocator) (Scalar, error) {
 	case reflect.Struct:
 		scalars := make([]Scalar, 0, v.Type().NumField())
 		fields := make([]string, 0, v.Type().NumField())
+		success := false
+		defer func() {
+			if success {
+				return
+			}
+			for _, child := range scalars {
+				if releasable, ok := child.(Releasable); ok {
+					releasable.Release()
+				}
+			}
+		}()
 		for i := 0; i < v.Type().NumField(); i++ {
 			fld := v.Type().Field(i)
 			tag := fld.Tag.Get("compute")
@@ -162,7 +173,12 @@ func ToScalar(val interface{}, mem memory.Allocator) (Scalar, error) {
 			fields = append(fields, "_type_name")
 		}
 
-		return NewStructScalarWithNames(scalars, fields)
+		out, err := NewStructScalarWithNames(scalars, fields)
+		if err != nil {
+			return nil, err
+		}
+		success = true
+		return out, nil
 	case reflect.Slice:
 		return createListScalar(v, mem)
 	default:

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -1410,6 +1410,11 @@ func (v valueFromScalarTarget) FromStructScalar(*scalar.Struct) error {
 	return nil
 }
 
+type PartialScalarTest struct {
+	Good []string
+	Bad  []complex64
+}
+
 func TestToScalar(t *testing.T) {
 	ot := &OptionValTest{ToType: arrow.BinaryTypes.String, Allow: true}
 	sc, err := scalar.ToScalar(ot, memory.DefaultAllocator)
@@ -1513,6 +1518,17 @@ func TestFromScalarMetadataDoesNotPrependEmptyEntries(t *testing.T) {
 	require.NotNil(t, out.FieldMeta[0])
 	assert.Equal(t, meta.Keys(), out.FieldMeta[0].Keys())
 	assert.Equal(t, meta.Values(), out.FieldMeta[0].Values())
+}
+
+func TestToScalarReleasesPartialStructOnError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	_, err := scalar.ToScalar(PartialScalarTest{
+		Good: []string{"retained before error"},
+		Bad:  []complex64{complex(1, 2)},
+	}, mem)
+	require.Error(t, err)
 }
 
 var dictIndexTypes = []arrow.DataType{

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -1220,6 +1220,11 @@ type OptionValTest struct {
 
 func (OptionValTest) TypeName() string { return "OptionValTest" }
 
+type PartialScalarTest struct {
+	Good []string
+	Bad  []complex64
+}
+
 func TestToScalar(t *testing.T) {
 	ot := &OptionValTest{ToType: arrow.BinaryTypes.String, Allow: true}
 	sc, err := scalar.ToScalar(ot, memory.DefaultAllocator)
@@ -1266,6 +1271,17 @@ func TestToScalar(t *testing.T) {
 		`valuint:list<item: uint64, nullable> = [14 15 16]}`
 
 	assert.Equal(t, expected, sc.String())
+}
+
+func TestToScalarReleasesPartialStructOnError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	_, err := scalar.ToScalar(PartialScalarTest{
+		Good: []string{"retained before error"},
+		Bad:  []complex64{complex(1, 2)},
+	}, mem)
+	require.Error(t, err)
 }
 
 var dictIndexTypes = []arrow.DataType{


### PR DESCRIPTION
### Rationale for this change

ToScalar creates child scalars incrementally. If a later Struct field fails, earlier array-backed children can remain retained after the conversion returns an error.

### What changes are included in this PR?

Release partial children on failure while keeping the existing ownership transfer for a completed struct scalar. Add checked-allocator coverage for the failed conversion.

### Are these changes tested?

- `go test ./arrow/scalar`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.