### PR TITLE
fix(arrow/scalar): format interval scalars in String

### DIFF
--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -558,6 +558,7 @@ func TestMonthIntervalScalarBasics(t *testing.T) {
 	assert.False(t, scalar.Equals(tsVal1, tsVal2))
 	assert.False(t, scalar.Equals(tsVal1, tsNull))
 	assert.False(t, scalar.Equals(tsNull, tsVal2))
+	assert.Equal(t, "1", tsVal1.String())
 }
 
 func TestDayTimeIntervalScalarBasics(t *testing.T) {
@@ -583,6 +584,7 @@ func TestDayTimeIntervalScalarBasics(t *testing.T) {
 	assert.False(t, scalar.Equals(tsVal1, tsVal2))
 	assert.False(t, scalar.Equals(tsVal1, tsNull))
 	assert.False(t, scalar.Equals(tsNull, tsVal2))
+	assert.Equal(t, "{\"days\":1,\"milliseconds\":1}", tsVal1.String())
 }
 
 func TestMonthDayNanoIntervalScalarBasics(t *testing.T) {
@@ -608,6 +610,11 @@ func TestMonthDayNanoIntervalScalarBasics(t *testing.T) {
 	assert.False(t, scalar.Equals(tsVal1, tsVal2))
 	assert.False(t, scalar.Equals(tsVal1, tsNull))
 	assert.False(t, scalar.Equals(tsNull, tsVal2))
+}
+
+func TestMonthDayNanoIntervalScalarString(t *testing.T) {
+	s := scalar.NewMonthDayNanoIntervalScalar(arrow.MonthDayNanoInterval{Months: 1, Days: 2, Nanoseconds: 3000})
+	assert.Equal(t, "{\"months\":1,\"days\":2,\"nanoseconds\":3000}", s.String())
 }
 
 func TestNumericScalarCasts(t *testing.T) {

--- a/arrow/scalar/temporal.go
+++ b/arrow/scalar/temporal.go
@@ -17,6 +17,7 @@
 package scalar
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
@@ -383,11 +384,7 @@ func (s *MonthInterval) String() string {
 	if !s.Valid {
 		return "null"
 	}
-	val, err := s.CastTo(arrow.BinaryTypes.String)
-	if err != nil {
-		return "..."
-	}
-	return string(val.(*String).Value.Bytes())
+	return fmt.Sprint(s.Value)
 }
 func (s *MonthInterval) equals(rhs Scalar) bool {
 	return s.Value == rhs.(*MonthInterval).Value
@@ -415,11 +412,11 @@ func (s *DayTimeInterval) String() string {
 	if !s.Valid {
 		return "null"
 	}
-	val, err := s.CastTo(arrow.BinaryTypes.String)
+	val, err := json.Marshal(s.Value)
 	if err != nil {
 		return "..."
 	}
-	return string(val.(*String).Value.Bytes())
+	return string(val)
 }
 
 func (s *DayTimeInterval) CastTo(to arrow.DataType) (Scalar, error) {
@@ -428,7 +425,7 @@ func (s *DayTimeInterval) CastTo(to arrow.DataType) (Scalar, error) {
 	}
 
 	if !arrow.TypeEqual(s.DataType(), to) {
-		return nil, fmt.Errorf("non-null daytimeinterval scalar cannot be cast to anything other than monthinterval")
+		return nil, fmt.Errorf("non-null daytimeinterval scalar cannot be cast to anything other than daytimeinterval")
 	}
 
 	return s, nil
@@ -457,11 +454,11 @@ func (s *MonthDayNanoInterval) String() string {
 	if !s.Valid {
 		return "null"
 	}
-	val, err := s.CastTo(arrow.BinaryTypes.String)
+	val, err := json.Marshal(s.Value)
 	if err != nil {
 		return "..."
 	}
-	return string(val.(*String).Value.Bytes())
+	return string(val)
 }
 
 func (s *MonthDayNanoInterval) CastTo(to arrow.DataType) (Scalar, error) {
@@ -470,7 +467,7 @@ func (s *MonthDayNanoInterval) CastTo(to arrow.DataType) (Scalar, error) {
 	}
 
 	if !arrow.TypeEqual(s.DataType(), to) {
-		return nil, fmt.Errorf("non-null month_day_nano_interval scalar cannot be cast to anything other than monthinterval")
+		return nil, fmt.Errorf("non-null month_day_nano_interval scalar cannot be cast to anything other than month_day_nano_interval")
 	}
 
 	return s, nil


### PR DESCRIPTION
### Rationale for this change

String returns three dots for valid interval scalars because the generic string cast is not supported. The DayTime error also reports the wrong interval type.

### What changes are included in this PR?

Format month intervals directly and use the existing JSON representation for day-time and month-day-nano intervals. Correct the related error messages.

### Are these changes tested?

- `go test ./arrow/scalar`

### Are there any user-facing changes?

Yes. Interval scalar String output is now meaningful for the supported interval types.