### PR TITLE
fix(arrow/scalar): release partial children after failed struct extraction

### DIFF
--- a/arrow/scalar/scalar.go
+++ b/arrow/scalar/scalar.go
@@ -679,6 +679,11 @@ func GetScalar(arr arrow.Array, idx int) (Scalar, error) {
 		for i := range children {
 			child, err := GetScalar(arr.Field(i), idx)
 			if err != nil {
+				for _, child := range children[:i] {
+					if releasable, ok := child.(Releasable); ok {
+						releasable.Release()
+					}
+				}
 				return nil, err
 			}
 			children[i] = child

--- a/arrow/scalar/scalar_test.go
+++ b/arrow/scalar/scalar_test.go
@@ -1388,6 +1388,30 @@ func TestGetScalarIndexOutOfRange(t *testing.T) {
 	assert.ErrorIs(t, err, arrow.ErrIndex)
 }
 
+func TestGetScalarReleasesPartialStructChildrenOnError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	dt := arrow.StructOf(
+		arrow.Field{Name: "values", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32)},
+		arrow.Field{Name: "view", Type: arrow.BinaryTypes.StringView},
+	)
+	builder := array.NewStructBuilder(mem, dt)
+	defer builder.Release()
+
+	builder.Append(true)
+	listBuilder := builder.FieldBuilder(0).(*array.ListBuilder)
+	listBuilder.Append(true)
+	listBuilder.ValueBuilder().(*array.Int32Builder).Append(1)
+	builder.FieldBuilder(1).(*array.StringViewBuilder).Append("unsupported")
+
+	arr := builder.NewStructArray()
+	defer arr.Release()
+
+	_, err := scalar.GetScalar(arr, 0)
+	require.Error(t, err)
+}
+
 func TestDictionaryScalarValidateErrors(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)


### PR DESCRIPTION
### Rationale for this change

GetScalar can create children before a later Struct child fails conversion. Returning immediately leaves the children already created on the error path unreleased.

### What changes are included in this PR?

Release partial children when extraction fails while preserving ownership for a successfully built struct scalar. The regression test uses a list child followed by an unsupported view child.

### Are these changes tested?

- `go test ./arrow/scalar`

### Are there any user-facing changes?

No API changes. This corrects the reported behavior while preserving the existing ownership and compatibility contracts.