### PR TITLE
fix(arrow/ipc): return errors for invalid record indexes

### DIFF
--- a/arrow/ipc/file_reader.go
+++ b/arrow/ipc/file_reader.go
@@ -442,7 +442,7 @@ func (f *FileReader) Record(i int) (arrow.Record, error) {
 // call concurrently.
 func (f *FileReader) RecordBatchAt(i int) (arrow.RecordBatch, error) {
 	if i < 0 || i >= f.NumRecords() {
-		panic("arrow/ipc: record index out of bounds")
+		return nil, fmt.Errorf("%w: record index %d out of bounds", arrow.ErrIndex, i)
 	}
 
 	blk, err := f.r.block(f.mem, &f.footer, i)
@@ -506,6 +506,9 @@ func (f *FileReader) Read() (rec arrow.RecordBatch, err error) {
 
 // ReadAt reads the i-th record batch from the underlying stream and an error, if any.
 func (f *FileReader) ReadAt(i int64) (arrow.RecordBatch, error) {
+	if i < 0 || i >= int64(f.NumRecords()) {
+		return nil, fmt.Errorf("%w: record index %d out of bounds", arrow.ErrIndex, i)
+	}
 	return f.RecordBatch(int(i))
 }
 

--- a/arrow/ipc/ipc_test.go
+++ b/arrow/ipc/ipc_test.go
@@ -830,9 +830,19 @@ func TestFileReaderRecordBatchIndexErrors(t *testing.T) {
 
 	_, err = reader.RecordBatchAt(-1)
 	require.ErrorIs(t, err, arrow.ErrIndex)
+	_, err = reader.RecordBatchAt(reader.NumRecords())
+	require.ErrorIs(t, err, arrow.ErrIndex)
 
+	_, err = reader.ReadAt(-1)
+	require.ErrorIs(t, err, arrow.ErrIndex)
 	_, err = reader.ReadAt(math.MaxInt64)
 	require.ErrorIs(t, err, arrow.ErrIndex)
+	_, err = reader.ReadAt(int64(reader.NumRecords()))
+	require.ErrorIs(t, err, arrow.ErrIndex)
+
+	batch, err := reader.RecordBatchAt(0)
+	require.NoError(t, err)
+	batch.Release()
 }
 
 func TestRecordBatchCustomMetadataInterop(t *testing.T) {

--- a/arrow/ipc/ipc_test.go
+++ b/arrow/ipc/ipc_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"os"
 	"strconv"
@@ -800,6 +801,38 @@ func TestRecordBatchCustomMetadataFileRoundtrip(t *testing.T) {
 
 	require.Equal(t, meta.Keys(), rm.Metadata().Keys())
 	require.Equal(t, meta.Values(), rm.Metadata().Values())
+}
+
+func TestFileReaderRecordBatchIndexErrors(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	schema := arrow.NewSchema(
+		[]arrow.Field{{Name: "x", Type: arrow.PrimitiveTypes.Int32}},
+		nil,
+	)
+
+	builder := array.NewInt32Builder(mem)
+	builder.Append(1)
+	column := builder.NewArray()
+	builder.Release()
+	record := array.NewRecordBatch(schema, []arrow.Array{column}, 1)
+	column.Release()
+
+	var buf bytes.Buffer
+	writer, err := ipc.NewFileWriter(&buf, ipc.WithSchema(schema))
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+	record.Release()
+
+	reader, err := ipc.NewFileReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	_, err = reader.RecordBatchAt(-1)
+	require.ErrorIs(t, err, arrow.ErrIndex)
+
+	_, err = reader.ReadAt(math.MaxInt64)
+	require.ErrorIs(t, err, arrow.ErrIndex)
 }
 
 func TestRecordBatchCustomMetadataInterop(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

RecordBatchAt panics for an invalid record index even though it returns an error. ReadAt also converts an int64 index to int before checking the range.

### What changes are included in this PR?

Return an arrow.ErrIndex error for invalid indexes in RecordBatchAt and ReadAt, and check the int64 range before narrowing it to int.

### Are these changes tested?

- `go test ./arrow/ipc`

### Are there any user-facing changes?

Invalid record indexes now return errors instead of panicking.