### PR TITLE
fix(arrow/csv): append null for invalid fixed-size binary values

### DIFF
--- a/arrow/csv/reader.go
+++ b/arrow/csv/reader.go
@@ -914,6 +914,7 @@ func (r *Reader) parseFixedSizeBinaryType(field array.Builder, str string, byteW
 		field.(*array.FixedSizeBinaryBuilder).Append(decodedVal)
 	} else {
 		r.err = fmt.Errorf("%w: the length of fixed size binary value should match the fixed size binary byte width, expected %d, got %d", arrow.ErrInvalid, byteWidth, len(decodedVal))
+		field.AppendNull()
 	}
 }
 

--- a/arrow/csv/reader_test.go
+++ b/arrow/csv/reader_test.go
@@ -235,7 +235,6 @@ func TestFixedSizeBinaryParseErrorAppendsNull(t *testing.T) {
 	require.ErrorIs(t, r.Err(), arrow.ErrInvalid)
 
 	record := r.RecordBatch()
-	defer record.Release()
 	require.EqualValues(t, 1, record.NumRows())
 	for i := 0; i < int(record.NumCols()); i++ {
 		assert.Equal(t, 1, record.Column(i).Len())

--- a/arrow/csv/reader_test.go
+++ b/arrow/csv/reader_test.go
@@ -219,6 +219,23 @@ func TestCSVReadInvalidFields(t *testing.T) {
 	}
 }
 
+func TestFixedSizeBinaryParseErrorAppendsNull(t *testing.T) {
+	schema := arrow.NewSchema(
+		[]arrow.Field{{Name: "value", Type: &arrow.FixedSizeBinaryType{ByteWidth: 3}}},
+		nil,
+	)
+	r := csv.NewReader(strings.NewReader("AQ==\n"), schema, csv.WithHeader(false))
+	defer r.Release()
+
+	require.True(t, r.Next())
+	require.ErrorIs(t, r.Err(), arrow.ErrInvalid)
+
+	record := r.RecordBatch()
+	require.EqualValues(t, 1, record.NumRows())
+	require.Equal(t, 1, record.Column(0).Len())
+	assert.True(t, record.Column(0).IsNull(0))
+}
+
 func TestCSVReaderParseError(t *testing.T) {
 	f := bytes.NewBufferString(`## a simple set of data: int64;float64;string
 0;0;str-0

--- a/arrow/csv/reader_test.go
+++ b/arrow/csv/reader_test.go
@@ -221,19 +221,28 @@ func TestCSVReadInvalidFields(t *testing.T) {
 
 func TestFixedSizeBinaryParseErrorAppendsNull(t *testing.T) {
 	schema := arrow.NewSchema(
-		[]arrow.Field{{Name: "value", Type: &arrow.FixedSizeBinaryType{ByteWidth: 3}}},
+		[]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "value", Type: &arrow.FixedSizeBinaryType{ByteWidth: 3}},
+			{Name: "name", Type: arrow.BinaryTypes.String},
+		},
 		nil,
 	)
-	r := csv.NewReader(strings.NewReader("AQ==\n"), schema, csv.WithHeader(false))
+	r := csv.NewReader(strings.NewReader("1,AQ==,name\n"), schema, csv.WithHeader(false))
 	defer r.Release()
 
 	require.True(t, r.Next())
 	require.ErrorIs(t, r.Err(), arrow.ErrInvalid)
 
 	record := r.RecordBatch()
+	defer record.Release()
 	require.EqualValues(t, 1, record.NumRows())
-	require.Equal(t, 1, record.Column(0).Len())
-	assert.True(t, record.Column(0).IsNull(0))
+	for i := 0; i < int(record.NumCols()); i++ {
+		assert.Equal(t, 1, record.Column(i).Len())
+	}
+	assert.Equal(t, int64(1), record.Column(0).(*array.Int64).Value(0))
+	assert.True(t, record.Column(1).IsNull(0))
+	assert.Equal(t, "name", record.Column(2).(*array.String).Value(0))
 }
 
 func TestCSVReaderParseError(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

When a fixed-size binary value has the wrong decoded width, the CSV reader sets Err but does not append a value. Next then returns a record with no row for that field.

### What changes are included in this PR?

Append a null after reporting the fixed-size binary length error so the record keeps the same number of rows as the other fields.

### Are these changes tested?

- `go test ./arrow/csv -run TestFixedSizeBinaryParseErrorAppendsNull`

### Are there any user-facing changes?

Parse failures now keep the row and expose a null value for the invalid field.