### PR TITLE
fix(compute/exprs): avoid empty field reference panic

### DIFF
--- a/arrow/compute/exprs/exec_test.go
+++ b/arrow/compute/exprs/exec_test.go
@@ -345,6 +345,18 @@ func TestGetRefFieldEmptySchema(t *testing.T) {
 	assert.ErrorIs(t, err, compute.ErrNoChildren)
 }
 
+func TestGetRefFieldNestedNoChildren(t *testing.T) {
+	ref := &expr.StructFieldRef{
+		Field: 0,
+		Child: expr.NewStructFieldRef(0),
+	}
+	fields := []arrow.Field{{Name: "value", Type: arrow.PrimitiveTypes.Int32}}
+
+	_, err := exprs.GetRefField(ref, fields)
+	assert.ErrorIs(t, err, compute.ErrNoChildren)
+	assert.EqualError(t, err, compute.ErrNoChildren.Error()+": int32")
+}
+
 func TestExecuteScalarFuncCall(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	fromJSON := func(ty arrow.DataType, json string) arrow.Array {

--- a/arrow/compute/exprs/exec_test.go
+++ b/arrow/compute/exprs/exec_test.go
@@ -340,6 +340,11 @@ func TestExecuteFieldRef(t *testing.T) {
 	}
 }
 
+func TestGetRefFieldEmptySchema(t *testing.T) {
+	_, err := exprs.GetRefField(expr.NewStructFieldRef(0), nil)
+	assert.ErrorIs(t, err, compute.ErrNoChildren)
+}
+
 func TestExecuteScalarFuncCall(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	fromJSON := func(ty arrow.DataType, json string) arrow.Array {

--- a/arrow/compute/exprs/field_refs.go
+++ b/arrow/compute/exprs/field_refs.go
@@ -49,6 +49,9 @@ func GetRefField(ref expr.ReferenceSegment, fields []arrow.Field) (*arrow.Field,
 
 	for ref != nil {
 		if len(fields) == 0 {
+			if out == nil {
+				return nil, compute.ErrNoChildren
+			}
 			return nil, fmt.Errorf("%w: %s", compute.ErrNoChildren, out.Type)
 		}
 


### PR DESCRIPTION
### Rationale for this change

A field reference against an empty schema tries to include out.Type in the error before out has been set. This causes a nil pointer panic instead of returning ErrNoChildren.

### What changes are included in this PR?

Return ErrNoChildren for an empty schema before formatting a field type. Preserve the existing error detail for nested references and add regression coverage.

### Are these changes tested?

- `go test ./arrow/compute/exprs`

### Are there any user-facing changes?

Invalid field references now return an error instead of panicking when the schema has no fields.