### PR TITLE
fix(arrow): reject duplicate union type codes

### DIFF
--- a/arrow/datatype_nested.go
+++ b/arrow/datatype_nested.go
@@ -734,15 +734,15 @@ func (t *unionType) validate(fields []Field, typeCodes []UnionTypeCode, _ UnionM
 		return errors.New("arrow: union types should have the same number of fields as type codes")
 	}
 
-	seen := make(map[UnionTypeCode]struct{}, len(typeCodes))
+	var seen [int(MaxUnionTypeCode) + 1]bool
 	for _, c := range typeCodes {
 		if c < 0 || c > MaxUnionTypeCode {
 			return errors.New("arrow: union type code out of bounds")
 		}
-		if _, ok := seen[c]; ok {
+		if seen[c] {
 			return errors.New("arrow: union type codes must be unique")
 		}
-		seen[c] = struct{}{}
+		seen[c] = true
 	}
 	return nil
 }

--- a/arrow/datatype_nested.go
+++ b/arrow/datatype_nested.go
@@ -734,10 +734,15 @@ func (t *unionType) validate(fields []Field, typeCodes []UnionTypeCode, _ UnionM
 		return errors.New("arrow: union types should have the same number of fields as type codes")
 	}
 
+	seen := make(map[UnionTypeCode]struct{}, len(typeCodes))
 	for _, c := range typeCodes {
 		if c < 0 || c > MaxUnionTypeCode {
 			return errors.New("arrow: union type code out of bounds")
 		}
+		if _, ok := seen[c]; ok {
+			return errors.New("arrow: union type codes must be unique")
+		}
+		seen[c] = struct{}{}
 	}
 	return nil
 }

--- a/arrow/datatype_nested_test.go
+++ b/arrow/datatype_nested_test.go
@@ -631,3 +631,18 @@ func TestFieldsImmutability(t *testing.T) {
 		})
 	}
 }
+
+func TestUnionRejectsDuplicateTypeCodes(t *testing.T) {
+	fields := []Field{
+		{Name: "a", Type: PrimitiveTypes.Int32},
+		{Name: "b", Type: PrimitiveTypes.Int32},
+	}
+	codes := []UnionTypeCode{1, 1}
+
+	assert.Panics(t, func() {
+		SparseUnionOf(fields, codes)
+	})
+	assert.Panics(t, func() {
+		DenseUnionOf(fields, codes)
+	})
+}


### PR DESCRIPTION
### Rationale for this change

Duplicate union type codes overwrite a child lookup entry during construction, leaving one child unreachable.

### What changes are included in this PR?

Reject duplicate type codes during union validation and add coverage for both sparse and dense union types.

### Are these changes tested?

- `go test ./arrow`

### Are there any user-facing changes?

Union types with duplicate type codes are now rejected during construction instead of silently making one child unreachable.