### PR TITLE
fix(memory): handle zero-length checked reallocations

### DIFF
--- a/arrow/memory/buffer_test.go
+++ b/arrow/memory/buffer_test.go
@@ -58,6 +58,17 @@ func TestNewResizableBuffer(t *testing.T) {
 	assert.Zero(t, buf.Len())
 }
 
+func TestCheckedAllocatorReallocate(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	buf := mem.Reallocate(16, nil)
+	assert.Len(t, buf, 16)
+
+	buf = mem.Reallocate(0, buf)
+	assert.Empty(t, buf)
+}
+
 func TestBufferReset(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)

--- a/arrow/memory/checked_allocator.go
+++ b/arrow/memory/checked_allocator.go
@@ -69,21 +69,18 @@ func (a *CheckedAllocator) Reallocate(size int, b []byte) []byte {
 	a.sz.Add(int64(size - len(b)))
 
 	var oldptr uintptr
-	if cap(b) > 0 {
-		oldptr = uintptr(unsafe.Pointer(&b[:1][0]))
+	if len(b) > 0 {
+		oldptr = uintptr(unsafe.Pointer(unsafe.SliceData(b)))
 	}
 	out := a.mem.Reallocate(size, b)
+	if oldptr != 0 {
+		a.allocs.Delete(oldptr)
+	}
 	if size == 0 {
-		if oldptr != 0 {
-			a.allocs.Delete(oldptr)
-		}
 		return out
 	}
 
 	newptr := uintptr(unsafe.Pointer(&out[0]))
-	if oldptr != 0 {
-		a.allocs.Delete(oldptr)
-	}
 	pcs := make([]uintptr, maxRetainedFrames)
 
 	// For historical reasons the meaning of the skip argument

--- a/arrow/memory/checked_allocator.go
+++ b/arrow/memory/checked_allocator.go
@@ -68,14 +68,22 @@ func (a *CheckedAllocator) Allocate(size int) []byte {
 func (a *CheckedAllocator) Reallocate(size int, b []byte) []byte {
 	a.sz.Add(int64(size - len(b)))
 
-	oldptr := uintptr(unsafe.Pointer(&b[0]))
+	var oldptr uintptr
+	if cap(b) > 0 {
+		oldptr = uintptr(unsafe.Pointer(&b[:1][0]))
+	}
 	out := a.mem.Reallocate(size, b)
 	if size == 0 {
+		if oldptr != 0 {
+			a.allocs.Delete(oldptr)
+		}
 		return out
 	}
 
 	newptr := uintptr(unsafe.Pointer(&out[0]))
-	a.allocs.Delete(oldptr)
+	if oldptr != 0 {
+		a.allocs.Delete(oldptr)
+	}
 	pcs := make([]uintptr, maxRetainedFrames)
 
 	// For historical reasons the meaning of the skip argument


### PR DESCRIPTION
### Rationale for this change

CheckedAllocator.Reallocate panics when called with nil, and zero-size reallocations leave stale entries in the leak-tracking map.

### What changes are included in this PR?

Handle nil input buffers and remove the old allocation record when a reallocation reduces the size to zero. Add coverage for both paths.

### Are these changes tested?

- `go test ./arrow/memory`

### Are there any user-facing changes?

CheckedAllocator no longer panics or reports a false allocation leak for these reallocation paths. The allocator interface is unchanged.