### PR TITLE
fix(compute/exec): report ListView buffer counts

### DIFF
--- a/arrow/compute/exec/span.go
+++ b/arrow/compute/exec/span.go
@@ -587,6 +587,8 @@ func getNumBuffers(dt arrow.DataType) int {
 		// builder is sufficient for most use cases).
 		return 3
 	case arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
+		// validity + offsets + sizes. Unlike the view types above, this
+		// count is exact rather than a cap on variadic data buffers.
 		return 3
 	case arrow.EXTENSION:
 		return getNumBuffers(dt.(arrow.ExtensionType).StorageType())

--- a/arrow/compute/exec/span.go
+++ b/arrow/compute/exec/span.go
@@ -586,6 +586,8 @@ func getNumBuffers(dt arrow.DataType) int {
 		// within a single block (the default 32KB allocation in the
 		// builder is sufficient for most use cases).
 		return 3
+	case arrow.LIST_VIEW, arrow.LARGE_LIST_VIEW:
+		return 3
 	case arrow.EXTENSION:
 		return getNumBuffers(dt.(arrow.ExtensionType).StorageType())
 	default:

--- a/arrow/compute/exec/span_test.go
+++ b/arrow/compute/exec/span_test.go
@@ -205,6 +205,8 @@ func TestArraySpan_NumBuffers(t *testing.T) {
 		{"large binary", fields{Type: arrow.BinaryTypes.LargeBinary}, 3},
 		{"string", fields{Type: arrow.BinaryTypes.String}, 3},
 		{"large string", fields{Type: arrow.BinaryTypes.LargeString}, 3},
+		{"list view", fields{Type: arrow.ListViewOf(arrow.PrimitiveTypes.Int32)}, 3},
+		{"large list view", fields{Type: arrow.LargeListViewOf(arrow.PrimitiveTypes.Int32)}, 3},
 		{"extension", fields{Type: extensions.NewUUIDType()}, 2},
 		{"int32", fields{Type: arrow.PrimitiveTypes.Int32}, 2},
 	}

--- a/arrow/compute/exec_internals_test.go
+++ b/arrow/compute/exec_internals_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/internal/testing/gen"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/arrow/scalar"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -578,6 +579,24 @@ func (e *ExecSpanItrSuite) TestZeroLengthInput() {
 	carr = e.getInt32Chunked([]int64{0})
 	input.Values = []Datum{&ChunkedDatum{carr}}
 	checkArgs(input)
+}
+
+func TestFillZeroLengthListView(t *testing.T) {
+	for _, dt := range []arrow.DataType{
+		arrow.ListViewOf(arrow.PrimitiveTypes.Int32),
+		arrow.LargeListViewOf(arrow.PrimitiveTypes.Int32),
+	} {
+		t.Run(dt.Name(), func(t *testing.T) {
+			var span exec.ArraySpan
+			exec.FillZeroLength(dt, &span)
+
+			assert.Equal(t, 3, span.NumBuffers())
+			for i := 0; i < span.NumBuffers(); i++ {
+				assert.NotNil(t, span.Buffers[i].Buf)
+				assert.Empty(t, span.Buffers[i].Buf)
+			}
+		})
+	}
 }
 
 func TestExecSpanIterator(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

`ListView` and `LargeListView` arrays have exactly three buffers: validity, offsets, and sizes. `ArraySpan.NumBuffers()` currently returns the default count of two, which leaves the size buffer unset for zero-length spans and truncates it when any ListView span is converted back to `array.Data` with `MakeData()`.

### What changes are included in this PR?

Return three buffers for ListView and LargeListView types, document why that count is exact, and cover both the direct buffer-count contract and zero-length buffer allocation.

### Are these changes tested?

- `go test ./arrow/compute/exec ./arrow/compute`

### Are there any user-facing changes?

There are no API changes. Compute kernels do not currently accept list views, so this is preparatory hardening rather than a live compute corruption fix.