### PR TITLE
fix(arrow): include KeysSorted in map equality

### DIFF
--- a/arrow/compare.go
+++ b/arrow/compare.go
@@ -74,16 +74,20 @@ func TypeEqual(left, right DataType, opts ...TypeEqualOption) bool {
 		}
 		return l.n == right.(*FixedSizeListType).n && l.elem.Nullable == right.(*FixedSizeListType).elem.Nullable
 	case *MapType:
-		if !TypeEqual(l.KeyType(), right.(*MapType).KeyType(), opts...) {
+		r := right.(*MapType)
+		if !TypeEqual(l.KeyType(), r.KeyType(), opts...) {
 			return false
 		}
-		if !TypeEqual(l.ItemType(), right.(*MapType).ItemType(), opts...) {
+		if !TypeEqual(l.ItemType(), r.ItemType(), opts...) {
 			return false
 		}
-		if l.KeyField().Nullable != right.(*MapType).KeyField().Nullable {
+		if l.KeysSorted != r.KeysSorted {
 			return false
 		}
-		if l.ItemField().Nullable != right.(*MapType).ItemField().Nullable {
+		if l.KeyField().Nullable != r.KeyField().Nullable {
+			return false
+		}
+		if l.ItemField().Nullable != r.ItemField().Nullable {
 			return false
 		}
 		if cfg.metadata {

--- a/arrow/compare.go
+++ b/arrow/compare.go
@@ -91,10 +91,10 @@ func TypeEqual(left, right DataType, opts ...TypeEqualOption) bool {
 			return false
 		}
 		if cfg.metadata {
-			if !l.KeyField().Metadata.Equal(right.(*MapType).KeyField().Metadata) {
+			if !l.KeyField().Metadata.Equal(r.KeyField().Metadata) {
 				return false
 			}
-			if !l.ItemField().Metadata.Equal(right.(*MapType).ItemField().Metadata) {
+			if !l.ItemField().Metadata.Equal(r.ItemField().Metadata) {
 				return false
 			}
 		}

--- a/arrow/compare_test.go
+++ b/arrow/compare_test.go
@@ -22,6 +22,12 @@ import (
 )
 
 func TestTypeEqual(t *testing.T) {
+	mapType := func(keysSorted bool) DataType {
+		typ := MapOf(BinaryTypes.String, PrimitiveTypes.Int32)
+		typ.KeysSorted = keysSorted
+		return typ
+	}
+
 	tests := []struct {
 		left, right   DataType
 		want          bool
@@ -333,6 +339,16 @@ func TestTypeEqual(t *testing.T) {
 			true, false,
 		},
 		{
+			mapType(false),
+			mapType(true),
+			false, false,
+		},
+		{
+			mapType(true),
+			mapType(true),
+			true, false,
+		},
+		{
 			MapOf(PrimitiveTypes.Int32, FixedWidthTypes.Timestamp_ns),
 			MapOf(PrimitiveTypes.Int32, FixedWidthTypes.Timestamp_ns),
 			true, false,
@@ -393,20 +409,5 @@ func TestTypeEqual(t *testing.T) {
 				t.Fatalf("TypeEqual(%v, %v, %v): got=%v, want=%v", test.left, test.right, test.checkMetadata, got, test.want)
 			}
 		})
-	}
-}
-
-func TestTypeEqualMapKeysSorted(t *testing.T) {
-	unsorted := MapOf(BinaryTypes.String, PrimitiveTypes.Int32)
-	sorted := MapOf(BinaryTypes.String, PrimitiveTypes.Int32)
-	sorted.KeysSorted = true
-
-	if TypeEqual(unsorted, sorted) {
-		t.Fatal("map types with different KeysSorted values should not be equal")
-	}
-
-	unsorted.KeysSorted = true
-	if !TypeEqual(unsorted, sorted) {
-		t.Fatal("map types with the same KeysSorted value should be equal")
 	}
 }

--- a/arrow/compare_test.go
+++ b/arrow/compare_test.go
@@ -395,3 +395,18 @@ func TestTypeEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestTypeEqualMapKeysSorted(t *testing.T) {
+	unsorted := MapOf(BinaryTypes.String, PrimitiveTypes.Int32)
+	sorted := MapOf(BinaryTypes.String, PrimitiveTypes.Int32)
+	sorted.KeysSorted = true
+
+	if TypeEqual(unsorted, sorted) {
+		t.Fatal("map types with different KeysSorted values should not be equal")
+	}
+
+	unsorted.KeysSorted = true
+	if !TypeEqual(unsorted, sorted) {
+		t.Fatal("map types with the same KeysSorted value should be equal")
+	}
+}


### PR DESCRIPTION
### Rationale for this change

MapType includes KeysSorted in its fingerprint and string representation, but TypeEqual ignores it. Maps with different key-ordering contracts can therefore compare equal.

### What changes are included in this PR?

Compare KeysSorted as part of map type equality and add coverage for both values.

### Are these changes tested?

- `go test ./arrow`

### Are there any user-facing changes?

Map types with different KeysSorted values no longer compare equal. There are no API changes.