### PR TITLE
fix(compute/exec): handle missing validity buffers

### DIFF
--- a/arrow/compute/exec/span.go
+++ b/arrow/compute/exec/span.go
@@ -114,7 +114,7 @@ func (a *ArraySpan) UpdateNullCount() int64 {
 	if curNulls != array.UnknownNullCount {
 		return curNulls
 	}
-	if a.Buffers[0].Buf == nil {
+	if len(a.Buffers[0].Buf) == 0 {
 		atomic.StoreInt64(&a.Nulls, 0)
 		return 0
 	}

--- a/arrow/compute/exec/span.go
+++ b/arrow/compute/exec/span.go
@@ -114,6 +114,10 @@ func (a *ArraySpan) UpdateNullCount() int64 {
 	if curNulls != array.UnknownNullCount {
 		return curNulls
 	}
+	if a.Buffers[0].Buf == nil {
+		atomic.StoreInt64(&a.Nulls, 0)
+		return 0
+	}
 
 	newNulls := a.Len - int64(bitutil.CountSetBits(a.Buffers[0].Buf, int(a.Offset), int(a.Len)))
 	atomic.StoreInt64(&a.Nulls, newNulls)

--- a/arrow/compute/exec/span_test.go
+++ b/arrow/compute/exec/span_test.go
@@ -118,6 +118,10 @@ func TestArraySpan_UpdateNullCount(t *testing.T) {
 		want   int64
 	}{
 		{"known", fields{Nulls: 25}, 25},
+		{"unknown without validity", fields{
+			Nulls: array.UnknownNullCount,
+			Len:   8,
+		}, 0},
 		{"unknown", fields{
 			Nulls:   array.UnknownNullCount,
 			Len:     8, // 0b01101101


### PR DESCRIPTION
### Rationale for this change

UpdateNullCount counts bits from a nil validity buffer when the null count is unknown. A missing validity bitmap represents all-valid data, but CountSetBits can panic for a non-zero length.

### What changes are included in this PR?

Treat a missing validity buffer as an all-valid array, cache a null count of zero, and add regression coverage.

### Are these changes tested?

- `go test ./arrow/compute/exec`

### Are there any user-facing changes?

Zero-null arrays without a validity bitmap no longer panic when their null count is first requested.