### PR TITLE
fix(parquet/metadata): return error for missing column metadata

### DIFF
--- a/parquet/metadata/column_chunk.go
+++ b/parquet/metadata/column_chunk.go
@@ -87,9 +87,10 @@ type ColumnChunkMetaData struct {
 // this is primarily used internally or between the subpackages. ColumnChunkMetaDataBuilder should
 // be used by consumers instead of using this directly.
 func NewColumnChunkMetaData(column *format.ColumnChunk, descr *schema.Column, writerVersion *AppVersion, rowGroupOrdinal, columnOrdinal int16, fileDecryptor encryption.FileDecryptor) (*ColumnChunkMetaData, error) {
+	columnMeta := column.GetMetaData()
 	c := &ColumnChunkMetaData{
 		column:        column,
-		columnMeta:    column.GetMetaData(),
+		columnMeta:    columnMeta,
 		descr:         descr,
 		writerVersion: writerVersion,
 		mem:           memory.DefaultAllocator,
@@ -116,6 +117,9 @@ func NewColumnChunkMetaData(column *format.ColumnChunk, descr *schema.Column, wr
 				return nil, errors.New("cannot decrypt column metadata. file decryption not setup correctly")
 			}
 		}
+	}
+	if c.columnMeta == nil {
+		return nil, errors.New("column chunk metadata is missing")
 	}
 	for _, enc := range c.columnMeta.Encodings {
 		c.encodings = append(c.encodings, parquet.Encoding(enc))

--- a/parquet/metadata/column_chunk.go
+++ b/parquet/metadata/column_chunk.go
@@ -87,10 +87,9 @@ type ColumnChunkMetaData struct {
 // this is primarily used internally or between the subpackages. ColumnChunkMetaDataBuilder should
 // be used by consumers instead of using this directly.
 func NewColumnChunkMetaData(column *format.ColumnChunk, descr *schema.Column, writerVersion *AppVersion, rowGroupOrdinal, columnOrdinal int16, fileDecryptor encryption.FileDecryptor) (*ColumnChunkMetaData, error) {
-	columnMeta := column.GetMetaData()
 	c := &ColumnChunkMetaData{
 		column:        column,
-		columnMeta:    columnMeta,
+		columnMeta:    column.GetMetaData(),
 		descr:         descr,
 		writerVersion: writerVersion,
 		mem:           memory.DefaultAllocator,

--- a/parquet/metadata/file_internal_test.go
+++ b/parquet/metadata/file_internal_test.go
@@ -36,3 +36,8 @@ func TestNewFileMetaDataReturnsSchemaErrors(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, meta)
 }
+
+func TestNewColumnChunkMetaDataReturnsErrorForMissingMetadata(t *testing.T) {
+	_, err := NewColumnChunkMetaData(&format.ColumnChunk{}, nil, nil, 0, 0, nil)
+	require.EqualError(t, err, "column chunk metadata is missing")
+}

--- a/parquet/metadata/file_internal_test.go
+++ b/parquet/metadata/file_internal_test.go
@@ -38,6 +38,7 @@ func TestNewFileMetaDataReturnsSchemaErrors(t *testing.T) {
 }
 
 func TestNewColumnChunkMetaDataReturnsErrorForMissingMetadata(t *testing.T) {
-	_, err := NewColumnChunkMetaData(&format.ColumnChunk{}, nil, nil, 0, 0, nil)
+	meta, err := NewColumnChunkMetaData(&format.ColumnChunk{}, nil, nil, 0, 0, nil)
 	require.EqualError(t, err, "column chunk metadata is missing")
+	require.Nil(t, meta)
 }


### PR DESCRIPTION
### Rationale for this change

NewColumnChunkMetaData dereferences column metadata while preparing encoding information. A malformed unencrypted ColumnChunk without MetaData therefore panics instead of returning its error result. Encrypted chunks may legitimately populate plaintext metadata during decryption.

### What changes are included in this PR?

Check for missing metadata after the decryption path and return an error for malformed chunks. Add regression coverage while preserving encrypted metadata handling.

### Are these changes tested?

- `go test ./parquet/metadata`

### Are there any user-facing changes?

Malformed unencrypted column chunks now return an error instead of panicking. Valid encrypted column chunks are unchanged.