### PR TITLE
fix(arrow/ipc): return compression errors from record encoder

### DIFF
--- a/arrow/ipc/ipc.go
+++ b/arrow/ipc/ipc.go
@@ -74,6 +74,7 @@ type config struct {
 	minSpaceSavings    float64
 	maxMetadataSize    int64
 	maxBodySize        int64
+	compressors        []compressor
 }
 
 const (
@@ -84,6 +85,12 @@ const (
 // Option is a functional option to configure opening or creating Arrow files
 // and streams.
 type Option func(*config)
+
+func withCompressors(compressors ...compressor) Option {
+	return func(cfg *config) {
+		cfg.compressors = compressors
+	}
+}
 
 func newConfig(opts ...Option) *config {
 	cfg := &config{

--- a/arrow/ipc/writer.go
+++ b/arrow/ipc/writer.go
@@ -1153,6 +1153,8 @@ func needTruncate(offset int64, buf *memory.Buffer, minLength int64) bool {
 // method after it is no longer needed.
 func GetRecordBatchPayload(batch arrow.RecordBatch, opts ...Option) (Payload, error) {
 	cfg := newConfig(opts...)
+	compressors := make([]compressor, cfg.compressNP)
+	copy(compressors, cfg.compressors)
 	var (
 		data = Payload{msg: MessageRecordBatch}
 		enc  = newRecordEncoder(
@@ -1163,7 +1165,7 @@ func GetRecordBatchPayload(batch arrow.RecordBatch, opts ...Option) (Payload, er
 			cfg.codec,
 			cfg.compressNP,
 			cfg.minSpaceSavings,
-			make([]compressor, cfg.compressNP),
+			compressors,
 		)
 	)
 

--- a/arrow/ipc/writer_test.go
+++ b/arrow/ipc/writer_test.go
@@ -48,13 +48,19 @@ type failingPayloadWriter struct {
 type shortWriteWriter struct{}
 
 type failingCompressor struct {
-	err error
+	err      error
+	closeErr error
 }
 
-func (failingCompressor) MaxCompressedLen(n int) int  { return n }
-func (failingCompressor) Reset(io.Writer)             {}
-func (f failingCompressor) Write([]byte) (int, error) { return 0, f.err }
-func (failingCompressor) Close() error                { return nil }
+func (failingCompressor) MaxCompressedLen(n int) int { return n }
+func (failingCompressor) Reset(io.Writer)            {}
+func (f failingCompressor) Write(p []byte) (int, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return len(p), nil
+}
+func (f failingCompressor) Close() error { return f.closeErr }
 func (failingCompressor) Type() flatbuf.CompressionType {
 	return flatbuf.CompressionTypeZSTD
 }
@@ -392,6 +398,23 @@ func TestRecordEncoderReturnsCompressionError(t *testing.T) {
 	defer payload.Release()
 
 	require.ErrorIs(t, encoder.Encode(&payload, record), want)
+}
+
+func TestGetRecordBatchPayloadReturnsCompressionErrorOnClose(t *testing.T) {
+	want := errors.New("compression failed")
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "col", Type: arrow.PrimitiveTypes.Int8}}, nil)
+	builder := array.NewRecordBuilder(mem, schema)
+	defer builder.Release()
+	builder.Field(0).(*array.Int8Builder).Append(1)
+	record := builder.NewRecordBatch()
+	defer record.Release()
+
+	_, err := GetRecordBatchPayload(record, WithAllocator(mem), WithZstd(),
+		withCompressors(failingCompressor{closeErr: want}))
+	require.ErrorIs(t, err, want)
 }
 
 func TestWriteWithCompressionAndMinSavings(t *testing.T) {


### PR DESCRIPTION
### Rationale for this change

`recordEncoder.encode` ignored errors returned by body compression, so a failed compressor could still result in record metadata being built and returned as a successful encode.

### What changes are included in this PR?

Return compression errors from `recordEncoder.encode`, release the temporary compressed buffer on failure, and add a regression test with a failing compressor.

### Are these changes tested?

- `go test ./arrow/ipc`

### Are there any user-facing changes?

IPC record encoding now reports compressor failures to the caller.