### PR TITLE
fix(arrow/ipc): preserve minSpaceSavings in stream writer

### DIFF
--- a/arrow/ipc/writer.go
+++ b/arrow/ipc/writer.go
@@ -125,14 +125,15 @@ func NewWriterWithPayloadWriter(pw PayloadWriter, opts ...Option) *Writer {
 func NewWriter(w io.Writer, opts ...Option) *Writer {
 	cfg := newConfig(opts...)
 	return &Writer{
-		w:              w,
-		mem:            cfg.alloc,
-		pw:             &streamWriter{w: w},
-		schema:         cfg.schema,
-		codec:          cfg.codec,
-		emitDictDeltas: cfg.emitDictDeltas,
-		compressNP:     cfg.compressNP,
-		compressors:    make([]compressor, cfg.compressNP),
+		w:               w,
+		mem:             cfg.alloc,
+		pw:              &streamWriter{w: w},
+		schema:          cfg.schema,
+		codec:           cfg.codec,
+		emitDictDeltas:  cfg.emitDictDeltas,
+		compressNP:      cfg.compressNP,
+		minSpaceSavings: cfg.minSpaceSavings,
+		compressors:     make([]compressor, cfg.compressNP),
 	}
 }
 

--- a/arrow/ipc/writer_test.go
+++ b/arrow/ipc/writer_test.go
@@ -325,6 +325,14 @@ func TestWriterMemCompression(t *testing.T) {
 	require.NoError(t, w.Write(rec))
 }
 
+func TestNewWriterWithMinSpaceSavings(t *testing.T) {
+	const minSpaceSavings = 0.5
+
+	writer := NewWriter(io.Discard, WithMinSpaceSavings(minSpaceSavings))
+
+	assert.Equal(t, minSpaceSavings, writer.minSpaceSavings)
+}
+
 func TestWriteWithCompressionAndMinSavings(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)


### PR DESCRIPTION
### Rationale for this change

`NewWriterWithPayloadWriter` copies `minSpaceSavings`, but `NewWriter` did not. As a result, `WithMinSpaceSavings` was ignored by the regular stream writer.

### What changes are included in this PR?

Copy the configured value in `NewWriter` and add a regression test.

### Are these changes tested?

- `go test ./arrow/ipc`

### Are there any user-facing changes?

The regular IPC stream writer now honors `WithMinSpaceSavings`.