### PR TITLE
fix(parquet/compress): honor LZ4 raw destination contract

### DIFF
--- a/parquet/compress/compress_test.go
+++ b/parquet/compress/compress_test.go
@@ -130,6 +130,21 @@ func TestCompressDataOneShot(t *testing.T) {
 	}
 }
 
+func TestLZ4RawCodecAllocatesDestination(t *testing.T) {
+	codec, err := compress.GetCodec(compress.Codecs.Lz4Raw)
+	assert.NoError(t, err)
+	src := bytes.Repeat([]byte("arrow"), 100)
+
+	for _, dst := range [][]byte{nil, make([]byte, 1)} {
+		compressed := codec.Encode(dst, src)
+		uncompressed := codec.Decode(make([]byte, len(src)), compressed)
+		assert.Equal(t, src, uncompressed)
+		if len(dst) > 0 {
+			assert.NotSame(t, &dst[0], &compressed[0])
+		}
+	}
+}
+
 func TestUncompressedCodecAllocatesDestination(t *testing.T) {
 	codec, err := compress.GetCodec(compress.Codecs.Uncompressed)
 	assert.NoError(t, err)

--- a/parquet/compress/lz4_raw.go
+++ b/parquet/compress/lz4_raw.go
@@ -35,6 +35,10 @@ func compressBlock(src, dst []byte) (int, error) {
 type lz4RawCodec struct{}
 
 func (c lz4RawCodec) Encode(dst, src []byte) []byte {
+	if bound := c.CompressBound(int64(len(src))); int64(cap(dst)) < bound {
+		dst = make([]byte, int(bound))
+	}
+
 	n, err := compressBlock(src, dst[:cap(dst)])
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## What

The LZ4 raw codec passed the provided capacity straight to CompressBlock. Nil or undersized destinations could panic instead of allocating as promised by Codec.Encode. This allocates the compression bound when the destination capacity is insufficient.

## Test

- go test ./parquet/compress -count=1