### PR TITLE
fix(arrow/csv): validate custom converter row counts

### DIFF
--- a/arrow/csv/common.go
+++ b/arrow/csv/common.go
@@ -239,7 +239,7 @@ func WithStringsReplacer(replacer *strings.Replacer) Option {
 
 // WithCustomTypeConverter allows specifying a custom type converter for the CSV writer.
 //
-// returns a slice of strings that must match the number of columns in the output csv.
+// The returned slice must contain one string for each value in col.
 // the second return value is a boolean that indicates if the conversion was handled.
 // if it is set to false, the library will attempt to use default conversion.
 //

--- a/arrow/csv/transformer.go
+++ b/arrow/csv/transformer.go
@@ -31,6 +31,9 @@ func (w *Writer) transformColToStringArr(typ arrow.DataType, col arrow.Array, st
 	if w.customTypeConverter != nil {
 		result, handled := w.customTypeConverter(typ, col)
 		if handled {
+			if len(result) != col.Len() {
+				return nil, fmt.Errorf("%w: custom type converter returned %d values for column with %d rows", arrow.ErrInvalid, len(result), col.Len())
+			}
 			return result, nil
 		}
 	}

--- a/arrow/csv/writer_test.go
+++ b/arrow/csv/writer_test.go
@@ -463,6 +463,30 @@ func TestCSVWriterPreservesDecimalScaleAndPrecision(t *testing.T) {
 	assert.Equal(t, value128.ToString(type128.Scale)+","+value256.ToString(type256.Scale)+"\n", output.String())
 }
 
+func TestCustomTypeConverterValidatesRowCount(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: arrow.PrimitiveTypes.Int32}}, nil)
+	builder := array.NewRecordBuilder(mem, schema)
+	builder.Field(0).(*array.Int32Builder).AppendValues([]int32{1, 2}, nil)
+	record := builder.NewRecordBatch()
+	builder.Release()
+	defer record.Release()
+
+	for name, result := range map[string][]string{
+		"too few":  {"one"},
+		"too many": {"one", "two", "three"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			writer := csv.NewWriter(io.Discard, schema, csv.WithCustomTypeConverter(func(arrow.DataType, arrow.Array) ([]string, bool) {
+				return result, true
+			}))
+			require.ErrorIs(t, writer.Write(record), arrow.ErrInvalid)
+		})
+	}
+}
+
 // TestParquetTestingCSVWriter tests that the CSV writer successfully convert arrow/parquet-testing files to CSV
 func TestParquetTestingCSVWriter(t *testing.T) {
 	dir := os.Getenv("PARQUET_TEST_DATA")


### PR DESCRIPTION
## What

The custom CSV writer converter is documented to return one string per array value, but the writer trusted the result. Short results silently produced empty cells and long results could panic while filling the record matrix. This returns arrow.ErrInvalid for either mismatch.

## Test

- go test ./arrow/csv -run TestCustomTypeConverterValidatesRowCount -count=1