### PR TITLE
fix(arrow/extensions): compare JSON storage types semantically

### DIFF
--- a/arrow/extensions/json.go
+++ b/arrow/extensions/json.go
@@ -19,7 +19,6 @@ package extensions
 import (
 	"fmt"
 	"reflect"
-	"slices"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -46,7 +45,14 @@ func (b *JSONType) ParquetLogicalType() schema.LogicalType {
 // NewJSONType creates a new JSONType with the specified storage type.
 // storageType must be one of String, LargeString, StringView.
 func NewJSONType(storageType arrow.DataType) (*JSONType, error) {
-	if !slices.Contains(jsonSupportedStorageTypes, storageType) {
+	supported := false
+	for _, typ := range jsonSupportedStorageTypes {
+		if arrow.TypeEqual(typ, storageType) {
+			supported = true
+			break
+		}
+	}
+	if !supported {
 		return nil, fmt.Errorf("unsupported storage type for JSON extension type: %s", storageType)
 	}
 	return &JSONType{ExtensionBase: arrow.ExtensionBase{Storage: storageType}}, nil

--- a/arrow/extensions/json_test.go
+++ b/arrow/extensions/json_test.go
@@ -62,6 +62,17 @@ func TestJSONTypeBasics(t *testing.T) {
 	assert.Equal(t, "extension<arrow.json[storage_type=string_view]>", typView.String())
 }
 
+func TestJSONTypeAcceptsSemanticallyEqualStorageType(t *testing.T) {
+	var holder struct {
+		_       byte
+		storage arrow.StringType
+	}
+
+	typ, err := extensions.NewJSONType(&holder.storage)
+	require.NoError(t, err)
+	require.True(t, arrow.TypeEqual(arrow.BinaryTypes.String, typ.StorageType()))
+}
+
 var jsonTestCases = []struct {
 	Name           string
 	StorageType    arrow.DataType


### PR DESCRIPTION
## What

NewJSONType used interface equality when checking supported storage types. A distinct StringType value is semantically the same Arrow type but could be rejected. This uses arrow.TypeEqual for the supported storage type check.

## Test

- go test ./arrow/extensions -count=1