### PR TITLE
fix(flightsql): stop row streaming after close

### DIFF
--- a/arrow/flight/flightsql/driver/driver.go
+++ b/arrow/flight/flightsql/driver/driver.go
@@ -117,6 +117,9 @@ func (r *Rows) Close() error {
 	r.currentRow = 0
 
 	r.releaseRecord()
+	for record := range r.recordChan {
+		record.Release()
+	}
 
 	return nil
 }

--- a/arrow/flight/flightsql/driver/driver.go
+++ b/arrow/flight/flightsql/driver/driver.go
@@ -100,6 +100,16 @@ func (r *Rows) releaseRecord() {
 	}
 }
 
+func (r *Rows) sendRecord(ctx context.Context, record arrow.RecordBatch) bool {
+	select {
+	case r.recordChan <- record:
+		return true
+	case <-ctx.Done():
+		record.Release()
+		return false
+	}
+}
+
 // Close closes the rows iterator.
 func (r *Rows) Close() error {
 	r.ctxCancelFunc() // interrupting data streaming.
@@ -587,7 +597,9 @@ func (r *Rows) streamRecordset(ctx context.Context, c *flightsql.Client, endpoin
 					continue
 				}
 
-				r.recordChan <- record
+				if !r.sendRecord(ctx, record) {
+					return
+				}
 
 				go initializeOnceOnly.Do(func() { r.initializedChan <- true })
 			}

--- a/arrow/flight/flightsql/driver/rows_test.go
+++ b/arrow/flight/flightsql/driver/rows_test.go
@@ -19,7 +19,6 @@ package driver
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -27,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRowsSendRecordStopsWhenContextCancelled(t *testing.T) {
+func TestRowsCloseReleasesRetainedRecords(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)
 
@@ -38,30 +37,27 @@ func TestRowsSendRecordStopsWhenContextCancelled(t *testing.T) {
 	builder.Field(0).(*array.Int64Builder).Append(2)
 	pending := builder.NewRecordBatch()
 	builder.Release()
-	defer queued.Release()
 
 	rows := newRows()
+	ctx, cancel := context.WithCancel(context.Background())
+	rows.ctxCancelFunc = cancel
+
+	queued.Retain()
+	pending.Retain()
 	rows.recordChan <- queued
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(rows.recordChan)
+		rows.sendRecord(ctx, pending)
+	}()
 
-	done := make(chan bool, 1)
-	go func() { done <- rows.sendRecord(ctx, pending) }()
+	queued.Release()
+	pending.Release()
 
-	select {
-	case <-done:
-		t.Fatal("sendRecord returned while the channel was full")
-	case <-time.After(10 * time.Millisecond):
-	}
-
-	cancel()
-	select {
-	case sent := <-done:
-		require.False(t, sent)
-	case <-time.After(time.Second):
-		t.Fatal("sendRecord did not stop after context cancellation")
-	}
-
-	<-rows.recordChan
+	require.Positive(t, mem.CurrentAlloc())
+	require.NoError(t, rows.Close())
+	<-done
+	require.Zero(t, mem.CurrentAlloc())
 }

--- a/arrow/flight/flightsql/driver/rows_test.go
+++ b/arrow/flight/flightsql/driver/rows_test.go
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRowsSendRecordStopsWhenContextCancelled(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: "value", Type: arrow.PrimitiveTypes.Int64}}, nil)
+	builder := array.NewRecordBuilder(mem, schema)
+	builder.Field(0).(*array.Int64Builder).Append(1)
+	queued := builder.NewRecordBatch()
+	builder.Field(0).(*array.Int64Builder).Append(2)
+	pending := builder.NewRecordBatch()
+	builder.Release()
+	defer queued.Release()
+
+	rows := newRows()
+	rows.recordChan <- queued
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan bool, 1)
+	go func() { done <- rows.sendRecord(ctx, pending) }()
+
+	select {
+	case <-done:
+		t.Fatal("sendRecord returned while the channel was full")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case sent := <-done:
+		require.False(t, sent)
+	case <-time.After(time.Second):
+		t.Fatal("sendRecord did not stop after context cancellation")
+	}
+
+	<-rows.recordChan
+}


### PR DESCRIPTION
## What

Rows.Close cancels the streaming context, but the producer could already be blocked sending a retained record into the full channel. This adds a context-aware send and releases the record when cancellation wins.

## Test

- go test ./arrow/flight/flightsql/driver -run TestRowsSendRecordStopsWhenContextCancelled -count=1