### PR TITLE
fix(flightsql): reject unsupported transaction options

### DIFF
--- a/arrow/flight/flightsql/driver/driver.go
+++ b/arrow/flight/flightsql/driver/driver.go
@@ -471,6 +471,8 @@ type Connection struct {
 	timeout time.Duration
 }
 
+var _ driver.ConnBeginTx = (*Connection)(nil)
+
 // Prepare returns a prepared statement, bound to this connection.
 func (c *Connection) Prepare(query string) (driver.Stmt, error) {
 	return c.PrepareContext(context.Background(), query)
@@ -620,11 +622,11 @@ func (c *Connection) Close() error {
 
 // Begin starts and returns a new transaction.
 func (c *Connection) Begin() (driver.Tx, error) {
-	return c.BeginTx(context.Background(), sql.TxOptions{})
+	return c.BeginTx(context.Background(), driver.TxOptions{})
 }
 
-func (c *Connection) BeginTx(ctx context.Context, opts sql.TxOptions) (driver.Tx, error) {
-	if opts.Isolation != sql.LevelDefault || opts.ReadOnly {
+func (c *Connection) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if opts.Isolation != driver.IsolationLevel(sql.LevelDefault) || opts.ReadOnly {
 		return nil, fmt.Errorf("%w: transaction options are not supported", ErrNotSupported)
 	}
 

--- a/arrow/flight/flightsql/driver/driver.go
+++ b/arrow/flight/flightsql/driver/driver.go
@@ -451,9 +451,11 @@ func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 	}
 	client.Alloc = c.allocator
 
-	return &Connection{
-		client:  client,
-		timeout: c.timeout,
+	return &connBeginTx{
+		Connection: &Connection{
+			client:  client,
+			timeout: c.timeout,
+		},
 	}, nil
 }
 
@@ -471,7 +473,18 @@ type Connection struct {
 	timeout time.Duration
 }
 
-var _ driver.ConnBeginTx = (*Connection)(nil)
+type connBeginTx struct {
+	*Connection
+}
+
+var _ driver.ConnBeginTx = (*connBeginTx)(nil)
+
+func (c *connBeginTx) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return c.Connection.BeginTx(ctx, sql.TxOptions{
+		Isolation: sql.IsolationLevel(opts.Isolation),
+		ReadOnly:  opts.ReadOnly,
+	})
+}
 
 // Prepare returns a prepared statement, bound to this connection.
 func (c *Connection) Prepare(query string) (driver.Stmt, error) {
@@ -622,11 +635,11 @@ func (c *Connection) Close() error {
 
 // Begin starts and returns a new transaction.
 func (c *Connection) Begin() (driver.Tx, error) {
-	return c.BeginTx(context.Background(), driver.TxOptions{})
+	return c.BeginTx(context.Background(), sql.TxOptions{})
 }
 
-func (c *Connection) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
-	if opts.Isolation != driver.IsolationLevel(sql.LevelDefault) || opts.ReadOnly {
+func (c *Connection) BeginTx(ctx context.Context, opts sql.TxOptions) (driver.Tx, error) {
+	if opts.Isolation != sql.LevelDefault || opts.ReadOnly {
 		return nil, fmt.Errorf("%w: transaction options are not supported", ErrNotSupported)
 	}
 

--- a/arrow/flight/flightsql/driver/driver.go
+++ b/arrow/flight/flightsql/driver/driver.go
@@ -624,6 +624,10 @@ func (c *Connection) Begin() (driver.Tx, error) {
 }
 
 func (c *Connection) BeginTx(ctx context.Context, opts sql.TxOptions) (driver.Tx, error) {
+	if opts.Isolation != sql.LevelDefault || opts.ReadOnly {
+		return nil, fmt.Errorf("%w: transaction options are not supported", ErrNotSupported)
+	}
+
 	tx, err := c.client.BeginTransaction(ctx)
 	if err != nil {
 		return nil, err

--- a/arrow/flight/flightsql/driver/transaction_test.go
+++ b/arrow/flight/flightsql/driver/transaction_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package driver_test
+package driver
 
 import (
 	"context"
@@ -22,18 +22,17 @@ import (
 	sqldriver "database/sql/driver"
 	"testing"
 
-	"github.com/apache/arrow-go/v18/arrow/flight/flightsql/driver"
 	"github.com/stretchr/testify/require"
 )
 
 type connectionConnector struct{}
 
 func (connectionConnector) Connect(context.Context) (sqldriver.Conn, error) {
-	return &driver.Connection{}, nil
+	return &connBeginTx{Connection: &Connection{}}, nil
 }
 
 func (connectionConnector) Driver() sqldriver.Driver {
-	return &driver.Driver{}
+	return &Driver{}
 }
 
 func TestBeginTxRejectsUnsupportedOptions(t *testing.T) {
@@ -47,6 +46,6 @@ func TestBeginTxRejectsUnsupportedOptions(t *testing.T) {
 		{ReadOnly: true},
 	} {
 		_, err := db.BeginTx(context.Background(), &opts)
-		require.ErrorIs(t, err, driver.ErrNotSupported)
+		require.ErrorIs(t, err, ErrNotSupported)
 	}
 }

--- a/arrow/flight/flightsql/driver/transaction_test.go
+++ b/arrow/flight/flightsql/driver/transaction_test.go
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql/driver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBeginTxRejectsUnsupportedOptions(t *testing.T) {
+	conn := &driver.Connection{}
+
+	for _, opts := range []sql.TxOptions{
+		{Isolation: sql.LevelSerializable},
+		{ReadOnly: true},
+	} {
+		_, err := conn.BeginTx(context.Background(), opts)
+		require.ErrorIs(t, err, driver.ErrNotSupported)
+	}
+}

--- a/arrow/flight/flightsql/driver/transaction_test.go
+++ b/arrow/flight/flightsql/driver/transaction_test.go
@@ -19,20 +19,34 @@ package driver_test
 import (
 	"context"
 	"database/sql"
+	sqldriver "database/sql/driver"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql/driver"
 	"github.com/stretchr/testify/require"
 )
 
+type connectionConnector struct{}
+
+func (connectionConnector) Connect(context.Context) (sqldriver.Conn, error) {
+	return &driver.Connection{}, nil
+}
+
+func (connectionConnector) Driver() sqldriver.Driver {
+	return &driver.Driver{}
+}
+
 func TestBeginTxRejectsUnsupportedOptions(t *testing.T) {
-	conn := &driver.Connection{}
+	db := sql.OpenDB(connectionConnector{})
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 
 	for _, opts := range []sql.TxOptions{
 		{Isolation: sql.LevelSerializable},
 		{ReadOnly: true},
 	} {
-		_, err := conn.BeginTx(context.Background(), opts)
+		_, err := db.BeginTx(context.Background(), &opts)
 		require.ErrorIs(t, err, driver.ErrNotSupported)
 	}
 }


### PR DESCRIPTION
## What

- Connection.BeginTx used sql.TxOptions instead of driver.TxOptions.
- Because of that, Connection did not implement driver.ConnBeginTx and database/sql never called the method.
- Use driver.TxOptions so database/sql forwards the caller context and transaction options.
- Return ErrNotSupported for non-default isolation levels and read-only transactions because FlightSQL does not support configuring them.
- Add a compile-time interface check and test the behavior through sql.DB.BeginTx.

## Test

- go test ./arrow/flight/flightsql/driver -run TestBeginTxRejectsUnsupportedOptions -count=1
- go test -race ./arrow/flight/flightsql/driver -run TestBeginTxRejectsUnsupportedOptions -count=1
- go test ./arrow/flight/flightsql/... -count=1
- go test ./arrow/flight/... -count=1
- go vet ./arrow/flight/flightsql/driver