### PR TITLE
fix(compute): report FuncMeta for meta functions

### DIFF
--- a/arrow/compute/functions.go
+++ b/arrow/compute/functions.go
@@ -398,6 +398,7 @@ func NewMetaFunction(name string, arity Arity, doc FunctionDoc, impl MetaFunctio
 	return &MetaFunction{
 		baseFunction: baseFunction{
 			name:  name,
+			kind:  FuncMeta,
 			arity: arity,
 			doc:   doc,
 		},

--- a/arrow/compute/functions_test.go
+++ b/arrow/compute/functions_test.go
@@ -19,6 +19,7 @@
 package compute_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -47,6 +48,15 @@ func TestArityBasics(t *testing.T) {
 	varargs := compute.VarArgs(2)
 	assert.Equal(t, 2, varargs.NArgs)
 	assert.True(t, varargs.IsVarArgs)
+}
+
+func TestNewMetaFunctionKind(t *testing.T) {
+	fn := compute.NewMetaFunction("test_meta", compute.Nullary(), compute.EmptyFuncDoc,
+		func(context.Context, compute.FunctionOptions, ...compute.Datum) (compute.Datum, error) {
+			return nil, nil
+		})
+
+	assert.Equal(t, compute.FuncMeta, fn.Kind())
 }
 
 func CheckDispatchBest(t *testing.T, funcName string, originalTypes, expected []arrow.DataType) {

--- a/arrow/compute/functions_test.go
+++ b/arrow/compute/functions_test.go
@@ -59,6 +59,16 @@ func TestNewMetaFunctionKind(t *testing.T) {
 	assert.Equal(t, compute.FuncMeta, fn.Kind())
 }
 
+func TestRegisteredMetaFunctionKinds(t *testing.T) {
+	for _, name := range []string{"cast", "filter", "take", "sort", "sort_indices"} {
+		t.Run(name, func(t *testing.T) {
+			fn, ok := compute.GetFunctionRegistry().GetFunction(name)
+			require.True(t, ok)
+			assert.Equal(t, compute.FuncMeta, fn.Kind())
+		})
+	}
+}
+
 func CheckDispatchBest(t *testing.T, funcName string, originalTypes, expected []arrow.DataType) {
 	fn, exists := compute.GetFunctionRegistry().GetFunction(funcName)
 	require.True(t, exists)


### PR DESCRIPTION
## What

Set the function kind when constructing a MetaFunction. NewMetaFunction now reports FuncMeta instead of the zero-value scalar kind.

## Test

- go test ./arrow/compute -count=1