### PR TITLE
fix(compute): propagate nested expression serialization errors

### DIFF
--- a/arrow/compute/expression.go
+++ b/arrow/compute/expression.go
@@ -788,6 +788,11 @@ func SerializeExpr(expr Expression, mem memory.Allocator) (*memory.Buffer, error
 		metaValue []string
 		visit     func(Expression) error
 	)
+	defer func() {
+		for _, col := range cols {
+			col.Release()
+		}
+	}()
 
 	addScalar := func(s scalar.Scalar) (string, error) {
 		ret := len(cols)
@@ -823,7 +828,9 @@ func SerializeExpr(expr Expression, mem memory.Allocator) (*memory.Buffer, error
 			metaValue = append(metaValue, e.funcName)
 
 			for _, arg := range e.args {
-				visit(arg)
+				if err := visit(arg); err != nil {
+					return err
+				}
 			}
 
 			if e.options != nil {
@@ -859,7 +866,6 @@ func SerializeExpr(expr Expression, mem memory.Allocator) (*memory.Buffer, error
 	fields := make([]arrow.Field, len(cols))
 	for i, c := range cols {
 		fields[i].Type = c.DataType()
-		defer c.Release()
 	}
 
 	metadata := arrow.NewMetadata(metaKey, metaValue)

--- a/arrow/compute/expression_test.go
+++ b/arrow/compute/expression_test.go
@@ -467,3 +467,24 @@ func TestDeserializeExprRejectsUnknownOptions(t *testing.T) {
 	_, err = compute.DeserializeExpr(mem, serialized)
 	assert.ErrorIs(t, err, arrow.ErrInvalid)
 }
+
+func TestExpressionSerializationPropagatesNestedLiteralError(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	builder := array.NewInt32Builder(mem)
+	defer builder.Release()
+	builder.Append(1)
+	values := builder.NewArray()
+	defer values.Release()
+
+	expr := compute.NewCall("test", []compute.Expression{
+		compute.NewLiteral(1),
+		compute.NewLiteral(values),
+	}, nil)
+	defer expr.Release()
+
+	serialized, err := compute.SerializeExpr(expr, mem)
+	assert.Nil(t, serialized)
+	assert.ErrorContains(t, err, "serialization of non-scalar literals")
+}


### PR DESCRIPTION
### Rationale for this change

SerializeExpr ignores errors returned while visiting call arguments. A nested unsupported literal can therefore produce a successful result with incomplete metadata, and scalar columns allocated before the error are not released.

### What changes are included in this PR?

Propagate errors from nested arguments and release all temporary scalar columns on both success and failure paths.

### Are these changes tested?

Yes. The regression test places a valid scalar before an unsupported nested array literal and checks both the returned error and allocator cleanup. The full arrow/compute package suite passes.

### Are there any user-facing changes?

Nested serialization failures are now returned to the caller instead of being silently ignored.