### PR TITLE
perf(parquet): optimize numeric dictionary insertion

### DIFF
--- a/parquet/internal/encoding/encoding_benchmarks_test.go
+++ b/parquet/internal/encoding/encoding_benchmarks_test.go
@@ -423,6 +423,50 @@ func BenchmarkEncodeDictByteArray(b *testing.B) {
 	}
 }
 
+func benchmarkEncodeDictNumeric[T int32 | int64 | float32 | float64](b *testing.B, typ parquet.Type, col *schema.Column, valueSize int64) {
+	const (
+		nunique = 100
+		nvalues = 65535
+	)
+
+	values := make([]T, nvalues)
+	for idx := range values {
+		values[idx] = T(idx % nunique)
+	}
+
+	b.SetBytes(int64(len(values)) * valueSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		enc := encoding.NewEncoder(typ, parquet.Encodings.PlainDict, true, col, memory.DefaultAllocator).(encoding.Encoder[T])
+		enc.Put(values)
+		buf, err := enc.FlushValues()
+		if err != nil {
+			b.Fatal(err)
+		}
+		buf.Release()
+		enc.Release()
+	}
+}
+
+func BenchmarkEncodeDictNumeric(b *testing.B) {
+	b.Run("int32", func(b *testing.B) {
+		col := schema.NewColumn(schema.NewInt32Node("int32", parquet.Repetitions.Required, -1), 0, 0)
+		benchmarkEncodeDictNumeric[int32](b, parquet.Types.Int32, col, int64(arrow.Int32SizeBytes))
+	})
+	b.Run("int64", func(b *testing.B) {
+		col := schema.NewColumn(schema.NewInt64Node("int64", parquet.Repetitions.Required, -1), 0, 0)
+		benchmarkEncodeDictNumeric[int64](b, parquet.Types.Int64, col, int64(arrow.Int64SizeBytes))
+	})
+	b.Run("float32", func(b *testing.B) {
+		col := schema.NewColumn(schema.NewFloat32Node("float32", parquet.Repetitions.Required, -1), 0, 0)
+		benchmarkEncodeDictNumeric[float32](b, parquet.Types.Float, col, int64(arrow.Float32SizeBytes))
+	})
+	b.Run("float64", func(b *testing.B) {
+		col := schema.NewColumn(schema.NewFloat64Node("float64", parquet.Repetitions.Required, -1), 0, 0)
+		benchmarkEncodeDictNumeric[float64](b, parquet.Types.Double, col, int64(arrow.Float64SizeBytes))
+	})
+}
+
 func BenchmarkDecodeDictByteArray(b *testing.B) {
 	const (
 		nunique = 100

--- a/parquet/internal/encoding/typed_encoder.go
+++ b/parquet/internal/encoding/typed_encoder.go
@@ -142,8 +142,23 @@ func (enc *typedDictEncoder[T]) WriteDict(out []byte) {
 }
 
 func (enc *typedDictEncoder[T]) Put(in []T) {
-	for _, val := range in {
-		enc.dictEncoder.Put(val)
+	if len(in) == 0 {
+		return
+	}
+
+	curPos := len(enc.idxValues)
+	enc.expandBuffer(curPos + len(in))
+	enc.idxValues = enc.idxValues[:curPos+len(in)]
+	typedMemo := enc.memo.(TypedMemoTable[T])
+	for i, val := range in {
+		memoIdx, found, err := typedMemo.InsertOrGet(val)
+		if err != nil {
+			panic(err)
+		}
+		if !found {
+			enc.dictEncodedSize += int(unsafe.Sizeof(T(0)))
+		}
+		enc.idxValues[curPos+i] = int32(memoIdx)
 	}
 	enc.AddRawSize(int64(len(in)) * int64(unsafe.Sizeof(T(0))))
 }

--- a/parquet/internal/encoding/typed_encoder_test.go
+++ b/parquet/internal/encoding/typed_encoder_test.go
@@ -18,6 +18,7 @@ package encoding
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -26,6 +27,49 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/schema"
 	"github.com/stretchr/testify/assert"
 )
+
+func assertTypedDictEncoderPut[T int32 | int64 | float32 | float64](t *testing.T, values, expectedDict []T, expectedIndices []int32) {
+	t.Helper()
+	enc := &typedDictEncoder[T]{newDictEncoderBase(nil, NewDictionary[T](), memory.DefaultAllocator)}
+	defer enc.Release()
+
+	split := len(values) / 2
+	enc.Put(values[:split])
+	enc.Put(values[split:])
+
+	assert.Equal(t, expectedIndices, enc.idxValues)
+	actualDict := make([]T, len(expectedDict))
+	enc.memo.CopyValues(actualDict)
+	assert.Equal(t, expectedDict, actualDict)
+	assert.Equal(t, len(expectedDict)*int(unsafe.Sizeof(T(0))), enc.DictEncodedSize())
+}
+
+func TestTypedDictEncoderPut(t *testing.T) {
+	t.Run("int32", func(t *testing.T) {
+		assertTypedDictEncoderPut(t,
+			[]int32{1, 2, 1, 4, 2},
+			[]int32{1, 2, 4},
+			[]int32{0, 1, 0, 2, 1})
+	})
+	t.Run("int64", func(t *testing.T) {
+		assertTypedDictEncoderPut(t,
+			[]int64{-1, 2, -1, 3, 2},
+			[]int64{-1, 2, 3},
+			[]int32{0, 1, 0, 2, 1})
+	})
+	t.Run("float32", func(t *testing.T) {
+		assertTypedDictEncoderPut(t,
+			[]float32{1.5, 2.5, 1.5, 3.5, 2.5},
+			[]float32{1.5, 2.5, 3.5},
+			[]int32{0, 1, 0, 2, 1})
+	})
+	t.Run("float64", func(t *testing.T) {
+		assertTypedDictEncoderPut(t,
+			[]float64{1.5, 2.5, 1.5, 3.5, 2.5},
+			[]float64{1.5, 2.5, 3.5},
+			[]int32{0, 1, 0, 2, 1})
+	})
+}
 
 func TestPutDictionary(t *testing.T) {
 	exp := []int32{1, 2, 4, 8, 16}


### PR DESCRIPTION
## What changed

- use typed memo insertion for int32, int64, float32, and float64 dictionary encoders
- reserve the index buffer for the whole input batch and fill it directly
- keep the existing byte-array and fixed-length byte-array paths unchanged
- add correctness coverage for all four numeric types, including multiple `Put` calls
- add a numeric dictionary encoding benchmark

## Why

The numeric path was calling the generic dictionary insertion method for every value. That added interface and reflection overhead, and the index buffer could grow inside the hot loop.

The new path does the memo lookup with the concrete numeric type and sizes the index buffer once per batch. Dictionary order, duplicate handling, and encoded indices stay the same.

## Benchmark

With 65,535 values and 100 unique values on an Apple M1 Pro:

- int32: about 1.21 ms/op to 0.89 ms/op, 26 to 13 allocs/op
- int64: about 1.21 ms/op to 0.92 ms/op, 26 to 13 allocs/op
- float32: about 2.1 ms/op to 1.1 ms/op, 64,905 to 13 allocs/op
- float64: about 2.2 ms/op to 1.2 to 1.4 ms/op, 64,906 to 13 allocs/op

## Validation

- `go test ./parquet/internal/encoding -count=1`
- focused Parquet Arrow dictionary tests
- `go vet ./parquet/internal/encoding`
- `git diff --check`