### PR TITLE
perf(parquet/compress): reuse gzip writers

### DIFF
--- a/parquet/compress/compress_test.go
+++ b/parquet/compress/compress_test.go
@@ -200,6 +200,43 @@ func TestGzipCompressBound(t *testing.T) {
 	}
 }
 
+func TestGzipEncodeLevelConcurrent(t *testing.T) {
+	codec, err := compress.GetCodec(compress.Codecs.Gzip)
+	assert.NoError(t, err)
+
+	src := makeCompressibleData(4 * 1024)
+	levels := []int{
+		gzip.DefaultCompression,
+		gzip.NoCompression,
+		gzip.BestSpeed,
+		gzip.BestCompression,
+		gzip.StatelessCompression,
+	}
+
+	const workers = 16
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < len(levels); j++ {
+				level := levels[(i+j)%len(levels)]
+				compressed := codec.EncodeLevel(nil, src, level)
+				decoded, err := compress.Decode(codec, nil, compressed)
+				if err != nil {
+					t.Errorf("level %d: decode failed: %v", level, err)
+					return
+				}
+				if !bytes.Equal(src, decoded) {
+					t.Errorf("level %d: decoded data differs", level)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
 func TestBrotliCompressBound(t *testing.T) {
 	codec, err := compress.GetCodec(compress.Codecs.Brotli)
 	assert.NoError(t, err)

--- a/parquet/compress/gzip.go
+++ b/parquet/compress/gzip.go
@@ -20,11 +20,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/klauspost/compress/gzip"
 )
 
 type gzipCodec struct{}
+
+var gzipWriterPools [gzip.BestCompression - gzip.StatelessCompression + 1]sync.Pool
 
 const (
 	gzipHeaderSize              = 10
@@ -84,18 +87,48 @@ func (g gzipCodec) EncodeLevel(dst, src []byte, level int) []byte {
 		dst = make([]byte, 0, maxlen)
 	}
 	buf := bytes.NewBuffer(dst[:0])
-	w, err := gzip.NewWriterLevel(buf, level)
+	pool := gzipWriterPool(level)
+	var w *gzip.Writer
+	if pool != nil {
+		if cached := pool.Get(); cached != nil {
+			w = cached.(*gzip.Writer)
+			w.Reset(buf)
+		}
+	}
+	var err error
+	if w == nil {
+		w, err = gzip.NewWriterLevel(buf, level)
+	}
 	if err != nil {
 		panic(err)
 	}
 	_, err = w.Write(src)
 	if err != nil {
+		releaseGzipWriter(pool, w)
 		panic(err)
 	}
 	if err := w.Close(); err != nil {
+		releaseGzipWriter(pool, w)
 		panic(err)
 	}
-	return buf.Bytes()
+	compressed := buf.Bytes()
+	releaseGzipWriter(pool, w)
+	return compressed
+}
+
+func gzipWriterPool(level int) *sync.Pool {
+	if level < gzip.StatelessCompression || level > gzip.BestCompression {
+		return nil
+	}
+	return &gzipWriterPools[level-gzip.StatelessCompression]
+}
+
+func releaseGzipWriter(pool *sync.Pool, w *gzip.Writer) {
+	if pool == nil {
+		return
+	}
+	w.Reset(nil)
+	pool.Put(w)
 }
 
 func (g gzipCodec) Encode(dst, src []byte) []byte {

--- a/parquet/compress/gzip_benchmark_test.go
+++ b/parquet/compress/gzip_benchmark_test.go
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compress_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/parquet/compress"
+	"github.com/klauspost/compress/gzip"
+)
+
+func BenchmarkGzipEncodePages(b *testing.B) {
+	codec, err := compress.GetCodec(compress.Codecs.Gzip)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		data func(int) []byte
+	}{
+		{"repeated", makeCompressibleData},
+		{"random", makeRandomData},
+	} {
+		for _, pageSize := range []int{4 << 10, 64 << 10, 256 << 10} {
+			b.Run(tc.name+"/page="+formatBytes(pageSize), func(b *testing.B) {
+				src := tc.data(pageSize)
+				dst := make([]byte, 0, codec.CompressBound(int64(len(src))))
+
+				b.SetBytes(int64(len(src)))
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					dst = codec.EncodeLevel(dst[:0], src, gzip.DefaultCompression)
+				}
+			})
+		}
+	}
+}
+
+func formatBytes(size int) string {
+	if size >= 1<<20 {
+		return fmt.Sprintf("%dMiB", size>>20)
+	}
+	return fmt.Sprintf("%dKiB", size>>10)
+}


### PR DESCRIPTION
## Summary

- Pool gzip writers by compression level.
- Reset a writer before returning it to the pool.
- Avoid retaining the destination page buffer in the cached writer.
- Add a concurrent correctness test and page-size benchmarks.

## Benchmark

Apple M1 Pro. The output buffer is reused. Median of 3 runs.

| Input | upstream main | this PR | change |
| --- | ---: | ---: | ---: |
| Repeated, 64 KiB | 115 us, 1.08 MiB, 15 allocs | 25.7 us, 48 B, 1 alloc | 4.5x faster |
| Random, 64 KiB | 94.7 us, 1.08 MiB, 15 allocs | 15.6 us, 117 B, 1 alloc | 6.1x faster |

```text
go test ./parquet/compress -run '^$' -bench '^BenchmarkGzipEncodePages$' -benchmem -benchtime=200ms -count=3
```

## Tests

- `PARQUET_TEST_DATA=/path/to/parquet-testing/data go test ./parquet/... -count=1`
- `PARQUET_TEST_DATA=/path/to/parquet-testing/data go test -race ./parquet/compress ./parquet/file ./parquet/pqarrow -count=1`
- `go vet ./parquet/compress ./parquet/file`
