### PR TITLE
fix(arrow/extensions): reject Null Variant typed_value

### DIFF
--- a/arrow/extensions/variant.go
+++ b/arrow/extensions/variant.go
@@ -122,10 +122,10 @@ func createShreddedField(dt arrow.DataType) arrow.DataType {
 //	 ), Nullable: true})
 //
 // This is intended to be a convenient way to create a shredded variant type from a definition
-// of the fields to shred. If the provided data type is nil, it will create a default
-// variant type.
+// of the fields to shred. If the provided data type is nil or Null (including an
+// extension whose storage is Null), it will create a default variant type.
 func NewShreddedVariantType(dt arrow.DataType) *VariantType {
-	if dt == nil {
+	if dt == nil || isNullType(dt) {
 		return NewDefaultVariantType()
 	}
 
@@ -220,11 +220,7 @@ func NewVariantType(storage arrow.DataType) (*VariantType, error) {
 		return nil, fmt.Errorf("%w: typed_value field must be nullable, got %s", arrow.ErrInvalid, typedValueField.Type)
 	}
 
-	dt := typedValueField.Type
-	if dt.ID() == arrow.EXTENSION {
-		dt = dt.(arrow.ExtensionType).StorageType()
-	}
-
+	dt := storageType(typedValueField.Type)
 	if dt.ID() == arrow.NULL {
 		return nil, fmt.Errorf("%w: typed_value field must not be null type", arrow.ErrInvalid)
 	}
@@ -295,6 +291,17 @@ func isBinary(dt arrow.DataType) bool {
 		dt.ID() == arrow.BINARY_VIEW
 }
 
+func storageType(dt arrow.DataType) arrow.DataType {
+	if ext, ok := dt.(arrow.ExtensionType); ok {
+		return ext.StorageType()
+	}
+	return dt
+}
+
+func isNullType(dt arrow.DataType) bool {
+	return storageType(dt).ID() == arrow.NULL
+}
+
 func validStruct(s *arrow.StructType) bool {
 	switch s.NumFields() {
 	case 1:
@@ -302,7 +309,7 @@ func validStruct(s *arrow.StructType) bool {
 		if f.Name == "value" {
 			return isBinary(f.Type)
 		}
-		return f.Name == "typed_value" && f.Type.ID() != arrow.NULL
+		return f.Name == "typed_value" && !isNullType(f.Type)
 	case 2:
 		valField, ok := s.FieldByName("value")
 		if !ok || !valField.Nullable || !isBinary(valField.Type) {
@@ -318,7 +325,7 @@ func validStruct(s *arrow.StructType) bool {
 			return validNestedType(nt)
 		}
 
-		return typedField.Type.ID() != arrow.NULL
+		return !isNullType(typedField.Type)
 	default:
 		return false
 	}

--- a/arrow/extensions/variant.go
+++ b/arrow/extensions/variant.go
@@ -221,6 +221,9 @@ func NewVariantType(storage arrow.DataType) (*VariantType, error) {
 	}
 
 	dt := storageType(typedValueField.Type)
+	if dt == nil {
+		return nil, fmt.Errorf("%w: typed_value field has invalid storage type", arrow.ErrInvalid)
+	}
 	if dt.ID() == arrow.NULL {
 		return nil, fmt.Errorf("%w: typed_value field must not be null type", arrow.ErrInvalid)
 	}
@@ -292,14 +295,24 @@ func isBinary(dt arrow.DataType) bool {
 }
 
 func storageType(dt arrow.DataType) arrow.DataType {
-	if ext, ok := dt.(arrow.ExtensionType); ok {
-		return ext.StorageType()
+	seen := make(map[arrow.DataType]struct{})
+	for dt != nil {
+		ext, ok := dt.(arrow.ExtensionType)
+		if !ok {
+			return dt
+		}
+		if _, dup := seen[dt]; dup {
+			return nil
+		}
+		seen[dt] = struct{}{}
+		dt = ext.StorageType()
 	}
-	return dt
+	return nil
 }
 
 func isNullType(dt arrow.DataType) bool {
-	return storageType(dt).ID() == arrow.NULL
+	st := storageType(dt)
+	return st == nil || st.ID() == arrow.NULL
 }
 
 func validStruct(s *arrow.StructType) bool {

--- a/arrow/extensions/variant.go
+++ b/arrow/extensions/variant.go
@@ -225,6 +225,10 @@ func NewVariantType(storage arrow.DataType) (*VariantType, error) {
 		dt = dt.(arrow.ExtensionType).StorageType()
 	}
 
+	if dt.ID() == arrow.NULL {
+		return nil, fmt.Errorf("%w: typed_value field must not be null type", arrow.ErrInvalid)
+	}
+
 	if nt, ok := dt.(arrow.NestedType); ok {
 		if !validNestedType(nt) {
 			return nil, fmt.Errorf("%w: typed_value field must be a valid nested type, got %s", arrow.ErrInvalid, typedValueField.Type)
@@ -295,7 +299,10 @@ func validStruct(s *arrow.StructType) bool {
 	switch s.NumFields() {
 	case 1:
 		f := s.Field(0)
-		return (f.Name == "value" && isBinary(f.Type)) || f.Name == "typed_value"
+		if f.Name == "value" {
+			return isBinary(f.Type)
+		}
+		return f.Name == "typed_value" && f.Type.ID() != arrow.NULL
 	case 2:
 		valField, ok := s.FieldByName("value")
 		if !ok || !valField.Nullable || !isBinary(valField.Type) {
@@ -311,7 +318,7 @@ func validStruct(s *arrow.StructType) bool {
 			return validNestedType(nt)
 		}
 
-		return true
+		return typedField.Type.ID() != arrow.NULL
 	default:
 		return false
 	}

--- a/arrow/extensions/variant_test.go
+++ b/arrow/extensions/variant_test.go
@@ -83,6 +83,11 @@ func TestVariantExtensionType(t *testing.T) {
 			arrow.Field{Name: "metadata", Type: arrow.BinaryTypes.String, Nullable: false},
 			arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: false}),
 			"metadata field must be non-nullable binary type, got utf8"},
+		{arrow.StructOf(
+			arrow.Field{Name: "metadata", Type: arrow.BinaryTypes.Binary, Nullable: false},
+			arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
+			arrow.Field{Name: "typed_value", Type: arrow.Null, Nullable: true}),
+			"typed_value field must not be null type"},
 	}
 
 	for _, tt := range tests {
@@ -113,6 +118,11 @@ func TestVariantExtensionBadNestedTypes(t *testing.T) {
 			), Nullable: false})},
 		{"empty struct elem", arrow.StructOf(
 			arrow.Field{Name: "foobar", Type: arrow.StructOf(), Nullable: false})},
+		{"null typed_value in shredded field", arrow.StructOf(
+			arrow.Field{Name: "foobar", Type: arrow.StructOf(
+				arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
+				arrow.Field{Name: "typed_value", Type: arrow.Null, Nullable: true},
+			), Nullable: false})},
 		{"non-nullable two elem struct", arrow.StructOf(
 			arrow.Field{Name: "foobar", Type: arrow.StructOf(
 				arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},

--- a/arrow/extensions/variant_test.go
+++ b/arrow/extensions/variant_test.go
@@ -93,6 +93,17 @@ func TestVariantExtensionType(t *testing.T) {
 			arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
 			arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(arrow.Null, "null", "test"), Nullable: true}),
 			"typed_value field must not be null type"},
+		{arrow.StructOf(
+			arrow.Field{Name: "metadata", Type: arrow.BinaryTypes.Binary, Nullable: false},
+			arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
+			arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(
+				extensions.NewOpaqueType(arrow.Null, "null", "test"), "null", "test"), Nullable: true}),
+			"typed_value field must not be null type"},
+		{arrow.StructOf(
+			arrow.Field{Name: "metadata", Type: arrow.BinaryTypes.Binary, Nullable: false},
+			arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
+			arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(nil, "null", "test"), Nullable: true}),
+			"typed_value field has invalid storage type"},
 	}
 
 	for _, tt := range tests {
@@ -136,6 +147,17 @@ func TestVariantExtensionBadNestedTypes(t *testing.T) {
 			arrow.Field{Name: "foobar", Type: arrow.StructOf(
 				arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
 				arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(arrow.Null, "null", "test"), Nullable: true},
+			), Nullable: false})},
+		{"double-wrapped null typed_value in one-field shredded field", arrow.StructOf(
+			arrow.Field{Name: "foobar", Type: arrow.StructOf(
+				arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(
+					extensions.NewOpaqueType(arrow.Null, "null", "test"), "null", "test"), Nullable: true},
+			), Nullable: false})},
+		{"double-wrapped null typed_value in two-field shredded field", arrow.StructOf(
+			arrow.Field{Name: "foobar", Type: arrow.StructOf(
+				arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
+				arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(
+					extensions.NewOpaqueType(arrow.Null, "null", "test"), "null", "test"), Nullable: true},
 			), Nullable: false})},
 		{"non-nullable two elem struct", arrow.StructOf(
 			arrow.Field{Name: "foobar", Type: arrow.StructOf(
@@ -1588,6 +1610,11 @@ func TestNewSimpleShreddedVariantType(t *testing.T) {
 		extensions.NewShreddedVariantType(arrow.Null)))
 	assert.True(t, arrow.TypeEqual(extensions.NewDefaultVariantType(),
 		extensions.NewShreddedVariantType(extensions.NewOpaqueType(arrow.Null, "null", "test"))))
+	assert.True(t, arrow.TypeEqual(extensions.NewDefaultVariantType(),
+		extensions.NewShreddedVariantType(extensions.NewOpaqueType(
+			extensions.NewOpaqueType(arrow.Null, "null", "test"), "null", "test"))))
+	assert.True(t, arrow.TypeEqual(extensions.NewDefaultVariantType(),
+		extensions.NewShreddedVariantType(extensions.NewOpaqueType(nil, "null", "test"))))
 
 	vt := extensions.NewShreddedVariantType(arrow.PrimitiveTypes.Float32)
 	s := arrow.StructOf(

--- a/arrow/extensions/variant_test.go
+++ b/arrow/extensions/variant_test.go
@@ -88,6 +88,11 @@ func TestVariantExtensionType(t *testing.T) {
 			arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
 			arrow.Field{Name: "typed_value", Type: arrow.Null, Nullable: true}),
 			"typed_value field must not be null type"},
+		{arrow.StructOf(
+			arrow.Field{Name: "metadata", Type: arrow.BinaryTypes.Binary, Nullable: false},
+			arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
+			arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(arrow.Null, "null", "test"), Nullable: true}),
+			"typed_value field must not be null type"},
 	}
 
 	for _, tt := range tests {
@@ -122,6 +127,15 @@ func TestVariantExtensionBadNestedTypes(t *testing.T) {
 			arrow.Field{Name: "foobar", Type: arrow.StructOf(
 				arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
 				arrow.Field{Name: "typed_value", Type: arrow.Null, Nullable: true},
+			), Nullable: false})},
+		{"null typed_value extension in one-field shredded field", arrow.StructOf(
+			arrow.Field{Name: "foobar", Type: arrow.StructOf(
+				arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(arrow.Null, "null", "test"), Nullable: true},
+			), Nullable: false})},
+		{"null typed_value extension in two-field shredded field", arrow.StructOf(
+			arrow.Field{Name: "foobar", Type: arrow.StructOf(
+				arrow.Field{Name: "value", Type: arrow.BinaryTypes.Binary, Nullable: true},
+				arrow.Field{Name: "typed_value", Type: extensions.NewOpaqueType(arrow.Null, "null", "test"), Nullable: true},
 			), Nullable: false})},
 		{"non-nullable two elem struct", arrow.StructOf(
 			arrow.Field{Name: "foobar", Type: arrow.StructOf(
@@ -1570,6 +1584,10 @@ func TestVariantBuilderUnmarshalJSON(t *testing.T) {
 func TestNewSimpleShreddedVariantType(t *testing.T) {
 	assert.True(t, arrow.TypeEqual(extensions.NewDefaultVariantType(),
 		extensions.NewShreddedVariantType(nil)))
+	assert.True(t, arrow.TypeEqual(extensions.NewDefaultVariantType(),
+		extensions.NewShreddedVariantType(arrow.Null)))
+	assert.True(t, arrow.TypeEqual(extensions.NewDefaultVariantType(),
+		extensions.NewShreddedVariantType(extensions.NewOpaqueType(arrow.Null, "null", "test"))))
 
 	vt := extensions.NewShreddedVariantType(arrow.PrimitiveTypes.Float32)
 	s := arrow.StructOf(


### PR DESCRIPTION
### Rationale for this change

A Null `typed_value` column is not a valid shredded Variant type. Nulls are encoded in the `value` column as Variant null (`00`). A dedicated Null `typed_value` would also make “field present and null” indistinguishable from “field missing” for shredded objects.

See apache/arrow#50622 and apache/arrow#50810.

Fixes #1205

### What changes are included in this PR?

- `NewVariantType` rejects a Null `typed_value` field
- Nested shredded fields with a Null `typed_value` are also rejected

### Are these changes tested?

- `go test ./arrow/extensions`

### Are there any user-facing changes?

Yes — constructing a Variant extension type with a Null `typed_value` now returns `arrow.ErrInvalid`.