### PR TITLE
ci: use bundled GTest for conda integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -406,7 +406,6 @@ jobs:
           archery docker run \
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
             -e ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS=go \
-            -e GTest_SOURCE=SYSTEM \
             -e ARCHERY_INTEGRATION_WITH_DOTNET=1 \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_JAVA=1 \


### PR DESCRIPTION
### Rationale for this change

The Conda integration workflow overrides Apache Arrow's `GTest_SOURCE=BUNDLED` image configuration with `SYSTEM`. That can compile integration tests against Conda GTest headers while linking the bundled/different-version library, producing intermittent `testing::internal::AssertHelper` undefined-symbol failures.

### What changes are included in this PR?

Remove the workflow override so the upstream `conda-cpp` image's explicit `GTest_SOURCE=BUNDLED` setting is used consistently for headers and libraries.

### Are these changes tested?

- `actionlint .github/workflows/test.yml` (excluding unrelated existing ShellCheck findings)
- `git diff --check`

The complete Conda integration image is exercised by CI.

### Are there any user-facing changes?

No.
